### PR TITLE
Respect empty lines between case statements and switch expression patterns

### DIFF
--- a/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
+++ b/Src/CSharpier.Tests/TestFiles/SwitchExpression/SwitchExpressions.cst
@@ -7,15 +7,21 @@ class ClassName
             1 => 100,
             2 => 200,
             3 when false => 300,
+
             _ => throw new global::System.Exception()
         };
 
         var newState = (GetState(), action, hasKey) switch
         {
+            // Open/Close
             (DoorState.Closed, Action.Open, _) => DoorState.Opened,
             (DoorState.Opened, Action.Close, _) => DoorState.Closed,
+
+            // Locking
             (DoorState.Closed, Action.Lock, true) => DoorState.Locked,
             (DoorState.Locked, Action.Unlock, true) => DoorState.Closed,
+
+            // Do nothing
             (var state, _, _) => state
         };
 

--- a/Src/CSharpier.Tests/TestFiles/SwitchStatement/SwitchStatements.cst
+++ b/Src/CSharpier.Tests/TestFiles/SwitchStatement/SwitchStatements.cst
@@ -9,13 +9,16 @@ public class ClassName
             {
                 break;
             }
+
             case 1 + 1:
             {
                 return;
             }
+
             case 4:
                 var x = 1;
                 break;
+
             default:
             {
                 return;
@@ -26,6 +29,7 @@ public class ClassName
         {
             case 1:
             case 2:
+
             default:
                 break;
         }
@@ -52,8 +56,10 @@ public class ClassName
         {
             case "A" when b > 50:
             case "B" when B < 50:
+
             case "C______________________________________________________________________"
                 when C == 50:
+
             default:
             {
                 break;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
-using CSharpier.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
@@ -10,14 +7,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(CasePatternSwitchLabelSyntax node)
         {
-            var docs = new List<Doc>();
-            docs.Add(Token.PrintWithSuffix(node.Keyword, " "), Node.Print(node.Pattern));
-            if (node.WhenClause != null)
-            {
-                docs.Add(Node.Print(node.WhenClause));
-            }
-            docs.Add(Token.Print(node.ColonToken));
-            return Doc.Concat(docs);
+            return Doc.Concat(
+                ExtraNewLines.Print(node),
+                Token.PrintWithSuffix(node.Keyword, " "),
+                Node.Print(node.Pattern),
+                node.WhenClause != null ? Node.Print(node.WhenClause) : Doc.Null,
+                Token.Print(node.ColonToken)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
@@ -1,5 +1,4 @@
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
@@ -9,6 +8,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
         public static Doc Print(CaseSwitchLabelSyntax node)
         {
             return Doc.Concat(
+                ExtraNewLines.Print(node),
                 Token.PrintWithSuffix(node.Keyword, " "),
                 Doc.Group(Node.Print(node.Value)),
                 Token.Print(node.ColonToken)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultSwitchLabel.cs
@@ -1,5 +1,4 @@
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
@@ -8,7 +7,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(DefaultSwitchLabelSyntax node)
         {
-            return Doc.Concat(Token.Print(node.Keyword), Token.Print(node.ColonToken));
+            return Doc.Concat(
+                ExtraNewLines.Print(node),
+                Token.Print(node.Keyword),
+                Token.Print(node.ColonToken)
+            );
         }
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -7,31 +7,28 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
     {
         public static Doc Print(SwitchExpressionSyntax node)
         {
-            return Doc.Concat(
-                Node.Print(node.GoverningExpression),
-                " ",
-                Token.Print(node.SwitchKeyword),
-                Doc.HardLine,
-                Token.Print(node.OpenBraceToken),
-                Doc.Group(
+            var sections = Doc.Group(
                     Doc.Indent(
                         Doc.HardLine,
                         SeparatedSyntaxList.Print(
                             node.Arms,
                             o =>
-                                Doc.Group(
-                                    Node.Print(o.Pattern),
-                                    o.WhenClause != null
-                                        ? Node.Print(o.WhenClause)
-                                        : Doc.Null,
-                                    // use align 2 here to make sure that the => never lines up with statements above it
-                                    // it makes this more readable for big ugly switch expressions
-                                    Doc.Align(
-                                        2,
-                                        Doc.Concat(
-                                            Doc.Line,
-                                            Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
-                                            Node.Print(o.Expression)
+                                Doc.Concat(
+                                    ExtraNewLines.Print(o),
+                                    Doc.Group(
+                                        Node.Print(o.Pattern),
+                                        o.WhenClause != null
+                                            ? Node.Print(o.WhenClause)
+                                            : Doc.Null,
+                                        // use align 2 here to make sure that the => never lines up with statements above it
+                                        // it makes this more readable for big ugly switch expressions
+                                        Doc.Align(
+                                            2,
+                                            Doc.Concat(
+                                                Doc.Line,
+                                                Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
+                                                Node.Print(o.Expression)
+                                            )
                                         )
                                     )
                                 ),
@@ -39,7 +36,17 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                         )
                     ),
                     Doc.HardLine
-                ),
+                );
+
+            DocUtilities.RemoveInitialDoubleHardLine(sections);
+
+            return Doc.Concat(
+                Node.Print(node.GoverningExpression),
+                " ",
+                Token.Print(node.SwitchKeyword),
+                Doc.HardLine,
+                Token.Print(node.OpenBraceToken),
+                sections,
                 Token.Print(node.CloseBraceToken)
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using CSharpier.DocTypes;
-using CSharpier.SyntaxPrinter;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
@@ -21,6 +20,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters
                       ),
                       Doc.HardLine
                   );
+
+            DocUtilities.RemoveInitialDoubleHardLine(sections);
 
             var groupId = Guid.NewGuid().ToString();
 


### PR DESCRIPTION
Respect empty lines between case statements and switch expression patterns

Closes #383