### PR TITLE
Testing out what it might be like to pass IList<Doc> down to each method to simplify doc tree

### DIFF
--- a/Src/.idea/.idea.CSharpier/.idea/riderModule.iml
+++ b/Src/.idea/.idea.CSharpier/.idea/riderModule.iml
@@ -2,6 +2,11 @@
 <module type="RIDER_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$/../.." />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.diagnostics.tracing.traceevent/2.0.49/lib/native/amd64" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.diagnostics.tracing.traceevent/2.0.49/lib/native/x86" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.diagnostics.tracing.traceevent/2.0.49/lib/netstandard1.6/Dia2Lib.dll" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.diagnostics.tracing.traceevent/2.0.49/lib/netstandard1.6/OSExtensions.dll" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.diagnostics.tracing.traceevent/2.0.49/lib/netstandard1.6/TraceReloggerLib.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/microsoft.net.test.sdk/16.5.0/build/netcoreapp2.1" />
     <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.5.0/build/netcoreapp2.1/x64/testhost.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.5.0/build/netcoreapp2.1/x64/testhost.exe" />

--- a/Src/CSharpier.Benchmarks/CSharpier.Benchmarks.csproj
+++ b/Src/CSharpier.Benchmarks/CSharpier.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CSharpier\CSharpier.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Src/CSharpier.Benchmarks/Program.cs
+++ b/Src/CSharpier.Benchmarks/Program.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace CSharpier.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<BenchmarkFormatting>();
+        }
+    }
+
+    // 48us with no changes
+    public class BenchmarkFormatting
+    {
+        [Benchmark]
+        public void FormatCode()
+        {
+            var code =
+                @"public class ClassName {
+    public void LongUglyMethod(string longParameter1, string longParameter2, string longParameter3) { 
+    }
+}";
+            var result = new CodeFormatter().Format(
+                code,
+                new Options { IncludeDocTree = false, IncludeAST = false, }
+            );
+        }
+    }
+}

--- a/Src/CSharpier.Tests/Samples.cs
+++ b/Src/CSharpier.Tests/Samples.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;

--- a/Src/CSharpier.Tests/Samples/Scratch.cst
+++ b/Src/CSharpier.Tests/Samples/Scratch.cst
@@ -1,15 +1,4 @@
-    public class FunctionParameter : EntityBase
-    {
-        public Function Function
-        
-        [Required]
-        [UniqueIndex(AdditionalColumns = nameof(Name))]
-        public Guid FunctionId { get; set; }
-        
-        public string Name { get; set; }
-        
-        public override string GetDisplayName()
-        {
-            return this.Name;
-        
+public class ClassName {
+    public void LongUglyMethod(string longParameter1, string longParameter2, string longParameter3) { 
     }
+}

--- a/Src/CSharpier.sln
+++ b/Src/CSharpier.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpier.Tests", "CSharpie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker", "Worker\Worker.csproj", "{CF32D239-2A27-4F46-8945-8B7B9A2C8774}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpier.Benchmarks", "CSharpier.Benchmarks\CSharpier.Benchmarks.csproj", "{D00290B1-6CAF-4A22-A3FA-0285BF52F699}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{CF32D239-2A27-4F46-8945-8B7B9A2C8774}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF32D239-2A27-4F46-8945-8B7B9A2C8774}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF32D239-2A27-4F46-8945-8B7B9A2C8774}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D00290B1-6CAF-4A22-A3FA-0285BF52F699}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D00290B1-6CAF-4A22-A3FA-0285BF52F699}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D00290B1-6CAF-4A22-A3FA-0285BF52F699}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D00290B1-6CAF-4A22-A3FA-0285BF52F699}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Src/CSharpier/Docs.cs
+++ b/Src/CSharpier/Docs.cs
@@ -56,19 +56,26 @@ namespace CSharpier
             };
         }
 
