### PR TITLE
refactoring + optimizing

### DIFF
--- a/CSharpier.sln.DotSettings
+++ b/CSharpier.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Concated/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=csharpierignore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=csharpierrc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sharpier/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Src/CSharpier.Benchmarks/Program.cs
+++ b/Src/CSharpier.Benchmarks/Program.cs
@@ -9,28 +9,19 @@ namespace CSharpier.Benchmarks
     [MemoryDiagnoser]
     public class Benchmarks
     {
-        // [Benchmark]
-        // public void Default()
-        // {
-        //     var codeFormatter = new CodeFormatter();
-        //     codeFormatter.Format(code, new PrinterOptions());
-        // }
+        [Benchmark]
+        public void Default_CodeFormatter()
+        {
+            var codeFormatter = new CodeFormatter();
+            codeFormatter.Format(code, new PrinterOptions());
+        }
 
-        // [Benchmark]
-        // public void Default_SyntaxNodeComparer()
-        // {
-        //     var syntaxNodeComparer = new SyntaxNodeComparer(code, code, CancellationToken.None);
-        //     SyntaxNodeComparer.BeBetter = false;
-        //     syntaxNodeComparer.CompareSource();
-        // }
-        //
-        // [Benchmark]
-        // public void Better_SyntaxNodeComparer()
-        // {
-        //     var syntaxNodeComparer = new SyntaxNodeComparer(code, code, CancellationToken.None);
-        //     SyntaxNodeComparer.BeBetter = true;
-        //     syntaxNodeComparer.CompareSource();
-        // }
+        [Benchmark]
+        public void Default_SyntaxNodeComparer()
+        {
+            var syntaxNodeComparer = new SyntaxNodeComparer(code, code, CancellationToken.None);
+            syntaxNodeComparer.CompareSource();
+        }
 
         private string code =
             @"using System;

--- a/Src/CSharpier.Benchmarks/Program.cs
+++ b/Src/CSharpier.Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
@@ -8,12 +9,28 @@ namespace CSharpier.Benchmarks
     [MemoryDiagnoser]
     public class Benchmarks
     {
-        [Benchmark]
-        public void Default()
-        {
-            var codeFormatter = new CodeFormatter();
-            codeFormatter.Format(code, new PrinterOptions());
-        }
+        // [Benchmark]
+        // public void Default()
+        // {
+        //     var codeFormatter = new CodeFormatter();
+        //     codeFormatter.Format(code, new PrinterOptions());
+        // }
+
+        // [Benchmark]
+        // public void Default_SyntaxNodeComparer()
+        // {
+        //     var syntaxNodeComparer = new SyntaxNodeComparer(code, code, CancellationToken.None);
+        //     SyntaxNodeComparer.BeBetter = false;
+        //     syntaxNodeComparer.CompareSource();
+        // }
+        //
+        // [Benchmark]
+        // public void Better_SyntaxNodeComparer()
+        // {
+        //     var syntaxNodeComparer = new SyntaxNodeComparer(code, code, CancellationToken.None);
+        //     SyntaxNodeComparer.BeBetter = true;
+        //     syntaxNodeComparer.CompareSource();
+        // }
 
         private string code =
             @"using System;

--- a/Src/CSharpier.Tests/DocUtilitiesTests.cs
+++ b/Src/CSharpier.Tests/DocUtilitiesTests.cs
@@ -19,16 +19,6 @@ namespace CSharpier.Tests
         }
 
         [Test]
-        public void RemoveInitialDoubleHardLine_Should_Remove_Null()
-        {
-            var doc = new List<Doc> { Doc.Null };
-
-            DocUtilities.RemoveInitialDoubleHardLine(doc);
-
-            doc.Should().BeEmpty();
-        }
-
-        [Test]
         public void RemoveInitialDoubleHardLine_Should_Not_Remove_Simple_HardLine()
         {
             var doc = new List<Doc> { Doc.HardLine };
@@ -45,7 +35,7 @@ namespace CSharpier.Tests
 
             DocUtilities.RemoveInitialDoubleHardLine(doc);
 
-            doc.Should().HaveCount(1);
+            doc.Should().BeEquivalentTo(new List<Doc> { Doc.HardLine, Doc.Null });
         }
 
         [Test]
@@ -67,7 +57,7 @@ namespace CSharpier.Tests
 
             DocUtilities.RemoveInitialDoubleHardLine(doc);
 
-            concat.Contents.Should().ContainSingle();
+            concat.Should().BeEquivalentTo(Doc.Concat(Doc.HardLine, Doc.Null));
         }
 
         [Test]
@@ -89,7 +79,7 @@ namespace CSharpier.Tests
 
             DocUtilities.RemoveInitialDoubleHardLine(doc);
 
-            concat.Contents.Should().ContainSingle();
+            concat.Contents.Should().BeEquivalentTo(new List<Doc> { Doc.HardLine, Doc.Null });
         }
 
         [Test]
@@ -100,7 +90,8 @@ namespace CSharpier.Tests
 
             DocUtilities.RemoveInitialDoubleHardLine(doc);
 
