### PR TITLE
Remove most configuration options

### DIFF
--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -6,35 +6,15 @@ CSharpier has support for a configuration file. You can use any of the following
 JSON
 ```json
 {
-   "printWidth": 100,
-   "useTabs": false,
-   "tabWidth": 4,
-   "endOfLine": "auto"
+   "printWidth": 100
 }
 ```
 YAML
 ```json
 printWidth: 100
-useTabs: false
-tabWidth: 4
-endOfLine: auto
 ```
 
 #### Print Width
 Specify at what point the printer will wrap content. This is not a hard limit. Some lines will be shorter or longer.
 
 Default 100
-#### Use Tabs
-Indent lines with tabs instead of spaces.
-
-Default false
-#### Tab Width
-Specify the number of spaces used per indentation level.
-
-Default 4
-#### End of Line
-Specify what type of line endings will be printed in files.
-Options
-- "auto" - Detects which type of line ending to used based on the first one it encounters in the file **Default**
-- "lf" - Line feed only (\n)
-- "crlf" Carriage return and line feed (\r\n)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install-Package CSharpier.MSBuild
 
 ## Documentation
 [Command Line Interface](Docs/CLI.md)  
-[Configuration File](Docs/Configure.md)  
+[Configuration File](Docs/Configuration.md)  
 [Editors and CI/CD](Docs/EditorsAndCICD.md)  
 [Ignoring Files](Docs/Ignore.md)  
 [ChangeLog](CHANGELOG.md)  

--- a/Src/CSharpier.Tests/ConfigurationFileOptionsTests.cs
+++ b/Src/CSharpier.Tests/ConfigurationFileOptionsTests.cs
@@ -103,36 +103,6 @@ namespace CSharpier.Tests
         }
 
         [Test]
-        public void Should_Return_TabWidth_With_Json()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "{ \"tabWidth\": 10 }");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.TabWidth.Should().Be(10);
-        }
-
-        [Test]
-        public void Should_Return_UseTabs_With_Json()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "{ \"useTabs\": true }");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.UseTabs.Should().BeTrue();
-        }
-
-        [Test]
-        public void Should_Return_EndOfLine_With_Json()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "{ \"endOfLine\": \"crlf\" }");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.EndOfLine.Should().Be(EndOfLine.CRLF);
-        }
-
-        [Test]
         public void Should_Return_PrintWidth_With_Yaml()
         {
             WhenAFileExists("c:/test/.csharpierrc", "printWidth: 10");
@@ -142,42 +112,9 @@ namespace CSharpier.Tests
             result.PrintWidth.Should().Be(10);
         }
 
-        [Test]
-        public void Should_Return_TabWidth_With_Yaml()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "tabWidth: 10");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.TabWidth.Should().Be(10);
-        }
-
-        [Test]
-        public void Should_Return_UseTabs_With_Yaml()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "useTabs: true");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.UseTabs.Should().BeTrue();
-        }
-
-        [Test]
-        public void Should_Return_EndOfLine_With_Yaml()
-        {
-            WhenAFileExists("c:/test/.csharpierrc", "endOfLine: crlf");
-
-            var result = CreateConfigurationOptions("c:/test");
-
-            result.EndOfLine.Should().Be(EndOfLine.CRLF);
-        }
-
         private void ShouldHaveDefaultOptions(ConfigurationFileOptions configurationFileOptions)
         {
             configurationFileOptions.PrintWidth.Should().Be(100);
-            configurationFileOptions.TabWidth.Should().Be(4);
-            configurationFileOptions.UseTabs.Should().BeFalse();
-            configurationFileOptions.EndOfLine.Should().Be(EndOfLine.Auto);
         }
 
         private ConfigurationFileOptions CreateConfigurationOptions(string baseDirectoryPath)

--- a/Src/CSharpier/ConfigurationFileOptions.cs
+++ b/Src/CSharpier/ConfigurationFileOptions.cs
@@ -13,9 +13,6 @@ namespace CSharpier
     public class ConfigurationFileOptions
     {
         public int PrintWidth { get; init; } = 100;
-        public int TabWidth { get; init; } = 4;
-        public bool UseTabs { get; init; }
-        public EndOfLine EndOfLine { get; init; }
 
         private static string[] validExtensions = { ".csharpierrc", ".json", ".yml", ".yaml" };
 
@@ -27,10 +24,10 @@ namespace CSharpier
 
             return new PrinterOptions
             {
-                TabWidth = configurationFileOptions.TabWidth,
-                UseTabs = configurationFileOptions.UseTabs,
+                TabWidth = 4,
+                UseTabs = false,
                 Width = configurationFileOptions.PrintWidth,
-                EndOfLine = configurationFileOptions.EndOfLine
+                EndOfLine = EndOfLine.Auto
             };
         }
 


### PR DESCRIPTION
If csharpier is opinionated, it shouldn't offer options beyond print width.
This hides those options, but doesn't yet clean up the code related to them.
closes #358