### PR TITLE
Implementing align doc type + using it for classes

### DIFF
--- a/Src/CSharpier.Tests/DocPrinterTests.cs
+++ b/Src/CSharpier.Tests/DocPrinterTests.cs
@@ -617,6 +617,26 @@ true || false"
         }
 
         [Test]
+        public void Align_Should_Print_Basic_Case()
+        {
+            var doc = Doc.Concat("+ ", Doc.Align(2, Doc.Group("1", Doc.HardLine, "2")));
+            PrintedDocShouldBe(doc, $"+ 1{NewLine}  2");
+        }
+
+        [Test]
+        public void Align_Should_Convert_Spaces_To_Tabs()
+        {
+            var doc = Doc.Concat(
+                "+ ",
+                Doc.Align(
+                    2,
+                    Doc.Indent(Doc.Concat("+ ", Doc.Align(2, Doc.Group("1", Doc.HardLine, "2"))))
+                )
+            );
+            PrintedDocShouldBe(doc, $"+ + 1{NewLine}\t\t  2", useTabs: true);
+        }
+
+        [Test]
         public void Scratch()
         {
             var doc = "";
@@ -627,9 +647,10 @@ true || false"
             Doc doc,
             string expected,
             int width = PrinterOptions.WidthUsedByTests,
-            bool trimInitialLines = false
+            bool trimInitialLines = false,
+            bool useTabs = false
         ) {
-            var result = Print(doc, width, trimInitialLines);
+            var result = Print(doc, width, trimInitialLines, useTabs);
 
             result.Should().Be(expected);
         }
@@ -637,11 +658,17 @@ true || false"
         private static string Print(
             Doc doc,
             int width = PrinterOptions.WidthUsedByTests,
-            bool trimInitialLines = false
+            bool trimInitialLines = false,
+            bool useTabs = false
         ) {
             return DocPrinter.DocPrinter.Print(
                     doc,
-                    new PrinterOptions { Width = width, TrimInitialLines = trimInitialLines, },
+                    new PrinterOptions
+                    {
+                        Width = width,
+                        TrimInitialLines = trimInitialLines,
+                        UseTabs = useTabs
+                    },
                     Environment.NewLine
                 )
                 .TrimEnd('\r', '\n');

--- a/Src/CSharpier.Tests/DocPrinterTests.cs
+++ b/Src/CSharpier.Tests/DocPrinterTests.cs
@@ -624,7 +624,7 @@ true || false"
         }
 
         [Test]
