### PR TITLE
Fix files with backslashes being generated on Linux

### DIFF
--- a/Src/Worker/GeneratePrinterSwitch.cs
+++ b/Src/Worker/GeneratePrinterSwitch.cs
@@ -47,7 +47,7 @@ namespace CSharpier
 
             var csharpDirectory = Path.Combine(
                 rootDirectory.FullName,
-                @"CSharpier\Printer");
+                "CSharpier/Printer");
             foreach (var file in new DirectoryInfo(csharpDirectory).GetFiles())
             {
                 var name = file.Name.Replace(".cs", "");

--- a/Src/Worker/SyntaxNodeComparerGenerator.cs
+++ b/Src/Worker/SyntaxNodeComparerGenerator.cs
@@ -31,7 +31,7 @@ namespace Worker
                 .ToList();
 
             var fileName =
-                directory.FullName + @"\CSharpier\SyntaxNodeComparer.generated.cs";
+                directory.FullName + "/CSharpier/SyntaxNodeComparer.generated.cs";
             using (var file = new StreamWriter(fileName, false))
             {
                 file.WriteLine(

--- a/Src/Worker/SyntaxNodeJsonWriterGenerator.cs
+++ b/Src/Worker/SyntaxNodeJsonWriterGenerator.cs
@@ -27,7 +27,7 @@ namespace Worker
                 o => !o.IsAbstract &&
                 typeof(CSharpSyntaxNode).IsAssignableFrom(o)).ToList();
 
-            var fileName = directory.FullName + @"\CSharpier.Parser\SyntaxNodeJsonWriter.generated.cs";
+            var fileName = directory.FullName + "/CSharpier.Parser/SyntaxNodeJsonWriter.generated.cs";
             using (var file = new StreamWriter(fileName, false))
             {
                 file.WriteLine("using System.Collections.Generic;");

--- a/Src/Worker/TypescriptNodeTypeGenerator.cs
+++ b/Src/Worker/TypescriptNodeTypeGenerator.cs
@@ -31,7 +31,7 @@ namespace Worker
                 typeof(CSharpSyntaxNode).IsAssignableFrom(o)).OrderBy(
                 o => o.Name).ToList();
 
-            var fileName = rootRepositoryFolder.FullName + @"\prettier-plugin-csharpier\src\Printer\NodeTypes.ts";
+            var fileName = rootRepositoryFolder.FullName + "/prettier-plugin-csharpier/src/Printer/NodeTypes.ts";
 
             using (var file = new StreamWriter(fileName, false))
             {


### PR DESCRIPTION
While there are a lot of backslashes in csproj files everywhere, msbuild seems to do a decent job at converting them automatically.
The ones in CS files directly on the other hand, cause files with literal backslashes in their names to be generated.
```
fernie@tiberius /tmp/scratch/csharpier/Src (git)-[master] % git status 
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   CSharpier.Tests/EncodingTests/USC2LEBOM.actual.cst
        modified:   CSharpier.Tests/Samples/AllInOne.json
        modified:   CSharpier.Tests/Samples/Scratch.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        "../Src\\CSharpier.Parser\\SyntaxNodeJsonWriter.generated.cs"
        "../Src\\CSharpier\\SyntaxNodeComparer.generated.cs"
        "../Src\\CSharpier\\SyntaxNodeJsonWriter.generated.cs"

no changes added to commit (use "git add" and/or "git commit -a")
```

AFAIK, Windows accepts `/` as well as `\`, so I think it makes much more sense to use forward slashes. However, you should validate that before merging this in. If it's not the case, let me know and I'll update them to use `Path.DirectorySeparator` instead.