-            concat.Contents.Should().HaveCount(2);
+            concat.Contents.Should()
+                .BeEquivalentTo(new List<Doc> { Doc.HardLine, Doc.Null, Doc.HardLine });
         }
 
         [Test]
@@ -144,7 +135,7 @@ namespace CSharpier.Tests
 
             DocUtilities.RemoveInitialDoubleHardLine(doc);
 
-            contents.Should().ContainSingle();
+            contents.Should().BeEquivalentTo(new List<Doc> { Doc.HardLine, Doc.Null });
         }
 
         [Test]
@@ -166,7 +157,11 @@ namespace CSharpier.Tests
 
             DocSerializer.Serialize(doc)
                 .Should()
-                .Be(DocSerializer.Serialize(Doc.Concat(Doc.HardLine, "1", Doc.HardLine, "2")));
+                .Be(
+                    DocSerializer.Serialize(
+                        Doc.Concat(Doc.HardLine, Doc.Null, "1", Doc.HardLine, "2")
+                    )
+                );
         }
     }
 }

--- a/Src/CSharpier.Tests/SyntaxNodeComparerTests.cs
+++ b/Src/CSharpier.Tests/SyntaxNodeComparerTests.cs
@@ -207,6 +207,73 @@ public enum Enum
             );
         }
 
+        [Test]
+        public void Extra_SyntaxTrivia_Should_Work()
+        {
+            var left = "  public class ClassName { }";
+            var right = "public class ClassName { }";
+
+            var result = this.AreEqual(left, right);
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Mismatched_Syntax_Trivia_Should_Print_Error()
+        {
+            var left =
+                @"// leading comment
+public class ClassName { }";
+            var right = "public class ClassName { }";
+
+            var result = this.AreEqual(left, right);
+            ResultShouldBe(
+                result,
+                @"----------------------------- Original: Around Line 0 -----------------------------
+// leading comment
+public class ClassName { }
+----------------------------- Formatted: Around Line 0 -----------------------------
+public class ClassName { }
+"
+            );
+        }
+
+        [Test]
+        public void Long_Mismatched_Syntax_Trivia_Should_Print_Error()
+        {
+            var left =
+                @"// 1
+// 2
+// 3
+// 4
+// 5
+// 6
+public class ClassName { }";
+            var right =
+                @"// 1
+// 2
+// 3
+// 4
+// 5
+// 7
+public class ClassName { }";
+
+            var result = this.AreEqual(left, right);
+            ResultShouldBe(
+                result,
+                @"----------------------------- Original: Around Line 5 -----------------------------
+// 4
+// 5
+// 6
+public class ClassName { }
+----------------------------- Formatted: Around Line 5 -----------------------------
+// 4
+// 5
+// 7
+public class ClassName { }
+"
+            );
+        }
+
         private void ResultShouldBe(string result, string be)
         {
             if (Environment.GetEnvironmentVariable("NormalizeLineEndings") != null)

--- a/Src/CSharpier.Tests/TestFiles/BaseTest.cs
+++ b/Src/CSharpier.Tests/TestFiles/BaseTest.cs
@@ -23,7 +23,7 @@ namespace CSharpier.Tests.TestFileTests
             }
         }
 