-        public void Align_Should_Convert_Spaces_To_Tabs()
+        public void Align_Should_Convert_Non_Trailing_Spaces_To_Tabs()
         {
             var doc = Doc.Concat(
                 "+ ",

--- a/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
@@ -6,13 +6,13 @@ class NoModifiers { }
 
 public class WithInterface : IInterface { }
 
-public class WithReallyLongNameInterface :
-    IReallyLongNameLetsMakeThisBreak___________________________ { }
+public class WithReallyLongNameInterface
+    : IReallyLongNameLetsMakeThisBreak___________________________ { }
 
-public class ThisIsSomeLongNameAndItShouldFormatWell1 :
-    AnotherLongClassName,
-    AndYetAnotherLongClassName,
-    AndStillOneMore { }
+public class ThisIsSomeLongNameAndItShouldFormatWell1
+    : AnotherLongClassName,
+      AndYetAnotherLongClassName,
+      AndStillOneMore { }
 
 public class SimpleGeneric<T>
     where T : new() { }
@@ -36,9 +36,24 @@ public class LongerClassNameWithLotsOfGenerics<
 public class SimpleGeneric<T> : BaseClass<T>
     where T : new() { }
 
-public class ThisIsSomeLongNameAndItShouldFormatWell2<T, T2, T3> :
-    AnotherLongClassName<T>,
-    AnotherClassName
+public class ThisIsSomeLongNameAndItShouldFormatWell2<T, T2, T3>
+    : AnotherLongClassName<T>,
+      AnotherClassName
     where T : new(), AnotherTypeConstraint
     where T2 : new()
     where T3 : new() { }
+
+public class IdentityDbContext<TUser, TRole, TKey>
+    : IdentityDbContext<
+          TUser,
+          TRole,
+          TKey,
+          IdentityUserClaim<TKey>,
+          IdentityUserRole<TKey>,
+          IdentityUserLogin<TKey>,
+          IdentityRoleClaim<TKey>,
+          IdentityUserToken<TKey>
+      >
+    where TUser : IdentityUser<TKey>
+    where TRole : IdentityRole<TKey>
+    where TKey : IEquatable<TKey> { }

--- a/Src/CSharpier.Tests/TestFiles/RecordDeclaration/RecordDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/RecordDeclaration/RecordDeclarations.cst
@@ -17,7 +17,7 @@ record PC(string x) : PrimaryConstructor(x) { }
 
 record RecordWithoutBody(string property);
 
-record LongerRecordNameWhatHappens_________________________________________(string x) :
-    R4<string>(x) { }
+record LongerRecordNameWhatHappens_________________________________________(string x)
+    : R4<string>(x) { }
 
 record GenericRecord<T>(T Result);

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -7,14 +7,21 @@ using CSharpier.Utilities;
 
 namespace CSharpier.DocPrinter
 {
-    public static class DocFitter
+    public class DocFitter
     {
-        public static bool Fits(
+        protected readonly Dictionary<string, PrintMode> GroupModeMap;
+        protected readonly Indenter Indenter;
+
+        public DocFitter(Dictionary<string, PrintMode> groupModeMap, Indenter indenter)
+        {
+            GroupModeMap = groupModeMap;
+            Indenter = indenter;
+        }
+
+        public bool Fits(
             PrintCommand nextCommand,
             Stack<PrintCommand> remainingCommands,
-            int remainingWidth,
-            PrinterOptions printerOptions,
-            Dictionary<string, PrintMode> groupModeMap
+            int remainingWidth
         ) {
             var returnFalseIfMoreStringsFound = false;
             var newCommands = new Stack<PrintCommand>();
@@ -83,7 +90,7 @@ namespace CSharpier.DocPrinter
                             Push(
                                 indent.Contents,
                                 currentMode,
-                                IndentBuilder.MakeIndent(currentIndent, printerOptions)
+                                Indenter.IncreaseIndent(currentIndent)
                             );
                             break;
                         case Trim:
@@ -102,13 +109,13 @@ namespace CSharpier.DocPrinter
 
                             if (group.GroupId != null)
                             {
-                                groupModeMap![group.GroupId] = groupMode;
+                                GroupModeMap![group.GroupId] = groupMode;
                             }
                             break;
                         case IfBreak ifBreak:
                             var ifBreakMode = ifBreak.GroupId != null
-                            && groupModeMap!.ContainsKey(ifBreak.GroupId)
-                                ? groupModeMap[ifBreak.GroupId]
+                            && GroupModeMap!.ContainsKey(ifBreak.GroupId)
+                                ? GroupModeMap[ifBreak.GroupId]
                                 : currentMode;
 
                             var contents = ifBreakMode == PrintMode.Break
@@ -150,11 +157,7 @@ namespace CSharpier.DocPrinter
                             Push(
                                 align.Contents,
                                 currentMode,
-                                IndentBuilder.MakeAlign(
-                                    currentIndent,
-                                    align.Alignment,
-                                    printerOptions
-                                )
+                                Indenter.AddAlign(currentIndent, align.Width)
                             );
                             break;
                         default:

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -7,21 +7,14 @@ using CSharpier.Utilities;
 
 namespace CSharpier.DocPrinter
 {
-    public class DocFitter
+    public static class DocFitter
     {
-        protected readonly Dictionary<string, PrintMode> GroupModeMap;
-        protected readonly Indenter Indenter;
-
-        public DocFitter(Dictionary<string, PrintMode> groupModeMap, Indenter indenter)
-        {
-            GroupModeMap = groupModeMap;
-            Indenter = indenter;
-        }
-
-        public bool Fits(
+        public static bool Fits(
             PrintCommand nextCommand,
             Stack<PrintCommand> remainingCommands,
-            int remainingWidth
+            int remainingWidth,
+            Dictionary<string, PrintMode> groupModeMap,
+            Indenter indenter
         ) {
             var returnFalseIfMoreStringsFound = false;
             var newCommands = new Stack<PrintCommand>();
@@ -90,7 +83,7 @@ namespace CSharpier.DocPrinter
                             Push(
                                 indent.Contents,
                                 currentMode,
-                                Indenter.IncreaseIndent(currentIndent)
+                                indenter.IncreaseIndent(currentIndent)
                             );
                             break;
                         case Trim:
@@ -109,13 +102,13 @@ namespace CSharpier.DocPrinter
 
                             if (group.GroupId != null)
                             {
-                                GroupModeMap![group.GroupId] = groupMode;
+                                groupModeMap![group.GroupId] = groupMode;
                             }
                             break;
                         case IfBreak ifBreak:
                             var ifBreakMode = ifBreak.GroupId != null
-                            && GroupModeMap!.ContainsKey(ifBreak.GroupId)
-                                ? GroupModeMap[ifBreak.GroupId]
+                            && groupModeMap!.ContainsKey(ifBreak.GroupId)
+                                ? groupModeMap[ifBreak.GroupId]
                                 : currentMode;
 
                             var contents = ifBreakMode == PrintMode.Break
@@ -157,7 +150,7 @@ namespace CSharpier.DocPrinter
                             Push(
                                 align.Contents,
                                 currentMode,
-                                Indenter.AddAlign(currentIndent, align.Width)
+                                indenter.AddAlign(currentIndent, align.Width)
                             );
                             break;
                         default:

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -83,7 +83,7 @@ namespace CSharpier.DocPrinter
                             Push(
                                 indent.Contents,
                                 currentMode,
-                                IndentBuilder.Make(currentIndent, printerOptions)
+                                IndentBuilder.MakeIndent(currentIndent, printerOptions)
                             );
                             break;
                         case Trim:
@@ -145,6 +145,17 @@ namespace CSharpier.DocPrinter
                             Push(flat.Contents, currentMode, currentIndent);
                             break;
                         case BreakParent:
+                            break;
+                        case Align align:
+                            Push(
+                                align.Contents,
+                                currentMode,
+                                IndentBuilder.MakeAlign(
+                                    currentIndent,
+                                    align.Alignment,
+                                    printerOptions
+                                )
+                            );
                             break;
                         default:
                             throw new Exception("Can't handle " + currentDoc.GetType());

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -18,7 +18,6 @@ namespace CSharpier.DocPrinter
         protected bool SkipNextNewLine;
         protected readonly string EndOfLine;
         protected readonly PrinterOptions PrinterOptions;
-        protected readonly DocFitter DocFitter;
         protected readonly Indenter Indenter;
 
         protected DocPrinter(Doc doc, PrinterOptions printerOptions, string endOfLine)
@@ -26,7 +25,6 @@ namespace CSharpier.DocPrinter
             EndOfLine = endOfLine;
             PrinterOptions = printerOptions;
             Indenter = new Indenter(printerOptions);
-            DocFitter = new DocFitter(this.GroupModeMap, Indenter);
             RemainingCommands.Push(new PrintCommand(Indenter.GenerateRoot(), PrintMode.Break, doc));
         }
 
@@ -275,7 +273,9 @@ namespace CSharpier.DocPrinter
             return DocFitter.Fits(
                 possibleCommand,
                 RemainingCommands,
-                PrinterOptions.Width - CurrentWidth
+                PrinterOptions.Width - CurrentWidth,
+                GroupModeMap,
+                Indenter
             );
         }
 

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -78,7 +78,11 @@ namespace CSharpier.DocPrinter
                     break;
                 }
                 case IndentDoc indentDoc:
-                    Push(indentDoc.Contents, mode, IndentBuilder.Make(indent, PrinterOptions));
+                    Push(
+                        indentDoc.Contents,
+                        mode,
+                        IndentBuilder.MakeIndent(indent, PrinterOptions)
+                    );
                     break;
                 case Trim:
                     CurrentWidth -= Output.TrimTrailingWhitespace();
@@ -127,6 +131,13 @@ namespace CSharpier.DocPrinter
                     break;
                 case ForceFlat forceFlat:
                     Push(forceFlat.Contents, PrintMode.Flat, indent);
+                    break;
+                case Align align:
+                    Push(
+                        align.Contents,
+                        mode,
+                        IndentBuilder.MakeAlign(indent, align.Alignment, PrinterOptions)
+                    );
                     break;
                 default:
                     throw new Exception("didn't handle " + doc);

--- a/Src/CSharpier/DocPrinter/Indent.cs
+++ b/Src/CSharpier/DocPrinter/Indent.cs
@@ -4,33 +4,130 @@ using System.Text;
 
 namespace CSharpier.DocPrinter
 {
-    public record Indent(string Value, int Length);
+    public class Indent
+    {
+        public string Value = string.Empty;
+        public int Length;
+        public IList<IndentType>? TypesForTabs;
+    }
+
+    public class IndentType
+    {
+        public bool IsAlign { get; set; }
+        public int AlignWidth { get; set; }
+    }
 
     public static class IndentBuilder
     {
         public static Indent MakeRoot()
         {
-            return new Indent(string.Empty, 0);
+            return new();
         }
 
-        public static Indent Make(Indent indent, PrinterOptions printerOptions)
+        public static Indent MakeIndent(Indent indent, PrinterOptions printerOptions)
         {
             return GenerateIndent(indent, printerOptions);
         }
 
         private static Indent GenerateIndent(Indent indent, PrinterOptions printerOptions)
         {
+            if (!printerOptions.UseTabs)
+            {
+                return new Indent
+                {
+                    Value = indent.Value + new string(' ', printerOptions.TabWidth),
+                    Length = indent.Length + printerOptions.TabWidth
+                };
+            }
+
+            if (indent.TypesForTabs != null)
+            {
+                return MakeIndentWithTypesForTabs(indent, new IndentType(), printerOptions);
+            }
+
+            return new Indent
+            {
+                Value = indent.Value + "\t",
+                Length = indent.Length + printerOptions.TabWidth
+            };
+        }
+
+        public static Indent MakeAlign(Indent indent, int alignment, PrinterOptions printerOptions)
+        {
             if (printerOptions.UseTabs)
             {
-                return new Indent(indent.Value + "\t", indent.Length + printerOptions.TabWidth);
+                return MakeIndentWithTypesForTabs(
+                    indent,
+                    new IndentType { IsAlign = true, AlignWidth = alignment },
+                    printerOptions
+                );
             }
             else
             {
-                return new Indent(
-                    indent.Value + new string(' ', printerOptions.TabWidth),
-                    indent.Length + printerOptions.TabWidth
-                );
+                return new Indent
+                {
+                    Value = indent.Value + new string(' ', alignment),
+                    Length = indent.Length + alignment
+                };
             }
+        }
+
+        // when using tabs we need to sometimes replace the spaces from align with tabs
+        // trailing aligns stay as spaces, but any aligns before a tab get converted to a single tab
+        // see https://github.com/prettier/prettier/blob/main/commands.md#align
+        private static Indent MakeIndentWithTypesForTabs(
+            Indent indent,
+            IndentType nextIndentType,
+            PrinterOptions printerOptions
+        ) {
+            List<IndentType> types;
+
+            // if it doesn't exist yet, then all values on it are regular indents, not aligns
+            if (indent.TypesForTabs == null)
+            {
+                types = new List<IndentType>();
+                for (var x = 0; x < indent.Value.Length; x++)
+                {
+                    types.Add(new IndentType());
+                }
+            }
+            else
+            {
+                var placeTab = false;
+                types = new List<IndentType>(indent.TypesForTabs);
+                for (var x = types.Count - 1; x >= 0; x--)
+                {
+                    if (!types[x].IsAlign)
+                    {
+                        placeTab = true;
+                    }
+
+                    if (placeTab)
+                    {
+                        types[x] = new IndentType();
+                    }
+                }
+            }
+
+            types.Add(nextIndentType);
+
+            var length = 0;
+            var value = new StringBuilder();
+            foreach (var indentType in types)
+            {
+                if (indentType.IsAlign)
+                {
+                    value.Append(' ', indentType.AlignWidth);
+                    length += indentType.AlignWidth;
+                }
+                else
+                {
+                    value.Append('\t');
+                    length += printerOptions.TabWidth;
+                }
+            }
+
+            return new Indent { Length = length, Value = value.ToString(), TypesForTabs = types };
         }
     }
 }

--- a/Src/CSharpier/DocSerializer.cs
+++ b/Src/CSharpier/DocSerializer.cs
@@ -61,6 +61,7 @@ namespace CSharpier
                 LineDoc lineDoc => indent
                 + (lineDoc.Type == LineDoc.LineType.Normal ? "Doc.Line" : "Doc.SoftLine"),
                 BreakParent => "",
+                Align align => $"{indent}Doc.Align({align.Alignment}, {PrintIndentedDocTree(align.Contents)})",
                 Trim => $"{indent}Doc.Trim",
                 ForceFlat forceFlat => $"{indent}Doc.ForceFlat({newLine}{PrintIndentedDocTree(forceFlat.Contents)})",
                 IndentDoc indentDoc => $"{indent}Doc.Indent({newLine}{PrintIndentedDocTree(indentDoc.Contents)}{newLine}{indent})",

--- a/Src/CSharpier/DocSerializer.cs
+++ b/Src/CSharpier/DocSerializer.cs
@@ -61,7 +61,7 @@ namespace CSharpier
                 LineDoc lineDoc => indent
                 + (lineDoc.Type == LineDoc.LineType.Normal ? "Doc.Line" : "Doc.SoftLine"),
                 BreakParent => "",
-                Align align => $"{indent}Doc.Align({align.Alignment}, {PrintIndentedDocTree(align.Contents)})",
+                Align align => $"{indent}Doc.Align({align.Width}, {PrintIndentedDocTree(align.Contents)})",
                 Trim => $"{indent}Doc.Trim",
                 ForceFlat forceFlat => $"{indent}Doc.ForceFlat({newLine}{PrintIndentedDocTree(forceFlat.Contents)})",
                 IndentDoc indentDoc => $"{indent}Doc.Indent({newLine}{PrintIndentedDocTree(indentDoc.Contents)}{newLine}{indent})",

--- a/Src/CSharpier/DocTypes/Align.cs
+++ b/Src/CSharpier/DocTypes/Align.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace CSharpier.DocTypes
 {
-    public class Align : Doc
+    public class Align : Doc, IHasContents
     {
         public int Width { get; }
         public Doc Contents { get; }

--- a/Src/CSharpier/DocTypes/Align.cs
+++ b/Src/CSharpier/DocTypes/Align.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace CSharpier.DocTypes
+{
+    public class Align : Doc
+    {
+        public int Alignment { get; }
+        public Doc Contents { get; }
+
+        public Align(int alignment, Doc contents)
+        {
+            if (alignment < 1)
+            {
+                throw new Exception($"{nameof(alignment)} must be >= 1");
+            }
+
+            this.Alignment = alignment;
+            this.Contents = contents;
+        }
+    }
+}

--- a/Src/CSharpier/DocTypes/Align.cs
+++ b/Src/CSharpier/DocTypes/Align.cs
@@ -4,17 +4,17 @@ namespace CSharpier.DocTypes
 {
     public class Align : Doc
     {
-        public int Alignment { get; }
+        public int Width { get; }
         public Doc Contents { get; }
 
-        public Align(int alignment, Doc contents)
+        public Align(int width, Doc contents)
         {
-            if (alignment < 1)
+            if (width < 1)
             {
-                throw new Exception($"{nameof(alignment)} must be >= 1");
+                throw new Exception($"{nameof(width)} must be >= 1");
             }
 
-            this.Alignment = alignment;
+            this.Width = width;
             this.Contents = contents;
         }
     }

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -107,6 +107,8 @@ namespace CSharpier.DocTypes
         public static Doc Directive(string value) => new StringDoc(value, true);
 
         public static ConditionalGroup ConditionalGroup(params Doc[] options) => new(options);
+
+        public static Align Align(int alignment, Doc contents) => new(alignment, contents);
     }
 
     public enum CommentType

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -119,6 +119,6 @@ namespace CSharpier.DocTypes
 
     interface IHasContents
     {
-        Doc Contents { get; set; }
+        Doc Contents { get; }
     }
 }

--- a/Src/CSharpier/DocTypes/StringDoc.cs
+++ b/Src/CSharpier/DocTypes/StringDoc.cs
@@ -2,8 +2,8 @@ namespace CSharpier.DocTypes
 {
     public class StringDoc : Doc
     {
-        public string Value { get; set; }
-        public bool IsDirective { get; set; }
+        public string Value { get; }
+        public bool IsDirective { get; }
 
         public StringDoc(string value, bool isDirective = false)
         {

--- a/Src/CSharpier/DocTypes/Trim.cs
+++ b/Src/CSharpier/DocTypes/Trim.cs
@@ -2,6 +2,5 @@ namespace CSharpier.DocTypes
 {
     public class Trim : Doc
     {
-        public Trim() { }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseList.cs
@@ -7,11 +7,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(BaseListSyntax node)
         {
-            return Doc.Concat(
-                " ",
-                Token.Print(node.ColonToken),
+            return Doc.Group(
                 Doc.Indent(
-                    Doc.Group(Doc.Line, SeparatedSyntaxList.Print(node.Types, Node.Print, Doc.Line))
+                    Doc.Line,
+                    Token.Print(node.ColonToken),
+                    " ",
+                    Doc.Align(
+                        2,
+                        Doc.Concat(SeparatedSyntaxList.Print(node.Types, Node.Print, Doc.Line))
+                    )
                 )
             );
         }


### PR DESCRIPTION
This implements a basic version of the align doc type. The prettier version does a lot more, but we can keep it simple until we need to add the extra complexity.
This also uses align to handle formatting ClassDeclaration with BaseLists to get them looking good with ConstraintClauses

closes #276
closes #275