### PR TITLE
Format switch statement consistently with other code.

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/SwitchStatements.cst
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/SwitchStatements.cst
@@ -81,7 +81,8 @@ public class ClassName
         switch (
             someLongValue
             + someOtherLongValue_________________________________________________________
-        ) {
+        )
+        {
             default:
                 return;
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
@@ -34,7 +34,7 @@ internal static class SwitchStatement
                     Doc.SoftLine
                 ),
                 Token.Print(node.CloseParenToken),
-                Doc.IfBreak(" ", Doc.Line, groupId),
+                node.Sections.Count == 0 ? " " : Doc.Line,
                 Token.Print(node.OpenBraceToken),
                 sections,
                 Token.Print(node.CloseBraceToken)


### PR DESCRIPTION
Switch was still using SpaceBrace