### PR TITLE
Improving the formatting of lambda's with expression bodies.

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/FieldDeclaration/FieldDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/FieldDeclaration/FieldDeclarations.cst
@@ -72,13 +72,11 @@ public class ClassName
 
     private Func<SomeObjectIn, bool> SomeFieldFunc = (someValue) => true;
 
-    private Func<SomeObjectIn, bool> SomeFieldFunc = (someValue) => SometimesBreaksThisWay(
-        someValue
-    );
+    private Func<SomeObjectIn, bool> SomeFieldFunc = (someValue) =>
+        SometimesBreaksThisWay(someValue);
 
-    private Func<SomeObjectIn, bool> SomeFieldFunc = (
-        someValue
-    ) => OrWhenLongerBreaksThisWay________(someValue);
+    private Func<SomeObjectIn, bool> SomeFieldFunc = (someValue) =>
+        OrWhenLongerBreaksThisWay________(someValue);
 
     private Func<SomeObjectIn_________________________, bool> SomeFieldFuncWithALongName_________ =
         (someValue) => SomeOtherLongerMethod(someValue);
@@ -91,17 +89,14 @@ public class ClassName
     private Func<
         SomeLongObjectIn__________________________________,
         bool
-    > SomeFieldFuncWithALongName = (someValue) => SometimesBreaksThisWay(
-        someValue,
-        SomeOtherLongValue
-    );
+    > SomeFieldFuncWithALongName = (someValue) =>
+        SometimesBreaksThisWay(someValue, SomeOtherLongValue);
 
     private Func<
         SomeLongObjectIn__________________________________,
         bool
-    > SomeFieldFuncWithALongName = (
-        someValue_____________________________
-    ) => SometimesBreaksThisWay(someValue, SomeOtherLongValue);
+    > SomeFieldFuncWithALongName = (someValue_____________________________) =>
+        SometimesBreaksThisWay(someValue, SomeOtherLongValue);
 }
 
 struct S

--- a/Src/CSharpier.Tests/TestFiles/ParenthesizedLambdaExpression/ParenthesizedLambdaExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/ParenthesizedLambdaExpression/ParenthesizedLambdaExpressions.cst
@@ -14,10 +14,16 @@ public class ClassName
         this.Where(static () => true);
         this.Where(async static () => true);
         this.SomeMethod(
+            (longParameter__________________, longParameter_________________) =>
+                longParameter________________
+        );
+
+        this.SomeMethod(
             (
-                a11111111111111111111111111111,
-                b222222222222222222222222222222
-            ) => someLongNameThatWillDoStuff
+                longerParameter_________________________,
+                longerParameter_________________________,
+                longerParameter_________________________
+            ) => evenLongerParameter
         );
 
         var task = Task.Factory.StartNew(
@@ -29,9 +35,8 @@ public class ClassName
             }
         );
 
-        Action find = () => EntryPointDiscoverer.FindStaticEntryMethod(
-            typeof(IEnumerable<>).Assembly
-        );
+        Action find = () =>
+            EntryPointDiscoverer.FindStaticEntryMethod(typeof(IEnumerable<>).Assembly);
 
         var @delegate = (Action<string>)((s) => { });
 
@@ -53,5 +58,15 @@ public class ClassName
                 }
             )
         };
+
+        CallSomeMethod(
+            () =>
+                CallAnotherMethodWithParameters(
+                    someParameter,
+                    someParameter___________________________________
+                )
+                > someValue,
+            anotherParameter
+        );
     }
 }

--- a/Src/CSharpier.Tests/TestFiles/VariableDeclaration/VariableDeclarations.cst
+++ b/Src/CSharpier.Tests/TestFiles/VariableDeclaration/VariableDeclarations.cst
@@ -25,13 +25,20 @@ class ClassName
         var captureUnmatchedValuesParameters______________________________ =
             new List<IPropertySymbol>();
 
+        Func<SyntaxTrivia, bool> s_isVisualBasicCommentTrivia = (syntaxTrivia) =>
+            syntaxTrivia.IsKind(VisualBasic.SyntaxKind.CommentTrivia);
+
         Func<SyntaxTrivia, bool> s_isVisualBasicCommentTrivia = (
-            syntaxTrivia
+            syntaxTrivia_________________________________
         ) => syntaxTrivia.IsKind(VisualBasic.SyntaxKind.CommentTrivia);
 
-        Action find = () => EntryPointDiscoverer.FindStaticEntryMethod(
-            typeof(IEnumerable<>).Assembly
-        );
+        Action find = () =>
+            EntryPointDiscoverer.FindStaticEntryMethod(typeof(IEnumerable<>).Assembly);
+
+        Action find = () =>
+            EntryPointDiscoverer.FindStaticEntryMethod(
+                typeof(IEnumerable<>).Assembly_________________________________________
+            );
 
         var arrayCreationExpression1 = new byte[100];
         var arrayCreationExpression2 = new byte[

--- a/Src/CSharpier/SyntaxPrinter/ArgumentListLikeSyntax.cs
+++ b/Src/CSharpier/SyntaxPrinter/ArgumentListLikeSyntax.cs
@@ -15,12 +15,14 @@ namespace CSharpier.SyntaxPrinter
             Doc.Concat(
                 Token.Print(openParenToken),
                 arguments.Any()
-                    ? Doc.Indent(
-                            Doc.SoftLine,
-                            SeparatedSyntaxList.Print(arguments, Argument.Print, Doc.Line)
+                    ? Doc.Concat(
+                            Doc.Indent(
+                                Doc.SoftLine,
+                                SeparatedSyntaxList.Print(arguments, Argument.Print, Doc.Line)
+                            ),
+                            Doc.SoftLine
                         )
                     : Doc.Null,
-                arguments.Any() ? Doc.SoftLine : Doc.Null,
                 Token.Print(closeParenToken)
             );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
@@ -14,19 +14,23 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Modifiers.Print(node.Modifiers),
                 ParameterList.Print(node.ParameterList),
                 " ",
-                Token.PrintWithSuffix(
-                    node.ArrowToken,
-                    node.Block
-                        is not null
-                            and { Statements: { Count: > 0 } } ? Doc.HardLine : " "
-                )
+                Token.Print(node.ArrowToken)
             };
             if (node.ExpressionBody != null)
             {
-                docs.Add(Node.Print(node.ExpressionBody));
+                docs.Add(Doc.Group(Doc.Indent(Doc.Line, Node.Print(node.ExpressionBody))));
             }
             else if (node.Block != null)
             {
+                if (node.Block.Statements.Count > 0)
+                {
+                    docs.Add(Doc.HardLine);
+                }
+                else
+                {
+                    docs.Add(" ");
+                }
+
                 docs.Add(Block.Print(node.Block));
             }
 


### PR DESCRIPTION
When printing expression bodies - indent and group the contents to handle edge cases like BinaryExpressions in them.
This also cleans up the formatting of expression bodies that used to break onto multiple lines when they had an InvocationExpression.

closes #176