### PR TITLE
Break after type constraints for method declarations. It keeps things more consistent

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
+++ b/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
@@ -17,6 +17,10 @@ class ClassName<T> where T : class
         return;
     }
 
+    public static ReturnType<T> MethodName<T, U>()
+        where T : class
+        where U : class { }
+
     public static ReturnType<T> MethodName<T, U>(string parameter)
         where T : class
         where U : class
@@ -35,11 +39,22 @@ class ClassName<T> where T : class
     public static ReturnType<T> MethodName<T, U>(
         string longParameter_______________________,
         string longParameter_______________________
+    ) where T : class { }
+
+    public static ReturnType<T> MethodName<T, U>(
+        string longParameter_______________________,
+        string longParameter_______________________
     ) where T : class
       where U : class
     {
         return;
     }
+
+    public static ReturnType<T> MethodName<T, U>(
+        string longParameter_______________________,
+        string longParameter_______________________
+    ) where T : class
+      where U : class { }
 }
 
 interface InterfaceName<T> where T : class { }
@@ -55,3 +70,10 @@ class ClassName<N, C, T, TT, L>
 {
     private string x;
 }
+
+class ClassName<N, C, T, TT, L>
+    where N : new()
+    where C : class
+    where T : IComparable
+    where TT : IList<N>
+    where L : class, new() { }

--- a/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
+++ b/Src/CSharpier.Tests/TestFiles/TypeParameterConstraintClause/TypeParameterConstraintClauses.cst
@@ -12,16 +12,34 @@ class ClassName<T> where T : class
 
     public static ReturnType<T> MethodName<T, U>()
         where T : class
-        where U : class { }
+        where U : class
+    {
+        return;
+    }
 
     public static ReturnType<T> MethodName<T, U>(string parameter)
         where T : class
-        where U : class { }
+        where U : class
+    {
+        return;
+    }
 
     public static ReturnType<T> MethodName<T, U>(
-        string reallyLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongParameterIMeanIt
+        string longParameter_______________________,
+        string longParameter_______________________
     ) where T : class
-      where U : class { }
+    {
+        return;
+    }
+
+    public static ReturnType<T> MethodName<T, U>(
+        string longParameter_______________________,
+        string longParameter_______________________
+    ) where T : class
+      where U : class
+    {
+        return;
+    }
 }
 
 interface InterfaceName<T> where T : class { }
@@ -33,4 +51,7 @@ class ClassName<N, C, T, TT, L>
     where C : class
     where T : IComparable
     where TT : IList<N>
-    where L : class, new() { }
+    where L : class, new()
+{
+    private string x;
+}

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -19,7 +19,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
             ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier = null;
             TypeParameterListSyntax? typeParameterList = null;
             Doc identifier = Doc.Null;
-            var constraintClauses = Enumerable.Empty<TypeParameterConstraintClauseSyntax>();
+            SyntaxList<TypeParameterConstraintClauseSyntax>? constraintClauses = null;
             ParameterListSyntax? parameterList = null;
             ConstructorInitializerSyntax? constructorInitializer = null;
             BlockSyntax? body = null;
@@ -159,7 +159,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                 );
             }
 
-            if (modifiers.HasValue && modifiers.Value.Count > 0)
+            if (modifiers is { Count: > 0 })
             {
                 docs.Add(Token.PrintLeadingTrivia(modifiers.Value[0]));
             }
@@ -170,15 +170,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
 
             docs.Add(Doc.Group(declarationGroup));
 
-            docs.Add(
-                groupId != null
-                    ? ConstraintClauses.PrintWithConditionalSpace(constraintClauses, groupId)
-                    : ConstraintClauses.Print(constraintClauses)
-            );
+            if (constraintClauses != null)
+            {
+                docs.Add(
+                    groupId != null
+                        ? ConstraintClauses.PrintWithConditionalSpace(constraintClauses, groupId)
+                        : ConstraintClauses.Print(constraintClauses)
+                );
+            }
+
             if (body != null)
             {
                 docs.Add(
                     groupId != null
+                    && (constraintClauses == null || constraintClauses.Value.Count == 0)
                         ? Block.PrintWithConditionalSpace(body, groupId)
                         : Block.Print(body)
                 );


### PR DESCRIPTION
closes #299