### PR TITLE
Add `DevelopmentDependency` property to `CSharpier.MsBuild.csproj`

### DIFF
--- a/Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
+++ b/Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
@@ -8,6 +8,7 @@
         -->
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>CSharpier.MsBuild</PackageId>
+        <DevelopmentDependency>true</DevelopmentDependency>
         <CSharpierOutputDir>../CSharpier.Cli/bin/$(Configuration)/net6.0</CSharpierOutputDir>
     </PropertyGroup>
 


### PR DESCRIPTION
Hi, awesome project, thanks for your work!

This package only runs in `BeforeTargets="Build"` right? I just tested installing the MsBuild package like this (with PrivateAssets attr), in a global `Directory.Build.Props` file, and it seems to work:
```csproj
  <ItemGroup>
    <PackageReference Include="CSharpier.MsBuild" Version="0.15.0" PrivateAssets="all" /> 
  </ItemGroup>
```

Usecase being we have some packages that are going to be published, and we only need `csharpier` during build (doesnt need to be a dep of the package).