### PR TITLE
fix: macos rider

### DIFF
--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
@@ -1,6 +1,8 @@
 package com.intellij.csharpier;
 
+import org.apache.commons.lang.SystemUtils;
 import java.io.*;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ProcessHelper {
@@ -12,10 +14,18 @@ public class ProcessHelper {
 
             logger.debug("user.dir is " + System.getProperty("user.dir"));
             logger.debug("Running " + String.join(" ", command) + directoryToLog);
-            var processBuilder = new ProcessBuilder(command);
-            if (env != null) {
-                processBuilder.environment().putAll(env);
+            var processBuilder = new ProcessBuilder(GetShellCommand(command));
+
+            if (env == null) {
+                env = new HashMap<>();
             }
+
+            if (!env.containsKey("PATH")) {
+                env.put("PATH", GetPathWithDotNetBinary());
+            }
+
+            processBuilder.environment().putAll(env);
+
             if (workingDirectory != null) {
                 processBuilder.directory(workingDirectory);
             }
@@ -46,5 +56,33 @@ public class ProcessHelper {
 
         }
         return null;
+    }
+
+    private static String GetPathWithDotNetBinary() {
+        var path = System.getenv("PATH");
+
+        // For Mac, the .NET binary isn't available for ProcessBuilder, so we'll add the default
+        // installation location to the PATH. We'll prefer the ARM version and fallback to the x64.
+        if (SystemUtils.IS_OS_MAC) {
+            return path + ":/usr/local/share/dotnet:/usr/local/share/dotnet/x64/dotnet";
+        }
+
+        // For others, it seems the .NET binary is already available to ProcessBuilder by default.
+        // So we'll just return the PATH as is.
+        return path;
+    }
+
+    // Setting the PATH doesn't affect the ProcessBuilder's command, but it will apply to
+    // spawned processes, so we'll run the desired command in the OS's default shell.
+    private static String[] GetShellCommand(String[] command) {
+        if (SystemUtils.IS_OS_MAC) {
+            return new String[] {"/bin/zsh", "-c", String.join(" ", command)};
+        }
+
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return new String[] {"cmd.exe", "/c", String.join(" ", command)};
+        }
+
+        return new String[] {"/bin/sh", "-c", String.join(" ", command)};
     }
 }

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
@@ -14,7 +14,7 @@ public class ProcessHelper {
 
             logger.debug("user.dir is " + System.getProperty("user.dir"));
             logger.debug("Running " + String.join(" ", command) + directoryToLog);
-            var processBuilder = new ProcessBuilder(GetShellCommand(command));
+            var processBuilder = new ProcessBuilder(GetShellCommandIfNeeded(command));
 
             if (env == null) {
                 env = new HashMap<>();
@@ -72,17 +72,14 @@ public class ProcessHelper {
         return path;
     }
 
-    // Setting the PATH doesn't affect the ProcessBuilder's command, but it will apply to
+    // For Mac, we'll have updated the PATH to include the .NET binary. However, setting
+    // the PATH doesn't affect the ProcessBuilder's command, but it will apply to
     // spawned processes, so we'll run the desired command in the OS's default shell.
-    private static String[] GetShellCommand(String[] command) {
+    private static String[] GetShellCommandIfNeeded(String[] command) {
         if (SystemUtils.IS_OS_MAC) {
             return new String[] {"/bin/zsh", "-c", String.join(" ", command)};
         }
 
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return new String[] {"cmd.exe", "/c", String.join(" ", command)};
-        }
-
-        return new String[] {"/bin/sh", "-c", String.join(" ", command)};
+        return command;
     }
 }


### PR DESCRIPTION
For #610

On Mac, the `dotnet` binary isn't available to the `ProcessBuilder`. I added the binary to the `PATH`. I wanted to be mindful of ARM/x64 so the `PATH` exposes the ARM build first and the x64 secondly. However, the `PATH` variable isn't available to the `ProcessBuilder`, but it is for any spawned processes. With that in mind, I updated the`ProcessHelper` to wrap the `command` argument within the OS's default shell.

**Alternatives**
- Add a `.GetDotNetBinary()` method that returned `/usr/local/share/dotnet/dotnet` on Mac.
    - This worked fine, but it wouldn't support x64 binaries on the M1 Mac, so I decided against it.
- Get the binary in use from Rider 
    - I couldn't figure out how to get this to work, but if we could make it happen, I believe it'd be the best option. 