### PR TITLE
fix: ignore file detection when directory contains period

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -21,10 +21,11 @@ internal static class CommandLineFormatter
                 string directoryOrFile
             )
             {
-                var baseDirectoryPath =
-                    fileSystem.Path.GetExtension(directoryOrFile) == string.Empty
-                        ? directoryOrFile
-                        : fileSystem.Path.GetDirectoryName(directoryOrFile);
+                var isDirectory = fileSystem.Directory.Exists(directoryOrFile);
+
+                var baseDirectoryPath = isDirectory
+                    ? directoryOrFile
+                    : fileSystem.Path.GetDirectoryName(directoryOrFile);
 
                 var ignoreFile = await IgnoreFile.Create(
                     baseDirectoryPath,


### PR DESCRIPTION
I was using CSharpier in a project whose directory name contained a period, e.g., `/home/jsanchezio/Documents/Repos/My.Project/`, and despite having a `.csharpierignore` file, it would still report files excluded by the ignore as unformatted. I was running the command as `dotnet csharpier --check .` After some investigation, it turns out `fileSystem.Path.GetExtension(directoryOrFile)` would return the path after the period, e.g., `.Project`. This change alters the command to instead check if the `directoryOrFile` is a directory that exists and reacts accordingly.

After I discovered the issue, I renamed my project's folder name and all worked well. However, in CI environments there is no guarantee that a `.` won't be in the path, so I figured it was best to handle it within CSharpier.