### PR TITLE
Use .net6 for msbuild library

### DIFF
--- a/Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
+++ b/Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
@@ -8,7 +8,7 @@
         -->
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>CSharpier.MsBuild</PackageId>
-        <CSharpierOutputDir>../CSharpier.Cli/bin/$(Configuration)/net5.0</CSharpierOutputDir>
+        <CSharpierOutputDir>../CSharpier.Cli/bin/$(Configuration)/net6.0</CSharpierOutputDir>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
closes #565

https://github.com/belav/csharpier/issues/459 has a note to update the readme when 0.15.0 is released.