### PR TITLE
Better print generic methods and constructors

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ClassDeclaration/ClassDeclarations.cst
@@ -14,8 +14,7 @@ public class ThisIsSomeLongNameAndItShouldFormatWell1
       AndYetAnotherLongClassName,
       AndStillOneMore { }
 
-public class SimpleGeneric<T>
-    where T : new() { }
+public class SimpleGeneric<T> where T : new() { }
 
 public class LongTypeConstraints<T>
     where T : SomeLongNameThatJustKeepsGoing,
@@ -33,8 +32,7 @@ public class LongerClassNameWithLotsOfGenerics<
     TThirdLongName__________________
 > : SomeBaseClass<TLongName> { }
 
-public class SimpleGeneric<T> : BaseClass<T>
-    where T : new() { }
+public class SimpleGeneric<T> : BaseClass<T> where T : new() { }
 
 public class ThisIsSomeLongNameAndItShouldFormatWell2<T, T2, T3>
     : AnotherLongClassName<T>,

--- a/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
@@ -36,9 +36,8 @@ public class Initializers : BasicClass
         string reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameter
     ) : base(false) { }
 
-    public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName() : base(
-        false
-    ) { }
+    public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName()
+        : base(false) { }
 }
 
 public class Exactly80

--- a/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
@@ -43,6 +43,14 @@ public class Initializers : BasicClass
         : base(
             reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameterIMeanIt
         ) { }
+
+    public Initializers(
+        string value
+    ) /*Comment*/
+      : base(value) { }
+
+    public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName()
+        /*Comment*/: base(false) { }
 }
 
 public class Exactly80

--- a/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
@@ -22,11 +22,20 @@ public class BasicClass
 
 public class Initializers : BasicClass
 {
-    public Initializers()
-        : this(true) { }
+    public Initializers() : this(true) { }
 
-    public Initializers(string value)
-        : base(value) { }
+    public Initializers(string value) : base(value) { }
+
+    public Initializers(
+        string parameter1,
+        string parameter2,
+        string parameter3,
+        string parameter4
+    ) : base(false)
+    {
+        _parameter1 = parameter1;
+        _parameter2 = parameter2;
+    }
 }
 
 public class Exactly80

--- a/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
@@ -38,6 +38,11 @@ public class Initializers : BasicClass
 
     public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName()
         : base(false) { }
+
+    public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName()
+        : base(
+            reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameterIMeanIt
+        ) { }
 }
 
 public class Exactly80

--- a/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/ConstructorDeclaration/ConstructorDeclarations.cst
@@ -27,15 +27,18 @@ public class Initializers : BasicClass
     public Initializers(string value) : base(value) { }
 
     public Initializers(
-        string parameter1,
-        string parameter2,
-        string parameter3,
-        string parameter4
-    ) : base(false)
-    {
-        _parameter1 = parameter1;
-        _parameter2 = parameter2;
-    }
+        string reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameter
+    ) : base(
+        reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameterIMeanIt
+    ) { }
+
+    public Initializers(
+        string reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameter
+    ) : base(false) { }
+
+    public ReallyLoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogMethodName() : base(
+        false
+    ) { }
 }
 
 public class Exactly80

--- a/Src/CSharpier.Tests/TestFiles/DelegateDeclaration/DelegateDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/DelegateDeclaration/DelegateDeclarations.cst
@@ -2,6 +2,5 @@ class ClassName
 {
     delegate void Delegate();
 
-    delegate void Delegate<[System.Obsolete()] out T>()
-        where T : struct;
+    delegate void Delegate<[System.Obsolete()] out T>() where T : struct;
 }

--- a/Src/CSharpier.Tests/TestFiles/ObnoxiousEdgeCases/ObnoxiousEdgeCases.cst
+++ b/Src/CSharpier.Tests/TestFiles/ObnoxiousEdgeCases/ObnoxiousEdgeCases.cst
@@ -60,8 +60,7 @@ class ClassName
             DynamicallyAccessedMemberTypes.PublicConstructors)]
         TAccountClaimsPrincipalFactory>(
         this IRemoteAuthenticationBuilder<RemoteAuthenticationState, RemoteUserAccount> builder
-    )
-        where TAccountClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount> =>
+    ) where TAccountClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount> =>
         builder.AddAccountClaimsPrincipalFactory<
             RemoteAuthenticationState,
             RemoteUserAccount,

--- a/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
+++ b/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
@@ -10,14 +10,18 @@ class ClassName<T> where T : class
         }
     }
 
+    public static ReturnType<T> MethodName<T, U>()
+        where T : class
+        where U : class { }
+
+    public static ReturnType<T> MethodName<T, U>(string parameter)
+        where T : class
+        where U : class { }
+
     public static ReturnType<T> MethodName<T, U>(
-        string parameter1,
-        string parameter2
+        string reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameterIMeanIt
     ) where T : class
