### PR TITLE
Scripting way to test formatting repo

### DIFF
--- a/CSharpier.sln
+++ b/CSharpier.sln
@@ -32,6 +32,7 @@ ProjectSection(SolutionItems) = preProject
 	Scripts/CreateReviewCodePRs.ps1 = Scripts/CreateReviewCodePRs.ps1
 	Scripts/ChangeLog.ps1 = Scripts/ChangeLog.ps1
 	Scripts/UpdateForkedRepos.ps1 = Scripts/UpdateForkedRepos.ps1
+	Scripts\CreateTestingPR.ps1 = Scripts\CreateTestingPR.ps1
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{7C99AEA7-E608-40B5-9B2E-353B6E4C9DBE}"

--- a/Scripts/CreateReviewCodePRs.ps1
+++ b/Scripts/CreateReviewCodePRs.ps1
@@ -3,6 +3,7 @@
 # Long term this process can probably go away, but for now it is a tolerable way to find edge cases or bugs that are introduced
 
 param (
+    [Parameter(Mandatory=$true)]
     [string]$version
 )
 

--- a/Scripts/CreateTestingPR.ps1
+++ b/Scripts/CreateTestingPR.ps1
@@ -1,0 +1,66 @@
+$ErrorActionPreference = "Stop"
+
+$branch = & git branch --show-current
+
+if ($branch -eq "master") {
+    Write-Output "You must be on the branch you want to test. You are currently on master"
+    exit 1
+}
+
+$preBranch = "pre-" + $branch
+$postBranch = "post-" + $branch
+
+$csharpierProject = (Get-Item $PSScriptRoot).Parent.FullName
+
+# TODO this should probably be a parameter
+$testingRepo = "C:\Projects\csharpierForkedRepos\aspnetcore"
+
+Set-Location $testingRepo
+& git reset --hard
+
+git checkout $postBranch
+$postBranchOutput = (git status) | Out-String
+$firstRun = -not $postBranchOutput.Contains("On branch $postBranch")
+if ($firstRun)
+{
+    Set-Location $csharpierProject
+    # TODO this should make sure the working tree is clean
+    & git checkout master
+    & dotnet build Src\CSharpier\CSharpier.csproj -c Release
+
+    Set-Location $testingRepo
+    
+    & git checkout main
+    & git reset --hard
+    & git checkout -b $preBranch
+
+    dotnet $csharpierProject\Src\CSharpier\bin\Release\net5.0\dotnet-csharpier.dll
+
+    & git add -A
+    & git commit -m "Before $branch"
+    & git push --set-upstream origin $preBranch
+}
+
+Set-Location $csharpierProject
+git checkout $branch
+& dotnet build Src\CSharpier\CSharpier.csproj -c Release
+
+Set-Location $testingRepo
+
+if ($firstRun) {
+    & git checkout -b $postBranch
+} else {
+    & git checkout $postBranch
+}
+
+dotnet $csharpierProject\Src\CSharpier\bin\Release\net5.0\dotnet-csharpier.dll
+
+& git add -A
+& git commit -m "After $branch"
+& git push --set-upstream origin $postBranch
+
+if ($firstRun) {
+    #uses https://github.com/github/hub/releases
+    $newPr = & hub pull-request -b belav:$preBranch -m "Testing $branch"
+    Write-Output $newPr
+}


### PR DESCRIPTION
This relates to #286, but doesn't yet close it. Ideally this would run automatically as PRs are created, and comment on those PRs.

