### PR TITLE
Better format interfaces and base classes

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
@@ -6,13 +6,13 @@ class NoModifiers { }
 
 public class WithInterface : IInterface { }
 
-public class WithReallyLongNameInterface
-    : IReallyLongNameLetsMakeThisBreak___________________________ { }
+public class WithReallyLongNameInterface :
+    IReallyLongNameLetsMakeThisBreak___________________________ { }
 
-public class ThisIsSomeLongNameAndItShouldFormatWell1
-    : AnotherLongClassName,
-        AndYetAnotherLongClassName,
-        AndStillOneMore { }
+public class ThisIsSomeLongNameAndItShouldFormatWell1 :
+    AnotherLongClassName,
+    AndYetAnotherLongClassName,
+    AndStillOneMore { }
 
 public class SimpleGeneric<T>
     where T : new() { }
@@ -36,9 +36,9 @@ public class LongerClassNameWithLotsOfGenerics<
 public class SimpleGeneric<T> : BaseClass<T>
     where T : new() { }
 
-public class ThisIsSomeLongNameAndItShouldFormatWell2<T, T2, T3>
-    : AnotherLongClassName<T>,
-        AnotherClassName
+public class ThisIsSomeLongNameAndItShouldFormatWell2<T, T2, T3> :
+    AnotherLongClassName<T>,
+    AnotherClassName
     where T : new(), AnotherTypeConstraint
     where T2 : new()
     where T3 : new() { }

--- a/Src/CSharpier.Tests/TestFiles/RecordDeclaration/RecordDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/RecordDeclaration/RecordDeclarations.cst
@@ -17,7 +17,7 @@ record PC(string x) : PrimaryConstructor(x) { }
 
 record RecordWithoutBody(string property);
 
-record LongerRecordNameWhatHappens_________________________________________(string x)
-    : R4<string>(x) { }
+record LongerRecordNameWhatHappens_________________________________________(string x) :
+    R4<string>(x) { }
 
 record GenericRecord<T>(T Result);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseList.cs
@@ -1,6 +1,4 @@
-using System.Linq;
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
@@ -9,11 +7,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(BaseListSyntax node)
         {
-            return Doc.Group(
+            return Doc.Concat(
+                " ",
+                Token.Print(node.ColonToken),
                 Doc.Indent(
-                    Doc.Line,
-                    Token.PrintWithSuffix(node.ColonToken, " "),
-                    Doc.Indent(SeparatedSyntaxList.Print(node.Types, Node.Print, Doc.Line))
+                    Doc.Group(Doc.Line, SeparatedSyntaxList.Print(node.Types, Node.Print, Doc.Line))
                 )
             );
         }


### PR DESCRIPTION
Format the inherited interfaces and base classes according to https://github.com/belav/csharpier/issues/189#issuecomment-847140886. 

The new style is like this
```csharp
public class AClass : 
    AReallyLongBuilder<BuilderType>, 
    IAnotherReallyBuilder<AnotherType> { }
```

Closes #189 