### PR TITLE
Make string concatenations wrap

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/BinaryExpression/StringConcatenation.cst
+++ b/Src/CSharpier.Tests/TestFiles/BinaryExpression/StringConcatenation.cst
@@ -1,0 +1,11 @@
+class TestClass
+{
+    void TestMethod()
+    {
+        var someVar = "a string" + thatIsJust(shortEnough) + "to not wrap";
+        var someLongVariableName =
+            "a really loooooooooooooooong string"
+            + someMethodCall("with long args")
+            + "really long string";
+    }
+}

--- a/Src/CSharpier.Tests/TestFiles/BinaryExpression/_BinaryExpressionTests.cs
+++ b/Src/CSharpier.Tests/TestFiles/BinaryExpression/_BinaryExpressionTests.cs
@@ -1,0 +1,14 @@
+using CSharpier.Tests.TestFileTests;
+using NUnit.Framework;
+
+namespace CSharpier.Tests.TestFiles
+{
+    public class BinaryExpressionTests : BaseTest
+    {
+        [Test]
+        public void StringConcatenation()
+        {
+            this.RunTest("BinaryExpression", "StringConcatenation");
+        }
+    }
+}

--- a/Src/CSharpier/Printer/BinaryExpressionSyntax.cs
+++ b/Src/CSharpier/Printer/BinaryExpressionSyntax.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -8,7 +9,7 @@ namespace CSharpier
         private Doc PrintBinaryExpressionSyntax(BinaryExpressionSyntax node)
         {
             var useLine =
-                node.OperatorToken.Kind() is SyntaxKind.BarBarToken or SyntaxKind.BarToken or SyntaxKind.AmpersandAmpersandToken or SyntaxKind.AmpersandToken;
+                node.OperatorToken.Kind() is SyntaxKind.BarBarToken or SyntaxKind.BarToken or SyntaxKind.AmpersandAmpersandToken or SyntaxKind.AmpersandToken or SyntaxKind.PlusToken;
 
             return Concat(
                 this.Print(node.Left),


### PR DESCRIPTION
Much like the bitwise operators, it makes sense to break around `+` because it's used for string concatenations.