### PR TITLE
Break and Tab Parameters with Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 # Jetbrains doesn't say to ignore these, but it seems like they shouldn't be committed
 **/.idea/**/watcherTasks.xml
 
+.vscode
+
 node_modules
 bin
 obj

--- a/Src/CSharpier.Tests/TestFiles/AttributeList/AttributeLists.cst
+++ b/Src/CSharpier.Tests/TestFiles/AttributeList/AttributeLists.cst
@@ -59,8 +59,10 @@ class ClassName
 
     public void MethodName(
         int someParameter,
-        [LongAttributeName(SomeFlag.SomeValue)]
-        AnotherObject anotherObject
+        [ShortAttributeName] AnotherObject anotherObject,
+        [VeryLongAttributeName(SomeFlag.SomeValue, SomeOtherFlag.SomeOtherLongValue)]
+            string tabbedBreakParameter,
+        bool anotherParameter
     ) {
         return;
     }

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -81,6 +81,13 @@ namespace CSharpier.DocTypes
             new()
             { Contents = contents.Count == 1 ? contents[0] : Concat(contents) };
 
+        public static Group GroupWithId(string groupId, List<Doc> contents)
+        {
+            var group = Group(contents);
+            group.GroupId = groupId;
+            return group;
+        }
+
         public static Group GroupWithId(string groupId, params Doc[] contents)
         {
             var group = Group(contents);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -34,7 +34,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             if (hasAttribute)
             {
                 docs.Add(Doc.Concat(paramDocs));
-                return Doc.Concat(Doc.GroupWithId(groupId, docs.ToArray()));
+                return Doc.GroupWithId(groupId, docs.ToArray());
             }
             else
             {

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -19,28 +19,18 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 Modifiers.Print(node.Modifiers)
             };
 
-            var paramDocs = new List<Doc>();
             if (node.Type != null)
             {
-                paramDocs.Add(Node.Print(node.Type), " ");
+                docs.Add(Node.Print(node.Type), " ");
             }
 
-            paramDocs.Add(Token.Print(node.Identifier));
+            docs.Add(Token.Print(node.Identifier));
             if (node.Default != null)
             {
-                paramDocs.Add(EqualsValueClause.Print(node.Default));
+                docs.Add(EqualsValueClause.Print(node.Default));
             }
 
-            if (hasAttribute)
-            {
-                docs.Add(Doc.Concat(paramDocs));
-                return Doc.GroupWithId(groupId, docs.ToArray());
-            }
-            else
-            {
-                docs.AddRange(paramDocs);
-                return Doc.Concat(docs);
-            }
+            return hasAttribute ? Doc.GroupWithId(groupId, docs) : Doc.Concat(docs);
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
@@ -1,5 +1,4 @@
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters


### PR DESCRIPTION
Added breaking and tab logic to parameter when attribute is involved, while grouping the parameter itself as that allowed for a custom break. Removed unnecessary `using` statement.

Ignored `.vscode` for people who think that it is an IDE.

Fixes #204.
Fixes #334.