### PR TITLE
Better SwitchExpression Formatting

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
@@ -1,6 +1,6 @@
 class ClassName
 {
-    int MethodName()
+    void MethodName()
     {
         return 1 switch
         {
@@ -17,6 +17,28 @@ class ClassName
             (DoorState.Closed, Action.Lock, true) => DoorState.Locked,
             (DoorState.Locked, Action.Unlock, true) => DoorState.Closed,
             (var state, _, _) => state
+        };
+
+        return someValue switch
+        {
+            SomeSimpleObject => DoSomething(),
+            SomeLongObject someLongObject
+              => CallSomeMethodWith____________________________(someLongObject),
+            YetAnotherObject
+              => CallSomeMethod(
+                    someValue,
+                    andOtherParameters,
+                    thatMakeThisLongEnoughToBreak___________________
+                ),
+            OneMore
+              => "someStrings"
+                + "moreStrings"
+                + "andMoreStrings_________________________________________",
+            SomeOtherObject
+                or AnotherObject
+                or OrEvenSomeOtherObject_________________
+              => CallSomeMethod(someValue),
+            _ => CallSomeMethod(someValue)
         };
     }
 }

--- a/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
@@ -22,21 +22,24 @@ class ClassName
         return someValue switch
         {
             SomeSimpleObject => DoSomething(),
+            { IsParameter: true } => 1,
+            // this comment shouldn't affect the next line
+            { IsParameter: false } => 0,
             SomeLongObject someLongObject
               => CallSomeMethodWith____________________________(someLongObject),
             YetAnotherObject
               => CallSomeMethod(
-                    someValue,
-                    andOtherParameters,
-                    thatMakeThisLongEnoughToBreak___________________
-                ),
+                  someValue,
+                  andOtherParameters,
+                  thatMakeThisLongEnoughToBreak___________________
+              ),
             OneMore
               => "someStrings"
-                + "moreStrings"
-                + "andMoreStrings_________________________________________",
+              + "moreStrings"
+              + "andMoreStrings_________________________________________",
             SomeOtherObject
-                or AnotherObject
-                or OrEvenSomeOtherObject_________________
+            or AnotherObject
+            or OrEvenSomeOtherObject_________________
               => CallSomeMethod(someValue),
             _ => CallSomeMethod(someValue)
         };

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
@@ -20,14 +20,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                                     Doc.Concat(
                                         subpatternNode.NameColon != null
                                             ? NameColon.Print(subpatternNode.NameColon)
-                                            : string.Empty,
+                                            : Doc.Null,
                                         Node.Print(subpatternNode.Pattern)
                                     ),
                                 " "
                             ),
                             Token.Print(node.PositionalPatternClause.CloseParenToken)
                         )
-                    : string.Empty,
+                    : Doc.Null,
                 node.PropertyPatternClause != null
                     ? Doc.Concat(
                             Token.PrintWithSuffix(node.PropertyPatternClause.OpenBraceToken, " "),
@@ -45,10 +45,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                             node.PropertyPatternClause.Subpatterns.Any() ? " " : Doc.Null,
                             Token.Print(node.PropertyPatternClause.CloseBraceToken)
                         )
-                    : string.Empty,
-                node.Designation != null
-                    ? Doc.Concat(" ", Node.Print(node.Designation))
-                    : string.Empty
+                    : Doc.Null,
+                node.Designation != null ? Doc.Concat(" ", Node.Print(node.Designation)) : Doc.Null
             );
         }
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -21,14 +21,21 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                         SeparatedSyntaxList.Print(
                             node.Arms,
                             o =>
-                                Doc.Concat(
-                                    Node.Print(o.Pattern),
-                                    " ",
+                                Doc.Group(
+                                    Doc.Indent(Node.Print(o.Pattern)),
                                     o.WhenClause != null
-                                        ? Doc.Concat(Node.Print(o.WhenClause), " ")
+                                        ? Doc.Concat(" ", Node.Print(o.WhenClause))
                                         : Doc.Null,
-                                    Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
-                                    Node.Print(o.Expression)
+                                    // use align 2 here to make sure that the => never lines up with statements above it
+                                    // it makes this more readable for big ugly switch expressions
+                                    Doc.Align(
+                                        2,
+                                        Doc.Concat(
+                                            Doc.Line,
+                                            Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
+                                            Doc.Align(2, Node.Print(o.Expression))
+                                        )
+                                    )
                                 ),
                             Doc.HardLine
                         )

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -22,7 +22,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                             node.Arms,
                             o =>
                                 Doc.Group(
-                                    Doc.Indent(Node.Print(o.Pattern)),
+                                    Node.Print(o.Pattern),
                                     o.WhenClause != null
                                         ? Doc.Concat(" ", Node.Print(o.WhenClause))
                                         : Doc.Null,
@@ -33,7 +33,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                                         Doc.Concat(
                                             Doc.Line,
                                             Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
-                                            Doc.Align(2, Node.Print(o.Expression))
+                                            Node.Print(o.Expression)
                                         )
                                     )
                                 ),


### PR DESCRIPTION
SwitchExpressions will now break + align 2 the => section.
Some of the test cases still look a little ugly because the Pattern/Expression of each arm are not indented. That indentation will be handled as part of BinaryExpressions #37 or BinaryPattern #349
closes #237