### PR TITLE
Another newline directive edge case.

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
+++ b/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
@@ -66,4 +66,14 @@ internal
 #endif
 static class ConditionallyPublic { }
 
+class IndentWithRegionEdgeCase
+{
+    string RegionsIndentAndNewLineProperly =
+        #region one
+        @"using System;"
+        #endregion one
+    ;
+}
+
+
 

--- a/Src/CSharpier/SyntaxPrinter/SyntaxTokens.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxTokens.cs
@@ -128,6 +128,7 @@ namespace CSharpier.SyntaxPrinter
                     docs.Add(
                         Docs.Trim,
                         Docs.HardLineIfNoPreviousLine,
+                        Docs.Trim,
                         trivia.ToString(),
                         Docs.HardLine
                     );
@@ -143,7 +144,13 @@ namespace CSharpier.SyntaxPrinter
                         triviaText = leadingTrivia[x - 1] + triviaText;
                     }
 
-                    docs.Add(Docs.Trim, triviaText, Docs.HardLine);
+                    docs.Add(
+                        Docs.Trim,
+                        Docs.HardLineIfNoPreviousLine,
+                        Docs.Trim,
+                        triviaText,
+                        Docs.HardLine
+                    );
                 }
             }
 


### PR DESCRIPTION
The previous fix wasn't applied to regions. Plus this case was indenting when it shouldn't.