+        public static Group GroupWithId(string groupId, params Doc[] contents)
+        {
+            var group = Group(contents);
+            group.GroupId = groupId;
+            return group;
+        }
+
+        public static Group GroupWithId(string groupId, List<Doc> contents)
+        {
+            var group = Group(contents);
+            group.GroupId = groupId;
+            return group;
+        }
+
         public static Group Group(List<Doc> contents)
         {
             return new()
             {
                 Contents = contents.Count == 1 ? contents[0] : Concat(contents),
             };
-        }
-
-        public static Group GroupWithId(string groupId, params Doc[] contents)
-        {
-            var group = Group(contents);
-            group.GroupId = groupId;
-            return group;
         }
 
         public static Group Group(params Doc[] contents)

--- a/Src/CSharpier/Printer.cs
+++ b/Src/CSharpier/Printer.cs
@@ -70,6 +70,32 @@ namespace CSharpier
             return docs.Count == 0 ? Doc.Null : Docs.Concat(docs);
         }
 
+        private void PrintSeparatedSyntaxList<T>(
+            SeparatedSyntaxList<T> list,
+            Func<T, Doc> printFunc,
+            Doc afterSeparator,
+            IList<Doc> docs
+        )
+            where T : SyntaxNode {
+            for (var x = 0; x < list.Count; x++)
+            {
+                docs.Add(printFunc(list[x]));
+
+                if (x >= list.SeparatorCount)
+                {
+                    continue;
+                }
+
+                var isTrailingSeparator = x == list.Count - 1;
+
+                SyntaxTokens.Print(list.GetSeparator(x), docs);
+                if (!isTrailingSeparator)
+                {
+                    docs.Add(afterSeparator);
+                }
+            }
+        }
+
         private Doc PrintAttributeLists(
             SyntaxNode node,
             SyntaxList<AttributeListSyntax> attributeLists
@@ -97,6 +123,25 @@ namespace CSharpier
             }
 
             return Docs.Concat(docs);
+        }
+
+        private void PrintModifiers(
+            SyntaxTokenList modifiers,
+            IList<Doc> docs
+        ) {
+            if (modifiers.Count == 0)
+            {
+                return;
+            }
+
+            var innerDocs = new List<Doc>();
+            foreach (var modifier in modifiers)
+            {
+                SyntaxTokens.Print(modifier, innerDocs);
+                innerDocs.Add(" ");
+            }
+
+            docs.Add(Docs.Group(innerDocs));
         }
 
         private Doc PrintModifiers(SyntaxTokenList modifiers)

--- a/Src/CSharpier/Printer.new.generated.cs
+++ b/Src/CSharpier/Printer.new.generated.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using CSharpier.DocTypes;
+using CSharpier.SyntaxPrinter;
+using CSharpier.SyntaxPrinter.SyntaxNodePrinters;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CSharpier
+{
+    public partial class Printer
+    {
+        public void Print(SyntaxNode syntaxNode, IList<Doc> docs)
+        {
+            if (syntaxNode == null)
+            {
+                return;
+            }
+
+            // TODO 0 kill? runtime repo has files that will fail on deep recursion
+            if (depth > 200)
+            {
+                throw new InTooDeepException();
+            }
+
+            depth++;
+            try
+            {
+                switch (syntaxNode)
+                {
+                    case PredefinedTypeSyntax predefinedTypeSyntax:
+                        this.PrintPredefinedTypeSyntax(
+                            predefinedTypeSyntax,
+                            docs
+                        );
+                        break;
+                    default:
+                        throw new Exception(
+                            "Can't handle " + syntaxNode.GetType().Name
+                        );
+                }
+            }
+
+            finally
+            {
+                depth--;
+            }
+        }
+    }
+}

--- a/Src/CSharpier/Printer/BlockSyntax.cs
+++ b/Src/CSharpier/Printer/BlockSyntax.cs
@@ -32,9 +32,10 @@ namespace CSharpier
             {
                 groupId != null
                     ? Docs.IfBreak(" ", Docs.Line, groupId)
-                    : Docs.Line,
-                SyntaxTokens.Print(node.OpenBraceToken)
+                    : Docs.Line
             };
