### PR TITLE
Fixing github actions

### DIFF
--- a/.github/workflows/format_repositories.yml
+++ b/.github/workflows/format_repositories.yml
@@ -14,7 +14,7 @@ jobs:
           path: csharpier
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
       - uses: actions/checkout@v2
         with:
           repository: belav/csharpier-repos

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
       - run: dotnet test Src/CSharpier.Tests/CSharpier.Tests.csproj
   publish-nuget:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
       - name: Publish CSharpier.Core library on version change
         uses: rohith/publish-nuget@v2
         with:

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
       - run: |
           dotnet build CSharpier.sln -c release
           dotnet test CSharpier.sln -c release
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
       - run: |
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.102'
+          dotnet-version: '6.0.x'
       - run: |
           dotnet build CSharpier.sln -c release
           dotnet test CSharpier.sln -c release
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.102'
+          dotnet-version: '6.0.x'
       - run: |
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.102'
       - run: |
           dotnet build CSharpier.sln -c release
           dotnet test CSharpier.sln -c release
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.102'
       - run: |
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestMajor"
+    "version": "6.0.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.0",
+    "version": "6.0.100",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
The github actions are failing due to the source generators appearing to use a newer version of roslyn.