### PR TITLE
Better format binary expressions

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/AssignmentExpression/AssignmentExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/AssignmentExpression/AssignmentExpressions.cst
@@ -12,5 +12,8 @@ class ClassName
         x = 15;
 
         x = 25; // trailing!!!!
+
+        assignmentInstructionalText =
+            editAssignmentViewModel.InstructionalTextxxxxxxxxxx ?? string.Empty;
     }
 }

--- a/Src/CSharpier.Tests/TestFiles/BinaryExpression/BinaryExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/BinaryExpression/BinaryExpressions.cst
@@ -31,5 +31,40 @@ class TestClass
         var directivesDontBreakBinary =
 #pragma
             true || false;
+
+        var x =
+            query
+            && (
+                currentChar == '='
+                || currentChar == '<'
+                || currentChar == '!'
+                || currentChar == '>'
+                || currentChar == '|'
+                || currentChar == '&'
+            );
+
+        var x =
+            node is BinaryExpressionSyntax
+            || node is IsPatternExpressionSyntax isPattern
+            && isPattern.Pattern is ConstantPatternSyntax;
+
+        var x =
+            (
+                optionsProvider != null
+                && optionsProvider.TryGetDiagnosticValue(
+                    tree,
+                    diagnosticId,
+                    CancellationToken.None,
+                    out _
+                )
+            )
+            || (
+                diagnosticCategory != null
+                && analyzerConfigOptions.TryGetValue(
+                    GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(diagnosticCategory),
+                    out _
+                )
+            )
+            || analyzerConfigOptions.TryGetValue(DotnetAnalyzerDiagnosticSeverityKey, out _);
     }
 }

--- a/Src/CSharpier.Tests/TestFiles/DoStatement/DoStatements.cst
+++ b/Src/CSharpier.Tests/TestFiles/DoStatement/DoStatements.cst
@@ -10,5 +10,12 @@ class ClassName
 
         do x++;
         while (x < 10);
+
+        do { }
+        while (
+            initialDepth - 1 < reader.Depth - (JsonTokenUtils.IsEndToken(reader.TokenType) ? 1 : 0)
+            && writeChildren
+            && reader.Read()
+        );
     }
 }

--- a/Src/CSharpier.Tests/TestFiles/IsPatternExpression/IsPatternExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/IsPatternExpression/IsPatternExpressions.cst
@@ -41,8 +41,7 @@ class ClassName
                     or SyntaxKind.PlusToken;
 
         if (
-            Nullable.GetUnderlyingType111111111111111(typeof(T))
-                is Type innerType
+            Nullable.GetUnderlyingType111111111111111(typeof(T)) is Type innerType
             && innerType.IsEnum
         ) {
             return;

--- a/Src/CSharpier/SyntaxPrinter/Assignment.cs
+++ b/Src/CSharpier/SyntaxPrinter/Assignment.cs
@@ -1,0 +1,69 @@
+using System;
+using CSharpier.DocTypes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CSharpier.SyntaxPrinter
+{
+    public static class Assignment
+    {
+        public static Doc PrintRhs(ExpressionSyntax rhs)
+        {
+            var formatMode = rhs
+                is AnonymousObjectCreationExpressionSyntax
+                    or AnonymousMethodExpressionSyntax
+                    or InitializerExpressionSyntax
+                    or InvocationExpressionSyntax
+                    or ConditionalExpressionSyntax
+                    or ObjectCreationExpressionSyntax
+                    or SwitchExpressionSyntax
+                    or LambdaExpressionSyntax
+                    or AwaitExpressionSyntax
+                    or WithExpressionSyntax
+                ? FormatMode.NoIndent
+                : rhs
+                        is BinaryExpressionSyntax
+                            or InterpolatedStringExpressionSyntax
+                            or IsPatternExpressionSyntax
+                            or LiteralExpressionSyntax
+                            or QueryExpressionSyntax
+                            or StackAllocArrayCreationExpressionSyntax
+                        ? FormatMode.IndentWithLine
+                        : FormatMode.Indent;
+            var groupId = Guid.NewGuid().ToString();
+            return Doc.Concat(
+                formatMode is FormatMode.IndentWithLine
+                    ? Doc.Null
+                    : Doc.GroupWithId(groupId, Doc.Indent(Doc.Line)),
+                rhs
+                    is InvocationExpressionSyntax
+                        or ParenthesizedLambdaExpressionSyntax
+                        or ObjectCreationExpressionSyntax
+                        or ElementAccessExpressionSyntax
+                        or ArrayCreationExpressionSyntax
+                        or ImplicitArrayCreationExpressionSyntax
+                    ? Doc.IndentIfBreak(Doc.Group(Node.Print(rhs)), groupId)
+                    : Doc.Group(IndentIfNeeded(rhs, formatMode))
+            );
+        }
+
+        private static Doc IndentIfNeeded(ExpressionSyntax initializerValue, FormatMode formatMode)
+        {
+            if (formatMode is FormatMode.NoIndent)
+            {
+                return Node.Print(initializerValue);
+            }
+
+            return Doc.Indent(
+                formatMode is FormatMode.IndentWithLine ? Doc.Line : Doc.Null,
+                Node.Print(initializerValue)
+            );
+        }
+
+        private enum FormatMode
+        {
+            NoIndent,
+            IndentWithLine,
+            Indent
+        }
+    }
+}

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AssignmentExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AssignmentExpression.cs
@@ -12,12 +12,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Node.Print(node.Left),
                 " ",
                 Token.Print(node.OperatorToken),
-                node.Right is QueryExpressionSyntax
-                    ? Doc.Indent(Doc.Line, Node.Print(node.Right))
-                    : Doc.Group(
-                            node.Right is InitializerExpressionSyntax ? Doc.Null : " ",
-                            Node.Print(node.Right)
-                        )
+                Assignment.PrintRhs(node.Right)
             );
         }
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
@@ -19,7 +19,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Doc.HardLine,
                 Token.PrintWithSuffix(node.WhileKeyword, " "),
                 Token.Print(node.OpenParenToken),
-                Node.Print(node.Condition),
+                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition)), Doc.SoftLine),
                 Token.Print(node.CloseParenToken),
                 Token.Print(node.SemicolonToken)
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
@@ -8,7 +8,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(IsPatternExpressionSyntax node)
         {
-            return Doc.Concat(
+            return Doc.Group(
                 Node.Print(node.Expression),
                 Doc.Indent(
                     Doc.Line,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
@@ -8,9 +8,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(ParenthesizedExpressionSyntax node)
         {
-            return Doc.Concat(
+            return Doc.Group(
                 Token.Print(node.OpenParenToken),
-                Node.Print(node.Expression),
+                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression)),
+                Doc.SoftLine,
                 Token.Print(node.CloseParenToken)
             );
         }


### PR DESCRIPTION
We do a couple of things in this PR
* Put nested binary expressions onto a newline and indent
* Fix `is` operator
* Fix the condition in `do-while`
* Extract the logic for printing the rhs of an `=` operator so that it can be used by both `VariableDeclaration` and `AssignmentExpression`