+            SyntaxTokens.Print(node.OpenBraceToken, docs);
+
             if (node.Statements.Count > 0)
             {
                 var innerDoc = Docs.Indent(
@@ -44,13 +45,16 @@ namespace CSharpier
 
                 DocUtilities.RemoveInitialDoubleHardLine(innerDoc);
 
-                docs.Add(Docs.Concat(innerDoc, statementSeparator));
+                docs.Add(innerDoc, statementSeparator);
             }
 
-            docs.Add(
-                node.Statements.Count == 0 ? " " : Docs.Null,
-                SyntaxTokens.Print(node.CloseBraceToken)
-            );
+            if (node.Statements.Count == 0)
+            {
+                docs.Add(" ");
+            }
+
+            SyntaxTokens.Print(node.CloseBraceToken, docs);
+
             return Docs.Group(docs);
         }
     }

--- a/Src/CSharpier/Printer/ParameterListSyntax.cs
+++ b/Src/CSharpier/Printer/ParameterListSyntax.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using CSharpier.DocTypes;
 using CSharpier.SyntaxPrinter;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier
@@ -10,24 +12,24 @@ namespace CSharpier
             ParameterListSyntax node,
             string? groupId = null
         ) {
-            return Docs.GroupWithId(
-                groupId ?? string.Empty,
-                SyntaxTokens.Print(node.OpenParenToken),
-                node.Parameters.Count > 0
-                    ? Docs.Concat(
-                            Docs.Indent(
-                                Docs.SoftLine,
-                                this.PrintSeparatedSyntaxList(
-                                    node.Parameters,
-                                    this.PrintParameterSyntax,
-                                    Docs.Line
-                                )
-                            ),
-                            Docs.SoftLine
-                        )
-                    : Doc.Null,
-                SyntaxTokens.Print(node.CloseParenToken)
-            );
+            var docs = new List<Doc>();
+            SyntaxTokens.Print(node.OpenParenToken, docs);
+            if (node.Parameters.Count > 0)
+            {
+                var innerDocs = new List<Doc> { Docs.SoftLine };
+                this.PrintSeparatedSyntaxList(
+                    node.Parameters,
+                    this.PrintParameterSyntax,
+                    Docs.Line,
+                    innerDocs
+                );
+
+                docs.Add(Docs.Indent(innerDocs));
+                docs.Add(Docs.SoftLine);
+            }
+            SyntaxTokens.Print(node.CloseParenToken, docs);
+
+            return Docs.GroupWithId(groupId ?? string.Empty, docs);
         }
     }
 }

--- a/Src/CSharpier/Printer/ParameterSyntax.cs
+++ b/Src/CSharpier/Printer/ParameterSyntax.cs
@@ -16,10 +16,11 @@ namespace CSharpier
             };
             if (node.Type != null)
             {
-                docs.Add(this.Print(node.Type), " ");
+                this.Print(node.Type, docs);
+                docs.Add(" ");
             }
 
-            docs.Add(SyntaxTokens.Print(node.Identifier));
+            SyntaxTokens.Print(node.Identifier, docs);
             if (node.Default != null)
             {
                 docs.Add(this.PrintEqualsValueClauseSyntax(node.Default));

--- a/Src/CSharpier/Printer/PredefinedTypeSyntax.cs
+++ b/Src/CSharpier/Printer/PredefinedTypeSyntax.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CSharpier.DocTypes;
 using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -9,6 +10,13 @@ namespace CSharpier
         private Doc PrintPredefinedTypeSyntax(PredefinedTypeSyntax node)
         {
             return SyntaxTokens.Print(node.Keyword);
+        }
+
+        private void PrintPredefinedTypeSyntax(
+            PredefinedTypeSyntax node,
+            IList<Doc> docs
+        ) {
+            SyntaxTokens.Print(node.Keyword, docs);
         }
     }
 }

