### PR TITLE
Only write files if they changed

### DIFF
--- a/CSharpier.sln
+++ b/CSharpier.sln
@@ -47,6 +47,13 @@ EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpier.Benchmarks", "Src\CSharpier.Benchmarks\CSharpier.Benchmarks.csproj", "{A338903F-69AD-4950-B827-8EE75F98B620}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MSBuild", "MSBuild", "{A267B806-24B0-4F3E-B5C2-9481C98627D0}"
+ProjectSection(SolutionItems) = preProject
+	Src\CSharpier.MsBuild\README.md = Src\CSharpier.MsBuild\README.md
+	Src\CSharpier.MsBuild\build\CSharpier.MsBuild.targets = Src\CSharpier.MsBuild\build\CSharpier.MsBuild.targets
+	Src\CSharpier.MsBuild\build\CSharpier.MsBuild.props = Src\CSharpier.MsBuild\build\CSharpier.MsBuild.props
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,5 +80,9 @@ Global
 		{A338903F-69AD-4950-B827-8EE75F98B620}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A338903F-69AD-4950-B827-8EE75F98B620}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A338903F-69AD-4950-B827-8EE75F98B620}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FE3D5DE-1284-45C6-95FC-8B3CDE63684B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FE3D5DE-1284-45C6-95FC-8B3CDE63684B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FE3D5DE-1284-45C6-95FC-8B3CDE63684B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FE3D5DE-1284-45C6-95FC-8B3CDE63684B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Src/CSharpier.MsBuild/README.md
+++ b/Src/CSharpier.MsBuild/README.md
@@ -1,3 +1,3 @@
-You can test this by doing
-`dotnet pack -o publish`
-Then add a nuget source pointing to that folder and install the nuget package into a project
+You can test this by running the following from `Src/CSharpier.MSBuild`  
+`dotnet pack -o publish`  
+Then add a nuget source pointing to `\Src\CSharpier.MsBuild\publish` and install the nuget package into a project

--- a/Src/CSharpier/CommandLineFormatter.cs
+++ b/Src/CSharpier/CommandLineFormatter.cs
@@ -242,8 +242,11 @@ namespace CSharpier
             cancellationToken.ThrowIfCancellationRequested();
             Interlocked.Increment(ref this.Result.Files);
 
-            if (!this.CommandLineOptions.Check && !this.CommandLineOptions.SkipWrite)
-            {
+            if (
+                !this.CommandLineOptions.Check
+                && !this.CommandLineOptions.SkipWrite
+                && result.Code != fileReaderResult.FileContents
+            ) {
                 // purposely avoid async here, that way the file completely writes if the process gets cancelled while running.
                 this.FileSystem.File.WriteAllText(file, result.Code, fileReaderResult.Encoding);
             }


### PR DESCRIPTION
closes #228
dotnet watch run gets stuck in a loop because it detects a file write even if the contents of the file did not change with that write.
#241 was created so we can hopefully modify CSharpier.MSBuild in the future to only format files that were changed.