### PR TITLE
Fix crash on empty files

### DIFF
--- a/Src/CSharpier/Program.cs
+++ b/Src/CSharpier/Program.cs
@@ -168,6 +168,11 @@ namespace CSharpier
 
             using var reader = new StreamReader(file);
             var code = await reader.ReadToEndAsync();
+            if (code.Length == 0)
+            {
+                return;
+            }
+
             var detectionResult = CharsetDetector.DetectFromFile(file);
             var encoding = detectionResult.Detected.Encoding;
             reader.Close();


### PR DESCRIPTION
Turns out charset detection fails on empty files, causing CSharpier to crash with a `NullReferenceException`.