--- a/Src/CSharpier/PrinterHelpers/BaseMethodDeclarationSyntax.cs
+++ b/Src/CSharpier/PrinterHelpers/BaseMethodDeclarationSyntax.cs
@@ -72,13 +72,13 @@ namespace CSharpier
             }
             if (modifiers.HasValue)
             {
-                docs.Add(this.PrintModifiers(modifiers.Value));
+                this.PrintModifiers(modifiers.Value, docs);
             }
 
             if (returnType != null)
             {
-                // TODO 1 preprocessor stuff is going to be painful, because it doesn't parse some of it. Could we figure that out somehow? that may get complicated
-                docs.Add(this.Print(returnType), " ");
+                this.Print(returnType, docs);
+                docs.Add(" ");
             }
 
             if (explicitInterfaceSpecifier != null)
@@ -165,7 +165,7 @@ namespace CSharpier
 
             if (semicolonToken.HasValue)
             {
-                docs.Add(SyntaxTokens.Print(semicolonToken.Value));
+                SyntaxTokens.Print(semicolonToken.Value, docs);
             }
 
             return Docs.Concat(docs);

--- a/Src/CSharpier/PrinterHelpers/BaseTypeDeclarationSyntax.cs
+++ b/Src/CSharpier/PrinterHelpers/BaseTypeDeclarationSyntax.cs
@@ -81,19 +81,17 @@ namespace CSharpier
             {
                 this.PrintExtraNewLines(node),
                 this.PrintAttributeLists(node, node.AttributeLists),
-                this.PrintModifiers(node.Modifiers)
             };
+
+            this.PrintModifiers(node.Modifiers, docs);
+
             if (keyword != null)
             {
-                docs.Add(
-                    this.PrintSyntaxToken(
-                        keyword.Value,
-                        afterTokenIfNoTrailing: " "
-                    )
-                );
+                SyntaxTokens.Print(keyword.Value, docs);
+                docs.Add(" ");
             }
 
-            docs.Add(SyntaxTokens.Print(node.Identifier));
+            SyntaxTokens.Print(node.Identifier, docs);
 
             if (parameterList != null)
             {
@@ -119,12 +117,12 @@ namespace CSharpier
                 docs.Add(
                     groupId != null
                         ? Docs.IfBreak(" ", Docs.Line, groupId)
-                        : Docs.HardLine,
-                    SyntaxTokens.Print(node.OpenBraceToken),
-                    members,
-                    Docs.HardLine,
-                    SyntaxTokens.Print(node.CloseBraceToken)
+                        : Docs.HardLine
                 );
+
+                SyntaxTokens.Print(node.OpenBraceToken, docs);
+                docs.Add(members, Docs.HardLine);
+                SyntaxTokens.Print(node.CloseBraceToken, docs);
             }
             else if (node.OpenBraceToken.Kind() != SyntaxKind.None)
             {
@@ -142,7 +140,7 @@ namespace CSharpier
 
             if (semicolonToken.HasValue)
             {
-                docs.Add(SyntaxTokens.Print(semicolonToken.Value));
+                SyntaxTokens.Print(semicolonToken.Value, docs);
             }
 
             return Docs.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxTokens.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxTokens.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CSharpier.DocTypes;
@@ -9,6 +10,11 @@ namespace CSharpier.SyntaxPrinter
 {
     public class SyntaxTokens
     {
+        public static void Print(SyntaxToken syntaxToken, IList<Doc> docs)
+        {
+            docs.Add(syntaxToken.Text);
+        }
+
         public static Doc Print(SyntaxToken syntaxToken)
         {
             return PrintSyntaxToken(syntaxToken);


### PR DESCRIPTION
If we pass IList<Doc> to each method, we can simplify the doc tree. We won't end up with things like
```
Docs.Concat(
    Docs.Concat(
        "one"
    ),
    Docs.Concat(
        "two"
    )
)
// would instead end up
Docs.Concat(
    "one",
    "two"
)
```
I did a little POC to see what some methods may look like, and benchmarked the changes.
The changes shaved ~15% off of the benchmark, but the benchmark was not reading/writing files.
When I included reading/writing files, it shaved 2%.
I didn't quite take it as far as I could with the code I was using. So theoretically it would be a tiny bit faster.
Being forced to pass IList<Doc> to methods also makes the code a lot less clean.
I'm thinking it isn't worth the time and ugly code just to make things a little bit faster and make our doc tree a little bit easier to read.