### PR TITLE
Fixing bug with directive following a trailing comment getting extra indentation

### DIFF
--- a/Src/CSharpier.Tests/DocPrinterTests.cs
+++ b/Src/CSharpier.Tests/DocPrinterTests.cs
@@ -363,6 +363,22 @@ namespace CSharpier.Tests
         }
 
         [Test]
+        public void TrailingComment_Does_Affect_Trim()
+        {
+            var doc = Doc.Concat(
+                Doc.TrailingComment("// trailing", CommentType.SingleLine),
+                Doc.HardLine,
+                Doc.Indent(
+                    Doc.HardLineIfNoPreviousLineSkipBreakIfFirstInGroup,
+                    Doc.Trim,
+                    "    #endregion"
+                )
+            );
+            var result = Print(doc);
+            result.Should().Be($" // trailing{NewLine}    #endregion");
+        }
+
+        [Test]
         public void HardLineIfNoPreviousLine_Should_Insert_Line_If_There_Is_Not_One()
         {
             var doc = Doc.Concat("1", Doc.HardLineIfNoPreviousLine, "2");

--- a/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
+++ b/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
@@ -20,8 +20,8 @@ class ClassName { }
 
 public class ClassName
 {
-    #region Trailing comment does not indent more than it should #endregion
-    private int x; // trailing comment
+    #region Region
+    private int x; // trailing comment here shouldn't give extra indent to the endregion after it
     #endregion
 
     void MethodWithOnlyDisabled()

--- a/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
+++ b/Src/CSharpier.Tests/TestFiles/Directives/Directives.cst
@@ -20,6 +20,10 @@ class ClassName { }
 
 public class ClassName
 {
+    #region Trailing comment does not indent more than it should #endregion
+    private int x; // trailing comment
+    #endregion
+
     void MethodWithOnlyDisabled()
     {
 #if DEBUG

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -215,6 +215,7 @@ namespace CSharpier.DocPrinter
                         break;
                     case Trim:
                         currentWidth -= TrimOutput(output);
+                        newLineNextStringValue = false;
                         break;
                     case Group group:
                         switch (command.Mode)


### PR DESCRIPTION
closes #216