### PR TITLE
Only publish the playground when a new tag is pushed

### DIFF
--- a/.github/workflows/playground_publish.yml
+++ b/.github/workflows/playground_publish.yml
@@ -1,10 +1,8 @@
 name: Publish Playground
 on:
   push:
-    branches: [ master ]
-    paths:
-      - "Src/CSharpier/**/*"
-      - "Src/CSharpier.Playground/**/*"
+    tags:
+      - "*"
 
 defaults:
   run:


### PR DESCRIPTION
This ensures that the published playground site will be running the most recent release, it will not be running prerelease code.
closes #224