-      where U : class
-    {
-        return;
-    }
+      where U : class { }
 }
 
 interface InterfaceName<T> where T : class { }

--- a/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
+++ b/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
@@ -1,25 +1,28 @@
-delegate void Delegate<T>()
-    where T : struct;
+delegate void Delegate<T>() where T : struct;
 
-class ClassName<T>
-    where T : class
+class ClassName<T> where T : class
 {
-    void MethodName<T>()
-        where T : class
+    void MethodName<T>() where T : class
     {
-        void LocalFunction<T>()
-            where T : class
+        void LocalFunction<T>() where T : class
         {
             return;
         }
     }
+
+    public static ReturnType<T> MethodName<T, U>(
+        string parameter1,
+        string parameter2
+    ) where T : class
+      where U : class
+    {
+        return;
+    }
 }
 
-interface InterfaceName<T>
-    where T : class { }
+interface InterfaceName<T> where T : class { }
 
-struct Struct<T>
-    where T : class { }
+struct Struct<T> where T : class { }
 
 class ClassName<N, C, T, TT, L>
     where N : new()

--- a/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
+++ b/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
@@ -8,47 +8,39 @@ namespace CSharpier.SyntaxPrinter
 {
     public static class ConstraintClauses
     {
+        public static Doc PrintWithConditionalSpace(
+            IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses,
+            string groupId
+        ) {
+            return Print(constraintClauses, groupId);
+        }
+
         public static Doc Print(IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses)
         {
+            return Print(constraintClauses, null);
+        }
+
+        private static Doc Print(
+            IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses,
+            string? groupId
+        ) {
             var constraintClausesList = constraintClauses.ToList();
 
             if (constraintClausesList.Count == 0)
             {
                 return Doc.Null;
             }
-            else if (constraintClausesList.Count == 1)
-            {
-                return Doc.Group(
-                    Doc.Indent(
-                        Doc.Line,
-                        Doc.Join(
-                            Doc.Line,
-                            constraintClausesList.Select(TypeParameterConstraintClause.Print)
-                        )
-                    )
-                );
-            }
-
-            if (constraintClausesList[0].Parent is MethodDeclarationSyntax)
-            {
-                return Doc.Concat(
-                    " ",
-                    Doc.Align(
-                        2,
-                        Doc.Join(
-                            Doc.HardLine,
-                            constraintClausesList.Select(TypeParameterConstraintClause.Print)
-                        )
-                    )
-                );
-            }
-
-            return Doc.Indent(
+            var prefix = constraintClausesList.Count >= 2 ? Doc.HardLine : Doc.Line;
+            var body = Doc.Join(
                 Doc.HardLine,
-                Doc.Join(
-                    Doc.HardLine,
-                    constraintClausesList.Select(TypeParameterConstraintClause.Print)
-                )
+                constraintClausesList.Select(TypeParameterConstraintClause.Print)
+            );
+
+            return Doc.Group(
+                Doc.Indent(groupId != null ? Doc.IfBreak(" ", prefix, groupId) : prefix),
+                groupId != null
+                    ? Doc.IfBreak(Doc.Align(2, body), Doc.Indent(body), groupId)
+                    : Doc.Indent(body)
             );
         }
     }

--- a/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
+++ b/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
@@ -16,19 +16,40 @@ namespace CSharpier.SyntaxPrinter
             {
                 return Doc.Null;
             }
-
-            var docs = new List<Doc>
+            else if (constraintClausesList.Count == 1)
             {
-                Doc.Indent(
-                    Doc.HardLine,
-                    Doc.Join(
-                        Doc.HardLine,
-                        constraintClausesList.Select(TypeParameterConstraintClause.Print)
+                return Doc.Group(
+                    Doc.Indent(
+                        Doc.Line,
+                        Doc.Join(
+                            Doc.Line,
+                            constraintClausesList.Select(TypeParameterConstraintClause.Print)
+                        )
                     )
-                )
-            };
+                );
+            }
 
-            return Doc.Concat(docs);
+            if (constraintClausesList[0].Parent is MethodDeclarationSyntax)
+            {
+                return Doc.Concat(
+                    " ",
+                    Doc.Align(
+                        2,
+                        Doc.Join(
+                            Doc.HardLine,
+                            constraintClausesList.Select(TypeParameterConstraintClause.Print)
+                        )
+                    )
+                );
+            }
+
+            return Doc.Indent(
+                Doc.HardLine,
+                Doc.Join(
+                    Doc.HardLine,
+                    constraintClausesList.Select(TypeParameterConstraintClause.Print)
+                )
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -179,8 +179,6 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             {
                 docs.Add(
                     groupId != null
-                    && constraintClauses.Count() < 2
-                    && constructorInitializer == null
                         ? Block.PrintWithConditionalSpace(body, groupId)
                         : Block.Print(body)
                 );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -170,7 +170,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 
             docs.Add(Doc.Group(declarationGroup));
 
-            docs.Add(ConstraintClauses.Print(constraintClauses));
+            docs.Add(
+                groupId != null
+                    ? ConstraintClauses.PrintWithConditionalSpace(constraintClauses, groupId)
+                    : ConstraintClauses.Print(constraintClauses)
+            );
             if (body != null)
             {
                 docs.Add(

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -168,6 +168,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             {
                 docs.Add(
                     groupId != null
+                    && constraintClauses.Count() < 2
+                    && constructorInitializer == null
                         ? Block.PrintWithConditionalSpace(body, groupId)
                         : Block.Print(body)
                 );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -149,7 +149,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 
             if (constructorInitializer != null)
             {
-                declarationGroup.Add(ConstructorInitializer.Print(constructorInitializer));
+                declarationGroup.Add(
+                    groupId != null
+                        ? ConstructorInitializer.PrintWithConditionalSpace(
+                                constructorInitializer,
+                                groupId
+                            )
+                        : ConstructorInitializer.Print(constructorInitializer)
+                );
             }
 
             if (modifiers.HasValue && modifiers.Value.Count > 0)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -19,9 +19,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 
         private static Doc Print(ConstructorInitializerSyntax node, string? groupId)
         {
+            var colonToken = Token.PrintWithSuffix(node.ColonToken, " ");
             return Doc.Group(
                 Doc.Indent(groupId != null ? Doc.IfBreak(" ", Doc.Line, groupId) : Doc.Line),
-                Token.PrintWithSuffix(node.ColonToken, " "),
+                groupId != null
+                    ? Doc.IfBreak(Doc.Align(2, colonToken), Doc.Indent(colonToken), groupId)
+                    : Doc.Indent(colonToken),
                 Token.Print(node.ThisOrBaseKeyword),
                 groupId != null
                     ? ArgumentList.Print(node.ArgumentList)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -23,7 +23,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Doc.Indent(groupId != null ? Doc.IfBreak(" ", Doc.Line, groupId) : Doc.Line),
                 Token.PrintWithSuffix(node.ColonToken, " "),
                 Token.Print(node.ThisOrBaseKeyword),
-                ArgumentList.Print(node.ArgumentList)
+                groupId != null ? ArgumentList.Print(node.ArgumentList) : Doc.Indent(ArgumentList.Print(node.ArgumentList))
             );
         }
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -8,8 +8,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(ConstructorInitializerSyntax node)
         {
-            return Doc.Indent(
-                Doc.HardLine,
+            return Doc.Concat(
+                " ",
                 Token.PrintWithSuffix(node.ColonToken, " "),
                 Token.Print(node.ThisOrBaseKeyword),
                 ArgumentList.Print(node.ArgumentList)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -1,15 +1,26 @@
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 {
     public static class ConstructorInitializer
     {
+        public static Doc PrintWithConditionalSpace(
+            ConstructorInitializerSyntax node,
+            string groupId
+        ) {
+            return Print(node, groupId);
+        }
+
         public static Doc Print(ConstructorInitializerSyntax node)
         {
-            return Doc.Concat(
-                " ",
+            return Print(node, null);
+        }
+
+        private static Doc Print(ConstructorInitializerSyntax node, string? groupId)
+        {
+            return Doc.Group(
+                Doc.Indent(groupId != null ? Doc.IfBreak(" ", Doc.Line, groupId) : Doc.Line),
                 Token.PrintWithSuffix(node.ColonToken, " "),
                 Token.Print(node.ThisOrBaseKeyword),
                 ArgumentList.Print(node.ArgumentList)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorInitializer.cs
@@ -23,7 +23,9 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Doc.Indent(groupId != null ? Doc.IfBreak(" ", Doc.Line, groupId) : Doc.Line),
                 Token.PrintWithSuffix(node.ColonToken, " "),
                 Token.Print(node.ThisOrBaseKeyword),
-                groupId != null ? ArgumentList.Print(node.ArgumentList) : Doc.Indent(ArgumentList.Print(node.ArgumentList))
+                groupId != null
+                    ? ArgumentList.Print(node.ArgumentList)
+                    : Doc.Indent(ArgumentList.Print(node.ArgumentList))
             );
         }
     }


### PR DESCRIPTION
If there is only one generic constraint, we try to keep it on the same line. If more one, they're broken up.
As for the constructor initialiser, it's kept on the same line as the ending brace of the arguments.

Closes #94