### PR TITLE
When printing a token, only concat the list of docs if it has >= 2 it…

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -77,18 +77,12 @@ namespace CSharpier.SyntaxPrinter
                 docs.Add(suffixDoc);
             }
 
-            if (docs.Count == 0)
+            return docs.Count switch
             {
-                return Doc.Null;
-            }
-            else if (docs.Count == 1)
-            {
-                return docs.First();
-            }
-            else
-            {
-                return Doc.Concat(docs);
-            }
+                <= 0 => Doc.Null,
+                1 => docs.First(),
+                _ => Doc.Concat(docs)
+            };
         }
 
         public static Doc PrintLeadingTrivia(SyntaxToken syntaxToken)

--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -77,7 +77,18 @@ namespace CSharpier.SyntaxPrinter
                 docs.Add(suffixDoc);
             }
 
-            return Doc.Concat(docs);
+            if (docs.Count == 0)
+            {
+                return Doc.Null;
+            }
+            else if (docs.Count == 1)
+            {
+                return docs.First();
+            }
+            else
+            {
+                return Doc.Concat(docs);
+            }
         }
 
         public static Doc PrintLeadingTrivia(SyntaxToken syntaxToken)


### PR DESCRIPTION
…ems. This will make looking through the node graph easier while debugging.