-        protected void RunTest(string folderName, string fileName)
+        protected void RunTest(string folderName, string fileName, bool useTabs = false)
         {
             var filePath = Path.Combine(
                 this.rootDirectory.FullName,
@@ -37,7 +37,7 @@ namespace CSharpier.Tests.TestFileTests
             var formatter = new CodeFormatter();
             var result = formatter.Format(
                 fileReaderResult.FileContents,
-                new PrinterOptions() { Width = PrinterOptions.WidthUsedByTests }
+                new PrinterOptions() { Width = PrinterOptions.WidthUsedByTests, UseTabs = useTabs }
             );
 
             var actualFilePath = filePath.Replace(".cst", ".actual.cst");

--- a/Src/CSharpier.Tests/TestFiles/Tabs/Tabs.cst
+++ b/Src/CSharpier.Tests/TestFiles/Tabs/Tabs.cst
@@ -1,0 +1,13 @@
+public class ClassName
+{
+	public dynamic ShortValue = new { Property = true };
+
+	public dynamic LongValue = new
+	{
+		One = "One",
+		Two = "Two",
+		ThreeThreeThree = "ThreeThreeThree"
+	};
+
+	public dynamic Value = new { NoName };
+}

--- a/Src/CSharpier.Tests/TestFiles/Tabs/_TabsTests.cs
+++ b/Src/CSharpier.Tests/TestFiles/Tabs/_TabsTests.cs
@@ -1,0 +1,14 @@
+using CSharpier.Tests.TestFileTests;
+using NUnit.Framework;
+
+namespace CSharpier.Tests.TestFiles
+{
+    public class TabsTests : BaseTest
+    {
+        [Test]
+        public void Tabs()
+        {
+            this.RunTest("Tabs", "Tabs", useTabs: true);
+        }
+    }
+}

--- a/Src/CSharpier/DocPrinter/Indent.cs
+++ b/Src/CSharpier/DocPrinter/Indent.cs
@@ -4,115 +4,33 @@ using System.Text;
 
 namespace CSharpier.DocPrinter
 {
-    public record IndentType(string Type, int Number);
-
-    public record Indent(string Value, int Length, List<IndentType> Queue);
+    public record Indent(string Value, int Length);
 
     public static class IndentBuilder
     {
         public static Indent MakeRoot()
         {
-            return new Indent(string.Empty, 0, new List<IndentType>());
+            return new Indent(string.Empty, 0);
         }
 
         public static Indent Make(Indent indent, PrinterOptions printerOptions)
         {
-            return GenerateIndent(indent, newPart: new IndentType("indent", 0), printerOptions);
+            return GenerateIndent(indent, printerOptions);
         }
 
-        private static Indent GenerateIndent(
-            Indent indent,
-            IndentType newPart,
-            PrinterOptions printerOptions
-        ) {
-            var queue = new List<IndentType>(indent.Queue);
-            if (newPart.Type == "dedent")
+        private static Indent GenerateIndent(Indent indent, PrinterOptions printerOptions)
+        {
+            if (printerOptions.UseTabs)
             {
-                queue.RemoveAt(queue.Count - 1);
+                return new Indent(indent.Value + "\t", indent.Length + printerOptions.TabWidth);
             }
             else
             {
-                queue.Add(newPart);
+                return new Indent(
+                    indent.Value + new string(' ', printerOptions.TabWidth),
+                    indent.Length + printerOptions.TabWidth
+                );
             }
-
-            var value = new StringBuilder();
-            var length = 0;
-            var lastTabs = 0;
-
-            var lastSpaces = 0;
-            foreach (var part in queue)
-            {
-                switch (part.Type)
-                {
-                    case "indent":
-                        Flush();
-                        if (printerOptions.UseTabs)
-                        {
-                            AddTabs(1);
-                        }
-                        else
-                        {
-                            AddSpaces(printerOptions.TabWidth);
-                        }
-                        break;
-                    default:
-                        throw new Exception(part.Type);
-                }
-            }
-
-            FlushSpaces();
-
-            void AddTabs(int count)
-            {
-                value.Append('\t', count);
-                length += printerOptions.TabWidth * count;
-            }
-
-            void AddSpaces(int count)
-            {
-                value.Append(' ', count);
-                length += count;
-            }
-
-            void Flush()
-            {
-                if (printerOptions.UseTabs)
-                {
-                    FlushTabs();
-                }
-                else
-                {
-                    FlushSpaces();
-                }
-            }
-
-            void FlushTabs()
-            {
-                if (lastTabs > 0)
-                {
-                    AddTabs(lastTabs);
-                }
-
-                ResetLast();
-            }
-
-            void FlushSpaces()
-            {
-                if (lastSpaces > 0)
-                {
-                    AddSpaces(lastSpaces);
-                }
-
-                ResetLast();
-            }
-
-            void ResetLast()
-            {
-                lastTabs = 0;
-                lastSpaces = 0;
-            }
-
-            return new Indent(value.ToString(), length, queue);
         }
     }
 }

--- a/Src/CSharpier/DocTypes/Align.cs
+++ b/Src/CSharpier/DocTypes/Align.cs
@@ -1,8 +1,0 @@
-namespace CSharpier.DocTypes
-{
-    // should possibly be used by ternary operator
-    public class Align : Doc, IHasContents
-    {
-        public Doc Contents { get; set; } = Doc.Null;
-    }
-}

--- a/Src/CSharpier/DocTypes/Concat.cs
+++ b/Src/CSharpier/DocTypes/Concat.cs
@@ -4,9 +4,9 @@ namespace CSharpier.DocTypes
 {
     public class Concat : Doc
     {
-        public List<Doc> Contents { get; set; }
+        public IList<Doc> Contents { get; set; }
 
-        public Concat(List<Doc> contents)
+        public Concat(IList<Doc> contents)
         {
             Contents = contents;
         }

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -10,26 +10,26 @@ namespace CSharpier.DocTypes
             return new StringDoc(value);
         }
 
-        public static NullDoc Null { get; } = NullDoc.Instance;
+        public static NullDoc Null => NullDoc.Instance;
 
         public static Doc BreakParent => new BreakParent();
 
-        public static HardLine HardLine => new();
+        public static readonly HardLine HardLine = new();
 
-        public static HardLine HardLineSkipBreakIfFirstInGroup => new(false, true);
+        public static readonly HardLine HardLineSkipBreakIfFirstInGroup = new(false, true);
 
-        public static HardLine HardLineIfNoPreviousLine => new(true);
+        public static readonly HardLine HardLineIfNoPreviousLine = new(true);
 
-        public static HardLine HardLineIfNoPreviousLineSkipBreakIfFirstInGroup => new(true, true);
+        public static readonly HardLine HardLineIfNoPreviousLineSkipBreakIfFirstInGroup =
+            new(true, true);
 
-        // TODO all of the Line types can probably turn into proper classes, and be the same instance by type
-        public static LiteralLine LiteralLine => new();
+        public static readonly LiteralLine LiteralLine = new();
 
-        public static LineDoc Line => new() { Type = LineDoc.LineType.Normal };
+        public static readonly LineDoc Line = new() { Type = LineDoc.LineType.Normal };
 
-        public static Trim Trim => Trim.Instance;
+        public static readonly LineDoc SoftLine = new() { Type = LineDoc.LineType.Soft };
 
-        public static LineDoc SoftLine => new() { Type = LineDoc.LineType.Soft };
+        public static readonly Trim Trim = new();
 
         public static LeadingComment LeadingComment(string comment, CommentType commentType) =>
             new() { Type = commentType, Comment = comment };
@@ -39,9 +39,7 @@ namespace CSharpier.DocTypes
 
         public static Concat Concat(List<Doc> contents) => new(contents);
 
-        public static Concat Concat(IEnumerable<Doc> contents) => new(contents.ToList());
-
-        public static Concat Concat(params Doc[] contents) => new(contents.ToList());
+        public static Concat Concat(params Doc[] contents) => new(contents);
 
         public static Doc Join(Doc separator, IEnumerable<Doc> array)
         {

--- a/Src/CSharpier/DocTypes/DocUtilities.cs
+++ b/Src/CSharpier/DocTypes/DocUtilities.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CSharpier.DocTypes
 {
@@ -10,23 +11,20 @@ namespace CSharpier.DocTypes
             RemoveInitialDoubleHardLine(docs, ref removeNextHardLine);
         }
 
-        private static void RemoveInitialDoubleHardLine(List<Doc> docs, ref bool removeNextHardLine)
-        {
+        private static void RemoveInitialDoubleHardLine(
+            IList<Doc> docs,
+            ref bool removeNextHardLine
+        ) {
             var x = 0;
             while (x < docs.Count)
             {
                 var doc = docs[x];
 
-                if (doc == Doc.Null)
-                {
-                    docs.RemoveAt(x);
-                    break;
-                }
-                else if (doc is HardLine)
+                if (doc is HardLine)
                 {
                     if (removeNextHardLine)
                     {
-                        docs.RemoveAt(x);
+                        docs[x] = Doc.Null;
                         return;
                     }
 

--- a/Src/CSharpier/DocTypes/NullDoc.cs
+++ b/Src/CSharpier/DocTypes/NullDoc.cs
@@ -2,7 +2,7 @@ namespace CSharpier.DocTypes
 {
     public class NullDoc : Doc
     {
-        public static NullDoc Instance { get; } = new NullDoc();
+        public static NullDoc Instance { get; } = new();
 
         private NullDoc() { }
     }

--- a/Src/CSharpier/DocTypes/Trim.cs
+++ b/Src/CSharpier/DocTypes/Trim.cs
@@ -2,8 +2,6 @@ namespace CSharpier.DocTypes
 {
     public class Trim : Doc
     {
-        public static Trim Instance { get; } = new Trim();
-
-        private Trim() { }
+        public Trim() { }
     }
 }

--- a/Src/CSharpier/Program.cs
+++ b/Src/CSharpier/Program.cs
@@ -12,9 +12,6 @@ namespace CSharpier
 {
     class Program
     {
-        // TODO 1 Configuration.cs from data.entities
-        // TODO 1 CurrencyDto.cs from data.entities
-
         // TODO https://github.com/dotnet/command-line-api/blob/main/docs/Your-first-app-with-System-CommandLine-DragonFruit.md
         // can be used to simplify this, but it didn't appear to work with descriptions of the parameters
         static async Task<int> Main(string[] args)

--- a/Src/CSharpier/SyntaxNodeComparer.cs
+++ b/Src/CSharpier/SyntaxNodeComparer.cs
@@ -185,7 +185,6 @@ namespace CSharpier
             return new() { IsInvalid = true, OriginalSpan = originalSpan, NewSpan = formattedSpan };
         }
 
-        // TODO this is used by compare lists, but then we don't have parents if one is missing
         private CompareResult Compare(SyntaxToken originalToken, SyntaxToken formattedToken)
         {
             return Compare(originalToken, formattedToken, null, null);

--- a/Src/CSharpier/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier/SyntaxPrinter/Modifiers.cs
@@ -27,7 +27,9 @@ namespace CSharpier.SyntaxPrinter
                 Token.PrintWithoutLeadingTrivia(modifiers[0]),
                 " ",
                 modifiers.Count > 1
-                    ? Doc.Concat(modifiers.Skip(1).Select(o => Token.PrintWithSuffix(o, " ")))
+                    ? Doc.Concat(
+                            modifiers.Skip(1).Select(o => Token.PrintWithSuffix(o, " ")).ToArray()
+                        )
                     : Doc.Null
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
@@ -14,7 +14,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 docs.Add(NameColon.Print(node.NameColon));
             }
 
-            docs.Add(Token.Print(node.RefKindKeyword, " "));
+            docs.Add(Token.PrintWithSuffix(node.RefKindKeyword, " "));
             docs.Add(Node.Print(node.Expression));
             return Doc.Concat(docs);
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
@@ -8,7 +8,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(ArrayCreationExpressionSyntax node)
         {
             return Doc.Group(
-                Token.Print(node.NewKeyword, " "),
+                Token.PrintWithSuffix(node.NewKeyword, " "),
                 Node.Print(node.Type),
                 node.Initializer != null
                     ? Doc.Concat(Doc.Line, Node.Print(node.Initializer))

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AwaitExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AwaitExpression.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(AwaitExpressionSyntax node)
         {
-            return Doc.Concat(Token.Print(node.AwaitKeyword, " "), Node.Print(node.Expression));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.AwaitKeyword, " "),
+                Node.Print(node.Expression)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -116,7 +116,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                         conversionOperatorDeclarationSyntax.ImplicitOrExplicitKeyword,
                         " "
                     ),
-                    Token.Print(conversionOperatorDeclarationSyntax.OperatorKeyword, " "),
+                    Token.PrintWithSuffix(conversionOperatorDeclarationSyntax.OperatorKeyword, " "),
                     Node.Print(conversionOperatorDeclarationSyntax.Type)
                 );
             }
@@ -125,7 +125,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 declarationGroup.Add(
                     Node.Print(operatorDeclarationSyntax.ReturnType),
                     " ",
-                    Token.Print(operatorDeclarationSyntax.OperatorKeyword, " "),
+                    Token.PrintWithSuffix(operatorDeclarationSyntax.OperatorKeyword, " "),
                     Token.Print(operatorDeclarationSyntax.OperatorToken)
                 );
             }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
@@ -37,7 +37,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             }
             else if (node is EventDeclarationSyntax eventDeclarationSyntax)
             {
-                eventKeyword = Token.Print(eventDeclarationSyntax.EventKeyword, " ");
+                eventKeyword = Token.PrintWithSuffix(eventDeclarationSyntax.EventKeyword, " ");
                 explicitInterfaceSpecifierSyntax = eventDeclarationSyntax.ExplicitInterfaceSpecifier;
                 identifier = Token.Print(eventDeclarationSyntax.Identifier);
                 semicolonToken = eventDeclarationSyntax.SemicolonToken;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -78,7 +78,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             };
             if (keyword != null)
             {
-                docs.Add(Token.Print(keyword.Value, " "));
+                docs.Add(Token.PrintWithSuffix(keyword.Value, " "));
             }
 
             docs.Add(Token.Print(node.Identifier));

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
@@ -8,16 +8,15 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 {
+    // this is a very basic version of the logic found in prettier/src/language-js/print/binaryish.js
+    // There are a ton of edge cases that are not yet handled
     public static class BinaryExpression
     {
-        // TODO this is a very basic version of the logic found in prettier/src/language-js/print/binaryish.js
-        // There are a ton of edge cases that are not yet handled
         public static Doc Print(BinaryExpressionSyntax node)
         {
             return Doc.Group(PrintBinaryExpression(node));
         }
 
-        // TODO 0 kill? runtime repo has files that will fail on deep recursion
         [ThreadStatic]
         private static int depth;
 

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryPattern.cs
@@ -10,7 +10,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             return Doc.Concat(
                 Node.Print(node.Left),
                 Doc.Line,
-                Token.Print(node.OperatorToken, " "),
+                Token.PrintWithSuffix(node.OperatorToken, " "),
                 Node.Print(node.Right)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
@@ -11,7 +11,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(CasePatternSwitchLabelSyntax node)
         {
             var docs = new List<Doc>();
-            docs.Add(Token.Print(node.Keyword, " "), Node.Print(node.Pattern));
+            docs.Add(Token.PrintWithSuffix(node.Keyword, " "), Node.Print(node.Pattern));
             if (node.WhenClause != null)
             {
                 docs.Add(" ", Node.Print(node.WhenClause));

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
@@ -9,7 +9,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(CaseSwitchLabelSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.Keyword, " "),
+                Token.PrintWithSuffix(node.Keyword, " "),
                 Doc.Group(Node.Print(node.Value)),
                 Token.Print(node.ColonToken)
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CatchClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CatchClause.cs
@@ -28,7 +28,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             {
                 docs.Add(
                     " ",
-                    Token.Print(node.Filter.WhenKeyword, " "),
+                    Token.PrintWithSuffix(node.Filter.WhenKeyword, " "),
                     Token.Print(node.Filter.OpenParenToken),
                     Node.Print(node.Filter.FilterExpression),
                     Token.Print(node.Filter.CloseParenToken)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
@@ -12,10 +12,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Doc.Group(
                     Doc.Indent(
                         Doc.Line,
-                        Token.Print(node.QuestionToken, " "),
+                        Token.PrintWithSuffix(node.QuestionToken, " "),
                         Doc.Indent(Node.Print(node.WhenTrue)),
                         Doc.Line,
-                        Token.Print(node.ColonToken, " "),
+                        Token.PrintWithSuffix(node.ColonToken, " "),
                         Doc.Indent(Node.Print(node.WhenFalse))
                     )
                 )

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -6,12 +6,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 {
     public static class ConstructorInitializer
     {
-        // TODO 0 where is this used? I changed it and nothing broke
         public static Doc Print(ConstructorInitializerSyntax node)
         {
             return Doc.Indent(
                 Doc.HardLine,
-                Token.Print(node.ColonToken, " "),
+                Token.PrintWithSuffix(node.ColonToken, " "),
                 Token.Print(node.ThisOrBaseKeyword),
                 ArgumentList.Print(node.ArgumentList)
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultConstraint.cs
@@ -6,7 +6,6 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 {
     public static class DefaultConstraint
     {
-        // TODO 0 look into things that aren't covered by unit tests
         public static Doc Print(DefaultConstraintSyntax node)
         {
             return Token.Print(node.DefaultKeyword);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
@@ -15,7 +15,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 ExtraNewLines.Print(node),
                 AttributeLists.Print(node, node.AttributeLists),
                 Modifiers.Print(node.Modifiers),
-                Token.Print(node.DelegateKeyword, " "),
+                Token.PrintWithSuffix(node.DelegateKeyword, " "),
                 Node.Print(node.ReturnType),
                 { " ", Token.Print(node.Identifier) }
             };

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
@@ -10,10 +10,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 ExtraNewLines.Print(node),
-                Token.Print(node.DoKeyword, node.Statement is not BlockSyntax ? " " : Doc.Null),
+                Token.PrintWithSuffix(
+                    node.DoKeyword,
+                    node.Statement
+                        is not BlockSyntax ? " " : Doc.Null
+                ),
                 Node.Print(node.Statement),
                 Doc.HardLine,
-                Token.Print(node.WhileKeyword, " "),
+                Token.PrintWithSuffix(node.WhileKeyword, " "),
                 Token.Print(node.OpenParenToken),
                 Node.Print(node.Condition),
                 Token.Print(node.CloseParenToken),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EqualsValueClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EqualsValueClause.cs
@@ -33,7 +33,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 
             Doc result = Doc.Group(
                 " ",
-                Token.Print(node.EqualsToken, separator),
+                Token.PrintWithSuffix(node.EqualsToken, separator),
                 Node.Print(node.Value)
             );
 

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExternAliasDirective.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExternAliasDirective.cs
@@ -10,8 +10,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 ExtraNewLines.Print(node),
-                Token.Print(node.ExternKeyword, " "),
-                Token.Print(node.AliasKeyword, " "),
+                Token.PrintWithSuffix(node.ExternKeyword, " "),
+                Token.PrintWithSuffix(node.AliasKeyword, " "),
                 Token.Print(node.Identifier),
                 Token.Print(node.SemicolonToken)
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForEachVariableStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForEachVariableStatement.cs
@@ -10,12 +10,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 ExtraNewLines.Print(node),
-                Token.Print(node.AwaitKeyword, " "),
-                Token.Print(node.ForEachKeyword, " "),
+                Token.PrintWithSuffix(node.AwaitKeyword, " "),
+                Token.PrintWithSuffix(node.ForEachKeyword, " "),
                 Token.Print(node.OpenParenToken),
                 Node.Print(node.Variable),
                 " ",
-                Token.Print(node.InKeyword, " "),
+                Token.PrintWithSuffix(node.InKeyword, " "),
                 Node.Print(node.Expression),
                 Token.Print(node.CloseParenToken),
                 Node.Print(node.Statement)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FromClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FromClause.cs
@@ -8,10 +8,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(FromClauseSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.FromKeyword, " "),
+                Token.PrintWithSuffix(node.FromKeyword, " "),
                 node.Type != null ? Doc.Concat(Node.Print(node.Type), " ") : Doc.Null,
-                Token.Print(node.Identifier, " "),
-                Token.Print(node.InKeyword, " "),
+                Token.PrintWithSuffix(node.Identifier, " "),
+                Token.PrintWithSuffix(node.InKeyword, " "),
                 Node.Print(node.Expression)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FunctionPointerType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FunctionPointerType.cs
@@ -11,7 +11,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 Token.Print(node.DelegateKeyword),
-                Token.Print(node.AsteriskToken, " "),
+                Token.PrintWithSuffix(node.AsteriskToken, " "),
                 node.CallingConvention != null
                     ? PrintCallingConvention(node.CallingConvention)
                     : Doc.Null,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GroupClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GroupClause.cs
@@ -8,10 +8,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(GroupClauseSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.GroupKeyword, " "),
+                Token.PrintWithSuffix(node.GroupKeyword, " "),
                 Node.Print(node.GroupExpression),
                 " ",
-                Token.Print(node.ByKeyword, " "),
+                Token.PrintWithSuffix(node.ByKeyword, " "),
                 Node.Print(node.ByExpression)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
@@ -14,7 +14,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Token.Print(node.NewKeyword),
                 Token.Print(node.OpenBracketToken),
                 Doc.Concat(commas),
-                Token.Print(node.CloseBracketToken, " "),
+                Token.PrintWithSuffix(node.CloseBracketToken, " "),
                 Node.Print(node.Initializer)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitObjectCreationExpression.cs
@@ -8,7 +8,6 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(ImplicitObjectCreationExpressionSyntax node)
         {
-            // TODO 1 more tests for this?
             return Doc.Concat(
                 Token.Print(node.NewKeyword),
                 ArgumentList.Print(node.ArgumentList),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
@@ -11,7 +11,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             return Doc.Concat(
                 Token.Print(node.StackAllocKeyword),
                 Token.Print(node.OpenBracketToken),
-                Token.Print(node.CloseBracketToken, " "),
+                Token.PrintWithSuffix(node.CloseBracketToken, " "),
                 Node.Print(node.Initializer)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IncompleteMember.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IncompleteMember.cs
@@ -7,7 +7,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(IncompleteMemberSyntax node)
         {
-            return string.Empty; // TODO 1 figure this out
+            return string.Empty;
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
@@ -18,7 +18,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             if (node.AlignmentClause != null)
             {
                 docs.Add(
-                    Token.Print(node.AlignmentClause.CommaToken, " "),
+                    Token.PrintWithSuffix(node.AlignmentClause.CommaToken, " "),
                     Node.Print(node.AlignmentClause.Value)
                 );
             }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LetClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LetClause.cs
@@ -8,9 +8,9 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(LetClauseSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.LetKeyword, " "),
-                Token.Print(node.Identifier, " "),
-                Token.Print(node.EqualsToken, " "),
+                Token.PrintWithSuffix(node.LetKeyword, " "),
+                Token.PrintWithSuffix(node.Identifier, " "),
+                Token.PrintWithSuffix(node.EqualsToken, " "),
                 Node.Print(node.Expression)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalDeclarationStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalDeclarationStatement.cs
@@ -10,8 +10,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 ExtraNewLines.Print(node),
-                Token.Print(node.AwaitKeyword, " "),
-                Token.Print(node.UsingKeyword, " "),
+                Token.PrintWithSuffix(node.AwaitKeyword, " "),
+                Token.PrintWithSuffix(node.UsingKeyword, " "),
                 Modifiers.Print(node.Modifiers),
                 VariableDeclaration.Print(node.Declaration),
                 Token.Print(node.SemicolonToken)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LockStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LockStatement.cs
@@ -11,7 +11,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             var docs = new List<Doc>
             {
-                Token.Print(node.LockKeyword, " "),
+                Token.PrintWithSuffix(node.LockKeyword, " "),
                 Token.Print(node.OpenParenToken),
                 Node.Print(node.Expression),
                 Token.Print(node.CloseParenToken)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameColon.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameColon.cs
@@ -8,7 +8,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(NameColonSyntax node)
         {
-            return Doc.Concat(Token.Print(node.Name.Identifier), Token.Print(node.ColonToken, " "));
+            return Doc.Concat(
+                Token.Print(node.Name.Identifier),
+                Token.PrintWithSuffix(node.ColonToken, " ")
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
@@ -8,7 +8,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(ObjectCreationExpressionSyntax node)
         {
             return Doc.Group(
-                Token.Print(node.NewKeyword, " "),
+                Token.PrintWithSuffix(node.NewKeyword, " "),
                 Node.Print(node.Type),
                 node.ArgumentList != null ? ArgumentList.Print(node.ArgumentList) : string.Empty,
                 node.Initializer != null

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
@@ -10,7 +10,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(OrderByClauseSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.OrderByKeyword, " "),
+                Token.PrintWithSuffix(node.OrderByKeyword, " "),
                 SeparatedSyntaxList.Print(
                     node.Orderings,
                     orderingNode =>

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryContinuation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryContinuation.cs
@@ -9,8 +9,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(QueryContinuationSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.IntoKeyword, " "),
-                Token.Print(node.Identifier, Doc.Line),
+                Token.PrintWithSuffix(node.IntoKeyword, " "),
+                Token.PrintWithSuffix(node.Identifier, Doc.Line),
                 QueryBody.Print(node.Body)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(RefExpressionSyntax node)
         {
-            return Doc.Concat(Token.Print(node.RefKeyword, " "), Node.Print(node.Expression));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.RefKeyword, " "),
+                Node.Print(node.Expression)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefType.cs
@@ -8,8 +8,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(RefTypeSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.RefKeyword, " "),
-                Token.Print(node.ReadOnlyKeyword, " "),
+                Token.PrintWithSuffix(node.RefKeyword, " "),
+                Token.PrintWithSuffix(node.ReadOnlyKeyword, " "),
                 Node.Print(node.Type)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefValueExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefValueExpression.cs
@@ -12,7 +12,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Token.Print(node.Keyword),
                 Token.Print(node.OpenParenToken),
                 Node.Print(node.Expression),
-                Token.Print(node.Comma, " "),
+                Token.PrintWithSuffix(node.Comma, " "),
                 Node.Print(node.Type),
                 Token.Print(node.CloseParenToken)
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RelationalPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RelationalPattern.cs
@@ -9,7 +9,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(RelationalPatternSyntax node)
         {
-            return Doc.Concat(Token.Print(node.OperatorToken), " ", Node.Print(node.Expression));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.OperatorToken, " "),
+                Node.Print(node.Expression)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
@@ -10,7 +10,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Group(
                 ExtraNewLines.Print(node),
-                Token.Print(node.ReturnKeyword, node.Expression != null ? " " : Doc.Null),
+                Token.PrintWithSuffix(node.ReturnKeyword, node.Expression != null ? " " : Doc.Null),
                 node.Expression != null
                     ? node.Expression is BinaryExpressionSyntax
                             ? Doc.Indent(Node.Print(node.Expression))

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SelectClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SelectClause.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(SelectClauseSyntax node)
         {
-            return Doc.Concat(Token.Print(node.SelectKeyword, " "), Node.Print(node.Expression));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.SelectKeyword, " "),
+                Node.Print(node.Expression)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/StackAllocArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/StackAllocArrayCreationExpression.cs
@@ -8,7 +8,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(StackAllocArrayCreationExpressionSyntax node)
         {
             return Doc.Concat(
-                Token.Print(node.StackAllocKeyword, " "),
+                Token.PrintWithSuffix(node.StackAllocKeyword, " "),
                 Node.Print(node.Type),
                 node.Initializer != null
                     ? Doc.Concat(" ", InitializerExpression.Print(node.Initializer))

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -27,7 +27,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                                     o.WhenClause != null
                                         ? Doc.Concat(Node.Print(o.WhenClause), " ")
                                         : Doc.Null,
-                                    Token.Print(o.EqualsGreaterThanToken, " "),
+                                    Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
                                     Node.Print(o.Expression)
                                 ),
                             Doc.HardLine

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
@@ -23,7 +23,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             return Doc.Concat(
                 ExtraNewLines.Print(node),
                 Doc.Group(
-                    Token.Print(node.SwitchKeyword, " "),
+                    Token.PrintWithSuffix(node.SwitchKeyword, " "),
                     Token.Print(node.OpenParenToken),
                     Node.Print(node.Expression),
                     Token.Print(node.CloseParenToken),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowExpression.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(ThrowExpressionSyntax node)
         {
-            return Doc.Concat(Token.Print(node.ThrowKeyword, " "), Node.Print(node.Expression));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.ThrowKeyword, " "),
+                Node.Print(node.Expression)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameter.cs
@@ -10,7 +10,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 AttributeLists.Print(node, node.AttributeLists),
-                Token.Print(node.VarianceKeyword, " "),
+                Token.PrintWithSuffix(node.VarianceKeyword, " "),
                 Token.Print(node.Identifier)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterConstraintClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterConstraintClause.cs
@@ -10,10 +10,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(TypeParameterConstraintClauseSyntax node)
         {
             return Doc.Group(
-                Token.Print(node.WhereKeyword, " "),
+                Token.PrintWithSuffix(node.WhereKeyword, " "),
                 Node.Print(node.Name),
                 " ",
-                Token.Print(node.ColonToken, " "),
+                Token.PrintWithSuffix(node.ColonToken, " "),
                 Doc.Indent(SeparatedSyntaxList.Print(node.Constraints, Node.Print, Doc.Line))
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(UnaryPatternSyntax node)
         {
-            return Doc.Concat(Token.Print(node.OperatorToken, " "), Node.Print(node.Pattern));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.OperatorToken, " "),
+                Node.Print(node.Pattern)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingDirective.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingDirective.cs
@@ -11,8 +11,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         {
             return Doc.Concat(
                 ExtraNewLines.Print(node),
-                Token.Print(node.UsingKeyword, " "),
-                Token.Print(node.StaticKeyword, " "),
+                Token.PrintWithSuffix(node.UsingKeyword, " "),
+                Token.PrintWithSuffix(node.StaticKeyword, " "),
                 node.Alias == null ? Doc.Null : NameEquals.Print(node.Alias),
                 Node.Print(node.Name),
                 Token.Print(node.SemicolonToken)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VarPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VarPattern.cs
@@ -7,7 +7,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(VarPatternSyntax node)
         {
-            return Doc.Concat(Token.Print(node.VarKeyword, " "), Node.Print(node.Designation));
+            return Doc.Concat(
+                Token.PrintWithSuffix(node.VarKeyword, " "),
+                Node.Print(node.Designation)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -25,12 +25,6 @@ namespace CSharpier.SyntaxPrinter
             return PrintSyntaxToken(syntaxToken);
         }
 
-        // TODO partial kill by replacing with PrintWithSuffix
-        public static Doc Print(SyntaxToken syntaxToken, Doc suffixDoc)
-        {
-            return PrintWithSuffix(syntaxToken, suffixDoc);
-        }
-
         public static Doc PrintWithSuffix(SyntaxToken syntaxToken, Doc suffixDoc)
         {
             return PrintSyntaxToken(syntaxToken, suffixDoc);


### PR DESCRIPTION
Cleaned up some todos.
Refactored some small stuff.
Optimized a hot path in SyntaxNodeComparer
Optimized a hot path in IndentBuilder and removed dedent, because we don't support it yet.
Got rid of extra List<Doc> creations that weren't required.
Use single instance of some Docs that have no parameters.