### PR TITLE
Refactoring so that the threadstatic fields can go away.

### DIFF
--- a/Src/CSharpier.Benchmarks/Program.cs
+++ b/Src/CSharpier.Benchmarks/Program.cs
@@ -95,7 +95,7 @@ namespace CSharpier
 
             try
             {
-                var document = Node.Print(rootNode);
+                var document = Node.Print(rootNode, context);
                 var lineEnding = GetLineEnding(code, printerOptions);
                 var formattedCode = DocPrinter.DocPrinter.Print(
                     document,

--- a/Src/CSharpier.Benchmarks/Program.cs
+++ b/Src/CSharpier.Benchmarks/Program.cs
@@ -95,7 +95,7 @@ namespace CSharpier
 
             try
             {
-                var document = Node.Print(rootNode, context);
+                var document = Node.Print(rootNode);
                 var lineEnding = GetLineEnding(code, printerOptions);
                 var formattedCode = DocPrinter.DocPrinter.Print(
                     document,

--- a/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
+++ b/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
@@ -12,7 +12,7 @@ namespace CSharpier.SyntaxPrinter
         [ThreadStatic]
         private static int depth;
 
-        public static Doc Print(SyntaxNode syntaxNode)
+        public static Doc Print(SyntaxNode syntaxNode, FormattingContext context)
         {
             if (syntaxNode == null)
             {
@@ -36,10 +36,10 @@ namespace CSharpier.SyntaxPrinter
                 {
                     {{- for nodeType in NodeTypes }}
                     case {{ nodeType.SyntaxNodeName }} {{ nodeType.VariableName }}:
-                        return {{ nodeType.PrinterName }}.Print({{ nodeType.VariableName }});
+                        return {{ nodeType.PrinterName }}.Print({{ nodeType.VariableName }}, context);
                     {{- end }}
                     default:
-                        return UnhandledNode.Print(syntaxNode);
+                        return UnhandledNode.Print(syntaxNode, context);
                 }
             }
             finally

--- a/Src/CSharpier/CodeFormatter.cs
+++ b/Src/CSharpier/CodeFormatter.cs
@@ -134,7 +134,7 @@ public class CodeFormatter
                 PreprocessorSymbols.Reset();
             }
 
-            var document = Node.Print(rootNode);
+            var document = Node.Print(rootNode, new FormattingContext());
             var lineEnding = GetLineEnding(syntaxTree.ToString(), printerOptions);
             var formattedCode = DocPrinter.DocPrinter.Print(document, printerOptions, lineEnding);
 
@@ -148,7 +148,10 @@ public class CodeFormatter
                     return result;
                 }
 
-                document = Node.Print(await syntaxTree.GetRootAsync(cancellationToken));
+                document = Node.Print(
+                    await syntaxTree.GetRootAsync(cancellationToken),
+                    new FormattingContext()
+                );
                 formattedCode = DocPrinter.DocPrinter.Print(document, printerOptions, lineEnding);
             }
 

--- a/Src/CSharpier/SyntaxPrinter/ArgumentListLikeSyntax.cs
+++ b/Src/CSharpier/SyntaxPrinter/ArgumentListLikeSyntax.cs
@@ -5,23 +5,24 @@ internal static class ArgumentListLike
     public static Doc Print(
         SyntaxToken openParenToken,
         SeparatedSyntaxList<ArgumentSyntax> arguments,
-        SyntaxToken closeParenToken
+        SyntaxToken closeParenToken,
+        FormattingContext context
     )
     {
-        var docs = new List<Doc> { Token.Print(openParenToken) };
+        var docs = new List<Doc> { Token.Print(openParenToken, context) };
 
         if (arguments.Any())
         {
             docs.Add(
                 Doc.Indent(
                     Doc.SoftLine,
-                    SeparatedSyntaxList.Print(arguments, Argument.Print, Doc.Line)
+                    SeparatedSyntaxList.Print(arguments, Argument.Print, Doc.Line, context)
                 ),
                 Doc.SoftLine
             );
         }
 
-        docs.Add(Token.Print(closeParenToken));
+        docs.Add(Token.Print(closeParenToken, context));
 
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/AttributeLists.cs
+++ b/Src/CSharpier/SyntaxPrinter/AttributeLists.cs
@@ -2,7 +2,11 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class AttributeLists
 {
-    public static Doc Print(SyntaxNode node, SyntaxList<AttributeListSyntax> attributeLists)
+    public static Doc Print(
+        SyntaxNode node,
+        SyntaxList<AttributeListSyntax> attributeLists,
+        FormattingContext context
+    )
     {
         if (attributeLists.Count == 0)
         {
@@ -16,7 +20,7 @@ internal static class AttributeLists
                 or ParenthesizedLambdaExpressionSyntax
             ? Doc.Line
             : Doc.HardLine;
-        docs.Add(Doc.Join(separator, attributeLists.Select(AttributeList.Print)));
+        docs.Add(Doc.Join(separator, attributeLists.Select(o => AttributeList.Print(o, context))));
 
         if (node is not (ParameterSyntax or TypeParameterSyntax))
         {

--- a/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
+++ b/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
@@ -2,7 +2,10 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class ConstraintClauses
 {
-    public static Doc Print(IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses)
+    public static Doc Print(
+        IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses,
+        FormattingContext context
+    )
     {
         var constraintClausesList = constraintClauses.ToList();
 

--- a/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
+++ b/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
@@ -13,7 +13,7 @@ internal static class ConstraintClauses
         var prefix = constraintClausesList.Count >= 2 ? Doc.HardLine : Doc.Line;
         var body = Doc.Join(
             Doc.HardLine,
-            constraintClausesList.Select(TypeParameterConstraintClause.Print)
+            constraintClausesList.Select(o => TypeParameterConstraintClause.Print(o, context))
         );
 
         return Doc.Group(Doc.Indent(prefix, body));

--- a/Src/CSharpier/SyntaxPrinter/FormattingContext.cs
+++ b/Src/CSharpier/SyntaxPrinter/FormattingContext.cs
@@ -1,0 +1,6 @@
+namespace CSharpier.SyntaxPrinter;
+
+public class FormattingContext
+{
+    
+}

--- a/Src/CSharpier/SyntaxPrinter/FormattingContext.cs
+++ b/Src/CSharpier/SyntaxPrinter/FormattingContext.cs
@@ -1,6 +1,3 @@
 namespace CSharpier.SyntaxPrinter;
 
-public class FormattingContext
-{
-    
-}
+public class FormattingContext { }

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -4,26 +4,6 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class MembersWithForcedLines
 {
-    // TODO some edgecases to fix, see https://github.com/belav/csharpier-repos/pull/40/files
-    /*
-     #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
-public class ClassName
-{
-    public void MethodName { }
-#endif
-    public class NestedClass
-    {
-        private int field;
-    }
-#if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
-}
-#endif
-
-     
-    start from https://github.com/belav/csharpier-repos/pull/40/files#diff-cfd2c2802b10c6701ade623e79a187812b6ba0d69baa6e4a934e23354e82c103
-    
-     */
-
     public static List<Doc> Print<T>(
         CSharpSyntaxNode node,
         IReadOnlyList<T> members,
@@ -88,7 +68,6 @@ public class ClassName
             var printExtraNewLines = false;
             var triviaContainsEndIfOrRegion = false;
 
-            // TODO test if this even matters, or if it makes memory worse
             var leadingTrivia = member
                 .GetLeadingTrivia()
                 .Select(o => o.RawSyntaxKind())
@@ -127,7 +106,7 @@ public class ClassName
 
             if (printExtraNewLines)
             {
-                Token.NextTriviaNeedsLine = true;
+                result.Add(ExtraNewLines.Print(member));
             }
             else if (addBlankLine && !triviaContainsEndIfOrRegion)
             {

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -6,13 +6,38 @@ internal static class MembersWithForcedLines
 {
     // TODO some edgecases to fix, see https://github.com/belav/csharpier-repos/pull/40/files
     // one of them is
-    //     public class ClassName
-    //     {
-    //     #if NET461
-    //         public void Blah () { }
-    //     #endif
-    //         public int Value { get; set; }
-    //     }
+/*
+public class ClassName
+{
+#if TODO
+
+
+    public void RemoveLinesAbove() { }
+#endif
+    /// <summary>Summary/summary>
+    public async Task AddLineAboveSummary() { }
+}
+
+        private sealed class WorkStealingQueue
+        {
+            /// <summary>Initial size of the queue's array.</summary>
+            private const int InitialSize = 32;
+            /// <summary>Starting index for the head and tail indices.</summary>
+            private const int StartIndex =
+#if DEBUG
+            int.MaxValue; // in debug builds, start at the end so we exercise the index reset logic
+#else
+                0;
+#endif
+            /// <summary>Head index from which to steal.  This and'd with the <see cref="_mask"/> is the index into <see cref="_array"/>.</summary>
+            private volatile int _headIndex = StartIndex
+            
+https://github.com/belav/csharpier-repos/pull/40/files#diff-7a8318af9bf1a68826755c4ef53496161290589ce1cc1edee671923480605915
+
+start from https://github.com/belav/csharpier-repos/pull/40/files#diff-cfd2c2802b10c6701ade623e79a187812b6ba0d69baa6e4a934e23354e82c103
+
+// TODO https://raw.githubusercontent.com/belav/csharpier-repos/8c770abc7626f3eb2dcbe416f2728c5cd36abfba/runtime/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+ */
 
     public static List<Doc> Print<T>(CSharpSyntaxNode node, IReadOnlyList<T> members)
         where T : MemberDeclarationSyntax
@@ -75,6 +100,7 @@ internal static class MembersWithForcedLines
             var printExtraNewLines = false;
             var triviaContainsEndIfOrRegion = false;
 
+            // TODO test if this even matters, or if it makes memory worse
             var leadingTrivia = member
                 .GetLeadingTrivia()
                 .Select(o => o.RawSyntaxKind())

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -103,7 +103,7 @@ internal static class MembersWithForcedLines
 
             if (printExtraNewLines)
             {
-                result.Add(ExtraNewLines.Print(member));
+                Token.NextTriviaNeedsLine = true;
             }
             else if (addBlankLine && !triviaContainsEndIfOrRegion)
             {

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -5,39 +5,24 @@ namespace CSharpier.SyntaxPrinter;
 internal static class MembersWithForcedLines
 {
     // TODO some edgecases to fix, see https://github.com/belav/csharpier-repos/pull/40/files
-    // one of them is
-/*
+    /*
+     #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
 public class ClassName
 {
-#if TODO
-
-
-    public void RemoveLinesAbove() { }
+    public void MethodName { }
 #endif
-    /// <summary>Summary/summary>
-    public async Task AddLineAboveSummary() { }
+    public class NestedClass
+    {
+        private int field;
+    }
+#if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
 }
-
-        private sealed class WorkStealingQueue
-        {
-            /// <summary>Initial size of the queue's array.</summary>
-            private const int InitialSize = 32;
-            /// <summary>Starting index for the head and tail indices.</summary>
-            private const int StartIndex =
-#if DEBUG
-            int.MaxValue; // in debug builds, start at the end so we exercise the index reset logic
-#else
-                0;
 #endif
-            /// <summary>Head index from which to steal.  This and'd with the <see cref="_mask"/> is the index into <see cref="_array"/>.</summary>
-            private volatile int _headIndex = StartIndex
-            
-https://github.com/belav/csharpier-repos/pull/40/files#diff-7a8318af9bf1a68826755c4ef53496161290589ce1cc1edee671923480605915
 
-start from https://github.com/belav/csharpier-repos/pull/40/files#diff-cfd2c2802b10c6701ade623e79a187812b6ba0d69baa6e4a934e23354e82c103
-
-// TODO https://raw.githubusercontent.com/belav/csharpier-repos/8c770abc7626f3eb2dcbe416f2728c5cd36abfba/runtime/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
- */
+     
+    start from https://github.com/belav/csharpier-repos/pull/40/files#diff-cfd2c2802b10c6701ade623e79a187812b6ba0d69baa6e4a934e23354e82c103
+    
+     */
 
     public static List<Doc> Print<T>(CSharpSyntaxNode node, IReadOnlyList<T> members)
         where T : MemberDeclarationSyntax

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -24,8 +24,11 @@ public class ClassName
     
      */
 
-    public static List<Doc> Print<T>(CSharpSyntaxNode node, IReadOnlyList<T> members)
-        where T : MemberDeclarationSyntax
+    public static List<Doc> Print<T>(
+        CSharpSyntaxNode node,
+        IReadOnlyList<T> members,
+        FormattingContext context
+    ) where T : MemberDeclarationSyntax
     {
         var result = new List<Doc> { Doc.HardLine };
         var lastMemberForcedBlankLine = false;
@@ -35,7 +38,7 @@ public class ClassName
             {
                 if (members is SeparatedSyntaxList<T> list && x < list.SeparatorCount)
                 {
-                    result.Add(Token.Print(list.GetSeparator(x)));
+                    result.Add(Token.Print(list.GetSeparator(x), context));
                 }
             }
 
@@ -74,7 +77,7 @@ public class ClassName
             if (x == 0)
             {
                 lastMemberForcedBlankLine = blankLineIsForced;
-                result.Add(Node.Print(member));
+                result.Add(Node.Print(member, context));
                 AddSeparatorIfNeeded();
                 continue;
             }
@@ -161,7 +164,7 @@ public class ClassName
                 Token.NextTriviaNeedsLine = true;
             }
 
-            result.Add(Doc.HardLine, Node.Print(member));
+            result.Add(Doc.HardLine, Node.Print(member, context));
             AddSeparatorIfNeeded();
 
             lastMemberForcedBlankLine = blankLineIsForced;

--- a/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier/SyntaxPrinter/MembersWithForcedLines.cs
@@ -4,6 +4,16 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class MembersWithForcedLines
 {
+    // TODO some edgecases to fix, see https://github.com/belav/csharpier-repos/pull/40/files
+    // one of them is
+    //     public class ClassName
+    //     {
+    //     #if NET461
+    //         public void Blah () { }
+    //     #endif
+    //         public int Value { get; set; }
+    //     }
+
     public static List<Doc> Print<T>(CSharpSyntaxNode node, IReadOnlyList<T> members)
         where T : MemberDeclarationSyntax
     {

--- a/Src/CSharpier/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier/SyntaxPrinter/Modifiers.cs
@@ -2,17 +2,20 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class Modifiers
 {
-    public static Doc Print(SyntaxTokenList modifiers)
+    public static Doc Print(SyntaxTokenList modifiers, FormattingContext context)
     {
         if (modifiers.Count == 0)
         {
             return Doc.Null;
         }
 
-        return Doc.Group(Doc.Join(" ", modifiers.Select(Token.Print)), " ");
+        return Doc.Group(Doc.Join(" ", modifiers.Select(o => Token.Print(o, context))), " ");
     }
 
-    public static Doc PrintWithoutLeadingTrivia(SyntaxTokenList modifiers)
+    public static Doc PrintWithoutLeadingTrivia(
+        SyntaxTokenList modifiers,
+        FormattingContext context
+    )
     {
         if (modifiers.Count == 0)
         {
@@ -20,10 +23,12 @@ internal static class Modifiers
         }
 
         return Doc.Group(
-            Token.PrintWithoutLeadingTrivia(modifiers[0]),
+            Token.PrintWithoutLeadingTrivia(modifiers[0], context),
             " ",
             modifiers.Count > 1
-              ? Doc.Concat(modifiers.Skip(1).Select(o => Token.PrintWithSuffix(o, " ")).ToArray())
+              ? Doc.Concat(
+                    modifiers.Skip(1).Select(o => Token.PrintWithSuffix(o, " ", context)).ToArray()
+                )
               : Doc.Null
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/NamespaceLikePrinter.cs
+++ b/Src/CSharpier/SyntaxPrinter/NamespaceLikePrinter.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class NamespaceLikePrinter
 {
-    public static void Print(BaseNamespaceDeclarationSyntax node, List<Doc> docs)
+    public static void Print(BaseNamespaceDeclarationSyntax node, List<Doc> docs, FormattingContext context)
     {
-        Print(node, node.Externs, node.Usings, node.Members, docs);
+        Print(node, node.Externs, node.Usings, node.Members, docs, context);
     }
 
-    public static void Print(CompilationUnitSyntax node, List<Doc> docs)
+    public static void Print(CompilationUnitSyntax node, List<Doc> docs, FormattingContext context)
     {
-        Print(node, node.Externs, node.Usings, node.Members, docs);
+        Print(node, node.Externs, node.Usings, node.Members, docs, context);
     }
 
     private static void Print(
@@ -17,12 +17,15 @@ internal static class NamespaceLikePrinter
         SyntaxList<ExternAliasDirectiveSyntax> externs,
         SyntaxList<UsingDirectiveSyntax> usings,
         SyntaxList<MemberDeclarationSyntax> members,
-        List<Doc> docs
+        List<Doc> docs,
+        FormattingContext context
     )
     {
         if (externs.Count > 0)
         {
-            docs.Add(Doc.Join(Doc.HardLine, externs.Select(ExternAliasDirective.Print)));
+            docs.Add(
+                Doc.Join(Doc.HardLine, externs.Select(o => ExternAliasDirective.Print(o, context)))
+            );
         }
 
         if (usings.Count > 0)
@@ -31,7 +34,7 @@ internal static class NamespaceLikePrinter
             {
                 docs.Add(Doc.HardLine);
             }
-            docs.Add(Doc.Join(Doc.HardLine, usings.Select(UsingDirective.Print)));
+            docs.Add(Doc.Join(Doc.HardLine, usings.Select(o => UsingDirective.Print(o, context))));
         }
 
         if (
@@ -56,7 +59,7 @@ internal static class NamespaceLikePrinter
             }
             docs.Add(
                 Doc.HardLine,
-                AttributeLists.Print(node, compilationUnitSyntax.AttributeLists)
+                AttributeLists.Print(node, compilationUnitSyntax.AttributeLists, context)
             );
         }
 
@@ -92,6 +95,6 @@ internal static class NamespaceLikePrinter
             }
         }
 
-        docs.AddRange(MembersWithForcedLines.Print(node, members));
+        docs.AddRange(MembersWithForcedLines.Print(node, members, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/NamespaceLikePrinter.cs
+++ b/Src/CSharpier/SyntaxPrinter/NamespaceLikePrinter.cs
@@ -2,7 +2,11 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class NamespaceLikePrinter
 {
-    public static void Print(BaseNamespaceDeclarationSyntax node, List<Doc> docs, FormattingContext context)
+    public static void Print(
+        BaseNamespaceDeclarationSyntax node,
+        List<Doc> docs,
+        FormattingContext context
+    )
     {
         Print(node, node.Externs, node.Usings, node.Members, docs, context);
     }

--- a/Src/CSharpier/SyntaxPrinter/OptionalBraces.cs
+++ b/Src/CSharpier/SyntaxPrinter/OptionalBraces.cs
@@ -2,10 +2,10 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class OptionalBraces
 {
-    public static Doc Print(StatementSyntax node)
+    public static Doc Print(StatementSyntax node, FormattingContext context)
     {
         return node is BlockSyntax blockSyntax
-          ? Block.Print(blockSyntax)
-          : Doc.Indent(Doc.HardLine, Node.Print(node));
+          ? Block.Print(blockSyntax, context)
+          : Doc.Indent(Doc.HardLine, Node.Print(node, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/RightHandSide.cs
+++ b/Src/CSharpier/SyntaxPrinter/RightHandSide.cs
@@ -6,7 +6,8 @@ internal static class RightHandSide
         CSharpSyntaxNode leftNode,
         Doc leftDoc,
         Doc operatorDoc,
-        ExpressionSyntax rightNode
+        ExpressionSyntax rightNode,
+        FormattingContext context
     )
     {
         var layout = DetermineLayout(leftNode, rightNode);
@@ -16,27 +17,32 @@ internal static class RightHandSide
         return layout switch
         {
             Layout.BasicConcatWithoutLine
-              => Doc.Concat(leftDoc, operatorDoc, Node.Print(rightNode)),
+              => Doc.Concat(leftDoc, operatorDoc, Node.Print(rightNode, context)),
             Layout.BreakAfterOperator
               => Doc.Group(
                   Doc.Group(leftDoc),
                   operatorDoc,
-                  Doc.Group(Doc.Indent(Doc.Line, Node.Print(rightNode)))
+                  Doc.Group(Doc.Indent(Doc.Line, Node.Print(rightNode, context)))
               ),
             Layout.Chain
-              => Doc.Concat(Doc.Group(leftDoc), operatorDoc, Doc.Line, Node.Print(rightNode)),
+              => Doc.Concat(
+                  Doc.Group(leftDoc),
+                  operatorDoc,
+                  Doc.Line,
+                  Node.Print(rightNode, context)
+              ),
             Layout.ChainTail
               => Doc.Concat(
                   Doc.Group(leftDoc),
                   operatorDoc,
-                  Doc.Indent(Doc.Line, Node.Print(rightNode))
+                  Doc.Indent(Doc.Line, Node.Print(rightNode, context))
               ),
             Layout.Fluid
               => Doc.Group(
                   Doc.Group(leftDoc),
                   operatorDoc,
                   Doc.GroupWithId(groupId, Doc.Indent(Doc.Line)),
-                  Doc.IndentIfBreak(Node.Print(rightNode), groupId)
+                  Doc.IndentIfBreak(Node.Print(rightNode, context), groupId)
               ),
             _ => throw new Exception("The layout type of " + layout + " was not handled.")
         };

--- a/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
@@ -12,7 +12,7 @@ internal static class SeparatedSyntaxList
         var docs = new List<Doc>();
         for (var x = startingIndex; x < list.Count; x++)
         {
-            docs.Add(printFunc(list[x]));
+            docs.Add(printFunc(list[x], context));
 
             if (x >= list.SeparatorCount)
             {
@@ -21,7 +21,7 @@ internal static class SeparatedSyntaxList
 
             var isTrailingSeparator = x == list.Count - 1;
 
-            docs.Add(Token.Print(list.GetSeparator(x)));
+            docs.Add(Token.Print(list.GetSeparator(x), context));
             if (!isTrailingSeparator)
             {
                 docs.Add(afterSeparator);

--- a/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
@@ -4,8 +4,9 @@ internal static class SeparatedSyntaxList
 {
     public static Doc Print<T>(
         SeparatedSyntaxList<T> list,
-        Func<T, Doc> printFunc,
+        Func<T, FormattingContext, Doc> printFunc,
         Doc afterSeparator,
+        FormattingContext context,
         int startingIndex = 0
     ) where T : SyntaxNode
     {

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AliasQualifiedName.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AliasQualifiedName.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AliasQualifiedName
 {
-    public static Doc Print(AliasQualifiedNameSyntax node)
+    public static Doc Print(AliasQualifiedNameSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.Alias),
-            Token.Print(node.ColonColonToken),
-            Node.Print(node.Name)
+            Node.Print(node.Alias, context),
+            Token.Print(node.ColonColonToken, context),
+            Node.Print(node.Name, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousMethodExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousMethodExpression.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AnonymousMethodExpression
 {
-    public static Doc Print(AnonymousMethodExpressionSyntax node)
+    public static Doc Print(AnonymousMethodExpressionSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            Modifiers.Print(node.Modifiers),
-            Token.Print(node.DelegateKeyword)
+            Modifiers.Print(node.Modifiers, context),
+            Token.Print(node.DelegateKeyword, context)
         };
 
         if (node.ParameterList != null)
         {
-            docs.Add(ParameterList.Print(node.ParameterList));
+            docs.Add(ParameterList.Print(node.ParameterList, context));
         }
 
-        docs.Add(Block.Print(node.Block));
+        docs.Add(Block.Print(node.Block, context));
 
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectCreationExpression.cs
@@ -13,7 +13,8 @@ internal static class AnonymousObjectCreationExpression
                     SeparatedSyntaxList.Print(
                         node.Initializers,
                         AnonymousObjectMemberDeclarator.Print,
-                        Doc.Line, context
+                        Doc.Line,
+                        context
                     )
                 )
               : Doc.Null,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectCreationExpression.cs
@@ -2,23 +2,23 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AnonymousObjectCreationExpression
 {
-    public static Doc Print(AnonymousObjectCreationExpressionSyntax node)
+    public static Doc Print(AnonymousObjectCreationExpressionSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.PrintWithSuffix(node.NewKeyword, Doc.Line),
-            Token.Print(node.OpenBraceToken),
+            Token.PrintWithSuffix(node.NewKeyword, Doc.Line, context),
+            Token.Print(node.OpenBraceToken, context),
             node.Initializers.Any()
               ? Doc.Indent(
                     Doc.Line,
                     SeparatedSyntaxList.Print(
                         node.Initializers,
                         AnonymousObjectMemberDeclarator.Print,
-                        Doc.Line
+                        Doc.Line, context
                     )
                 )
               : Doc.Null,
             Doc.Line,
-            Token.Print(node.CloseBraceToken)
+            Token.Print(node.CloseBraceToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectMemberDeclarator.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectMemberDeclarator.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AnonymousObjectMemberDeclarator
 {
-    public static Doc Print(AnonymousObjectMemberDeclaratorSyntax node)
+    public static Doc Print(AnonymousObjectMemberDeclaratorSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>();
         if (node.NameEquals != null)
         {
-            docs.Add(Token.PrintWithSuffix(node.NameEquals.Name.Identifier, " "));
-            docs.Add(Token.PrintWithSuffix(node.NameEquals.EqualsToken, " "));
+            docs.Add(Token.PrintWithSuffix(node.NameEquals.Name.Identifier, " ", context));
+            docs.Add(Token.PrintWithSuffix(node.NameEquals.EqualsToken, " ", context));
         }
-        docs.Add(Node.Print(node.Expression));
+        docs.Add(Node.Print(node.Expression, context));
         return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class Argument
 {
-    public static Doc Print(ArgumentSyntax node)
+    public static Doc Print(ArgumentSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>();
         if (node.NameColon != null)
         {
-            docs.Add(BaseExpressionColon.Print(node.NameColon));
+            docs.Add(BaseExpressionColon.Print(node.NameColon, context));
         }
 
         if (node.RefKindKeyword.RawSyntaxKind() != SyntaxKind.None)
         {
-            docs.Add(Token.PrintWithSuffix(node.RefKindKeyword, " "));
+            docs.Add(Token.PrintWithSuffix(node.RefKindKeyword, " ", context));
         }
 
-        docs.Add(Node.Print(node.Expression));
+        docs.Add(Node.Print(node.Expression, context));
         return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArgumentList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArgumentList.cs
@@ -27,7 +27,12 @@ internal static class ArgumentList
                                 Parent: { Parent: InvocationExpressionSyntax }
                             }
                     },
-                ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken, context)
+                ArgumentListLike.Print(
+                    node.OpenParenToken,
+                    node.Arguments,
+                    node.CloseParenToken,
+                    context
+                )
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArgumentList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArgumentList.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ArgumentList
 {
-    public static Doc Print(ArgumentListSyntax node)
+    public static Doc Print(ArgumentListSyntax node, FormattingContext context)
     {
         return Doc.Group(
             Doc.IndentIf(
@@ -27,7 +27,7 @@ internal static class ArgumentList
                                 Parent: { Parent: InvocationExpressionSyntax }
                             }
                     },
-                ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken)
+                ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ArrayCreationExpression
 {
-    public static Doc Print(ArrayCreationExpressionSyntax node)
+    public static Doc Print(ArrayCreationExpressionSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.PrintWithSuffix(node.NewKeyword, " "),
-            Node.Print(node.Type),
-            node.Initializer != null ? Doc.Concat(Doc.Line, Node.Print(node.Initializer)) : Doc.Null
+            Token.PrintWithSuffix(node.NewKeyword, " ", context),
+            Node.Print(node.Type, context),
+            node.Initializer != null ? Doc.Concat(Doc.Line, Node.Print(node.Initializer, context)) : Doc.Null
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayCreationExpression.cs
@@ -7,7 +7,9 @@ internal static class ArrayCreationExpression
         return Doc.Group(
             Token.PrintWithSuffix(node.NewKeyword, " ", context),
             Node.Print(node.Type, context),
-            node.Initializer != null ? Doc.Concat(Doc.Line, Node.Print(node.Initializer, context)) : Doc.Null
+            node.Initializer != null
+              ? Doc.Concat(Doc.Line, Node.Print(node.Initializer, context))
+              : Doc.Null
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayRankSpecifier.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayRankSpecifier.cs
@@ -2,29 +2,29 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ArrayRankSpecifier
 {
-    public static Doc Print(ArrayRankSpecifierSyntax node)
+    public static Doc Print(ArrayRankSpecifierSyntax node, FormattingContext context)
     {
         if (node.Sizes.All(o => o is OmittedArraySizeExpressionSyntax))
         {
             return Doc.Concat(
-                Token.Print(node.OpenBracketToken),
-                SeparatedSyntaxList.Print(node.Sizes, Node.Print, Doc.Null),
-                Token.Print(node.CloseBracketToken)
+                Token.Print(node.OpenBracketToken, context),
+                SeparatedSyntaxList.Print(node.Sizes, Node.Print, Doc.Null, context),
+                Token.Print(node.CloseBracketToken, context)
             );
         }
 
         return Doc.Group(
-            Token.Print(node.OpenBracketToken),
+            Token.Print(node.OpenBracketToken, context),
             node.Sizes.Any()
               ? Doc.Concat(
                     Doc.Indent(
                         Doc.SoftLine,
-                        SeparatedSyntaxList.Print(node.Sizes, Node.Print, Doc.Line)
+                        SeparatedSyntaxList.Print(node.Sizes, Node.Print, Doc.Line, context)
                     ),
                     Doc.SoftLine
                 )
               : Doc.Null,
-            Token.Print(node.CloseBracketToken)
+            Token.Print(node.CloseBracketToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrayType.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ArrayType
 {
-    public static Doc Print(ArrayTypeSyntax node)
+    public static Doc Print(ArrayTypeSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.ElementType),
-            Doc.Concat(node.RankSpecifiers.Select(Node.Print).ToArray())
+            Node.Print(node.ElementType, context),
+            Doc.Concat(node.RankSpecifiers.Select(o => Node.Print(o, context)).ToArray())
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrowExpressionClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ArrowExpressionClause.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ArrowExpressionClause
 {
-    public static Doc Print(ArrowExpressionClauseSyntax node)
+    public static Doc Print(ArrowExpressionClauseSyntax node, FormattingContext context)
     {
         return Doc.Group(
             Doc.Indent(
                 " ",
-                Token.PrintWithSuffix(node.ArrowToken, Doc.Line),
-                Node.Print(node.Expression)
+                Token.PrintWithSuffix(node.ArrowToken, Doc.Line, context),
+                Node.Print(node.Expression, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AssignmentExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AssignmentExpression.cs
@@ -2,13 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AssignmentExpression
 {
-    public static Doc Print(AssignmentExpressionSyntax node)
+    public static Doc Print(AssignmentExpressionSyntax node, FormattingContext context)
     {
         return RightHandSide.Print(
             node,
-            Doc.Concat(Node.Print(node.Left), " "),
-            Token.Print(node.OperatorToken),
-            node.Right
+            Doc.Concat(Node.Print(node.Left, context), " "),
+            Token.Print(node.OperatorToken, context),
+            node.Right,
+            context
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AttributeList
 {
-    public static Doc Print(AttributeListSyntax node)
+    public static Doc Print(AttributeListSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>();
         if (
@@ -13,20 +13,20 @@ internal static class AttributeList
             docs.Add(ExtraNewLines.Print(node));
         }
 
-        docs.Add(Token.Print(node.OpenBracketToken));
+        docs.Add(Token.Print(node.OpenBracketToken, context));
         if (node.Target != null)
         {
             docs.Add(
-                Token.Print(node.Target.Identifier),
-                Token.PrintWithSuffix(node.Target.ColonToken, " ")
+                Token.Print(node.Target.Identifier, context),
+                Token.PrintWithSuffix(node.Target.ColonToken, " ", context)
             );
         }
 
         var printSeparatedSyntaxList = SeparatedSyntaxList.Print(
             node.Attributes,
-            attributeNode =>
+            (attributeNode, _) =>
             {
-                var name = Node.Print(attributeNode.Name);
+                var name = Node.Print(attributeNode.Name, context);
                 if (attributeNode.ArgumentList == null)
                 {
                     return name;
@@ -34,29 +34,34 @@ internal static class AttributeList
 
                 return Doc.Group(
                     name,
-                    Token.Print(attributeNode.ArgumentList.OpenParenToken),
+                    Token.Print(attributeNode.ArgumentList.OpenParenToken, context),
                     Doc.Indent(
                         Doc.SoftLine,
                         SeparatedSyntaxList.Print(
                             attributeNode.ArgumentList.Arguments,
-                            attributeArgumentNode =>
+                            (attributeArgumentNode, _) =>
                                 Doc.Concat(
                                     attributeArgumentNode.NameEquals != null
-                                      ? NameEquals.Print(attributeArgumentNode.NameEquals)
+                                      ? NameEquals.Print(attributeArgumentNode.NameEquals, context)
                                       : Doc.Null,
                                     attributeArgumentNode.NameColon != null
-                                      ? BaseExpressionColon.Print(attributeArgumentNode.NameColon)
+                                      ? BaseExpressionColon.Print(
+                                            attributeArgumentNode.NameColon,
+                                            context
+                                        )
                                       : Doc.Null,
-                                    Node.Print(attributeArgumentNode.Expression)
+                                    Node.Print(attributeArgumentNode.Expression, context)
                                 ),
-                            Doc.Line
+                            Doc.Line,
+                            context
                         )
                     ),
                     Doc.SoftLine,
-                    Token.Print(attributeNode.ArgumentList.CloseParenToken)
+                    Token.Print(attributeNode.ArgumentList.CloseParenToken, context)
                 );
             },
-            Doc.Line
+            Doc.Line,
+            context
         );
 
         docs.Add(
@@ -67,7 +72,7 @@ internal static class AttributeList
 
         docs.Add(
             node.Attributes.Count > 1 ? Doc.SoftLine : Doc.Null,
-            Token.Print(node.CloseBracketToken)
+            Token.Print(node.CloseBracketToken, context)
         );
 
         return Doc.Group(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AwaitExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AwaitExpression.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class AwaitExpression
 {
-    public static Doc Print(AwaitExpressionSyntax node)
+    public static Doc Print(AwaitExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.AwaitKeyword, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.AwaitKeyword, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BaseExpression
 {
-    public static Doc Print(BaseExpressionSyntax node)
+    public static Doc Print(BaseExpressionSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Token);
+        return Token.Print(node.Token, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpressionColon.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpressionColon.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BaseExpressionColon
 {
-    public static Doc Print(BaseExpressionColonSyntax node)
+    public static Doc Print(BaseExpressionColonSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.Expression),
+            Node.Print(node.Expression, context),
             Token.PrintWithSuffix(
                 node.ColonToken,
                 node.Parent is SubpatternSyntax { Pattern: RecursivePatternSyntax { Type: null } }
                   ? Doc.Line
-                  : " "
+                  : " ", context
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpressionColon.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseExpressionColon.cs
@@ -10,7 +10,8 @@ internal static class BaseExpressionColon
                 node.ColonToken,
                 node.Parent is SubpatternSyntax { Pattern: RecursivePatternSyntax { Type: null } }
                   ? Doc.Line
-                  : " ", context
+                  : " ",
+                context
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
@@ -2,19 +2,19 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BaseFieldDeclaration
 {
-    public static Doc Print(BaseFieldDeclarationSyntax node)
+    public static Doc Print(BaseFieldDeclarationSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers)
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context)
         };
         if (node is EventFieldDeclarationSyntax eventFieldDeclarationSyntax)
         {
-            docs.Add(Token.PrintWithSuffix(eventFieldDeclarationSyntax.EventKeyword, " "));
+            docs.Add(Token.PrintWithSuffix(eventFieldDeclarationSyntax.EventKeyword, " ", context));
         }
 
-        docs.Add(VariableDeclaration.Print(node.Declaration), Token.Print(node.SemicolonToken));
+        docs.Add(VariableDeclaration.Print(node.Declaration, context), Token.Print(node.SemicolonToken, context));
         return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
@@ -14,7 +14,10 @@ internal static class BaseFieldDeclaration
             docs.Add(Token.PrintWithSuffix(eventFieldDeclarationSyntax.EventKeyword, " ", context));
         }
 
-        docs.Add(VariableDeclaration.Print(node.Declaration, context), Token.Print(node.SemicolonToken, context));
+        docs.Add(
+            VariableDeclaration.Print(node.Declaration, context),
+            Token.Print(node.SemicolonToken, context)
+        );
         return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BaseMethodDeclaration
 {
-    public static Doc Print(CSharpSyntaxNode node)
+    public static Doc Print(CSharpSyntaxNode node, FormattingContext context)
     {
         SyntaxList<AttributeListSyntax>? attributeLists = null;
         SyntaxTokenList? modifiers = null;
@@ -28,7 +28,7 @@ internal static class BaseMethodDeclaration
             {
                 returnType = methodDeclarationSyntax.ReturnType;
                 explicitInterfaceSpecifier = methodDeclarationSyntax.ExplicitInterfaceSpecifier;
-                identifier = () => Token.Print(methodDeclarationSyntax.Identifier);
+                identifier = () => Token.Print(methodDeclarationSyntax.Identifier, context);
                 typeParameterList = methodDeclarationSyntax.TypeParameterList;
                 constraintClauses = methodDeclarationSyntax.ConstraintClauses;
             }
@@ -36,13 +36,13 @@ internal static class BaseMethodDeclaration
             {
                 identifier = () =>
                     Doc.Concat(
-                        Token.Print(destructorDeclarationSyntax.TildeToken),
-                        Token.Print(destructorDeclarationSyntax.Identifier)
+                        Token.Print(destructorDeclarationSyntax.TildeToken, context),
+                        Token.Print(destructorDeclarationSyntax.Identifier, context)
                     );
             }
             else if (node is ConstructorDeclarationSyntax constructorDeclarationSyntax)
             {
-                identifier = () => Token.Print(constructorDeclarationSyntax.Identifier);
+                identifier = () => Token.Print(constructorDeclarationSyntax.Identifier, context);
                 constructorInitializer = constructorDeclarationSyntax.Initializer;
             }
 
@@ -53,7 +53,7 @@ internal static class BaseMethodDeclaration
             attributeLists = localFunctionStatementSyntax.AttributeLists;
             modifiers = localFunctionStatementSyntax.Modifiers;
             returnType = localFunctionStatementSyntax.ReturnType;
-            identifier = () => Token.Print(localFunctionStatementSyntax.Identifier);
+            identifier = () => Token.Print(localFunctionStatementSyntax.Identifier, context);
             typeParameterList = localFunctionStatementSyntax.TypeParameterList;
             parameterList = localFunctionStatementSyntax.ParameterList;
             constraintClauses = localFunctionStatementSyntax.ConstraintClauses;
@@ -71,23 +71,23 @@ internal static class BaseMethodDeclaration
 
         if (attributeLists is { Count: > 0 })
         {
-            docs.Add(AttributeLists.Print(node, attributeLists.Value));
+            docs.Add(AttributeLists.Print(node, attributeLists.Value, context));
         }
 
         if (modifiers is { Count: > 0 })
         {
-            docs.Add(Token.PrintLeadingTrivia(modifiers.Value[0]));
+            docs.Add(Token.PrintLeadingTrivia(modifiers.Value[0], context));
         }
         else if (returnType != null)
         {
-            docs.Add(Token.PrintLeadingTrivia(returnType.GetLeadingTrivia()));
+            docs.Add(Token.PrintLeadingTrivia(returnType.GetLeadingTrivia(), context));
         }
 
         var declarationGroup = new List<Doc>();
 
         if (modifiers.HasValue && modifiers.Value.Any())
         {
-            declarationGroup.Add(Modifiers.PrintWithoutLeadingTrivia(modifiers.Value));
+            declarationGroup.Add(Modifiers.PrintWithoutLeadingTrivia(modifiers.Value, context));
         }
 
         if (returnType != null)
@@ -97,15 +97,15 @@ internal static class BaseMethodDeclaration
                 Token.ShouldSkipNextLeadingTrivia = true;
             }
 
-            declarationGroup.Add(Node.Print(returnType), " ");
+            declarationGroup.Add(Node.Print(returnType, context), " ");
             Token.ShouldSkipNextLeadingTrivia = false;
         }
 
         if (explicitInterfaceSpecifier != null)
         {
             declarationGroup.Add(
-                Node.Print(explicitInterfaceSpecifier.Name),
-                Token.Print(explicitInterfaceSpecifier.DotToken)
+                Node.Print(explicitInterfaceSpecifier.Name, context),
+                Token.Print(explicitInterfaceSpecifier.DotToken, context)
             );
         }
 
@@ -119,38 +119,38 @@ internal static class BaseMethodDeclaration
             declarationGroup.Add(
                 Token.PrintWithSuffix(
                     conversionOperatorDeclarationSyntax.ImplicitOrExplicitKeyword,
-                    " "
+                    " ", context
                 ),
-                Token.PrintWithSuffix(conversionOperatorDeclarationSyntax.OperatorKeyword, " "),
-                Node.Print(conversionOperatorDeclarationSyntax.Type)
+                Token.PrintWithSuffix(conversionOperatorDeclarationSyntax.OperatorKeyword, " ", context),
+                Node.Print(conversionOperatorDeclarationSyntax.Type, context)
             );
         }
         else if (node is OperatorDeclarationSyntax operatorDeclarationSyntax)
         {
             declarationGroup.Add(
-                Node.Print(operatorDeclarationSyntax.ReturnType),
+                Node.Print(operatorDeclarationSyntax.ReturnType, context),
                 " ",
-                Token.PrintWithSuffix(operatorDeclarationSyntax.OperatorKeyword, " "),
-                Token.Print(operatorDeclarationSyntax.OperatorToken)
+                Token.PrintWithSuffix(operatorDeclarationSyntax.OperatorKeyword, " ", context),
+                Token.Print(operatorDeclarationSyntax.OperatorToken, context)
             );
         }
 
         if (typeParameterList != null && typeParameterList.Parameters.Any())
         {
-            declarationGroup.Add(TypeParameterList.Print(typeParameterList));
+            declarationGroup.Add(TypeParameterList.Print(typeParameterList, context));
         }
 
         if (parameterList != null)
         {
             if (parameterList.Parameters.Any())
             {
-                declarationGroup.Add(ParameterList.Print(parameterList));
+                declarationGroup.Add(ParameterList.Print(parameterList, context));
             }
             else
             {
                 declarationGroup.Add(
-                    Token.Print(parameterList.OpenParenToken),
-                    Token.Print(parameterList.CloseParenToken)
+                    Token.Print(parameterList.OpenParenToken, context),
+                    Token.Print(parameterList.CloseParenToken, context)
                 );
             }
 
@@ -159,8 +159,8 @@ internal static class BaseMethodDeclaration
 
         if (constructorInitializer != null)
         {
-            var colonToken = Token.PrintWithSuffix(constructorInitializer.ColonToken, " ");
-            var argumentList = Doc.Group(ArgumentList.Print(constructorInitializer.ArgumentList));
+            var colonToken = Token.PrintWithSuffix(constructorInitializer.ColonToken, " ", context);
+            var argumentList = Doc.Group(ArgumentList.Print(constructorInitializer.ArgumentList, context));
 
             declarationGroup.Add(
                 Doc.Group(
@@ -176,24 +176,24 @@ internal static class BaseMethodDeclaration
 
         if (constraintClauses != null)
         {
-            docs.Add(ConstraintClauses.Print(constraintClauses));
+            docs.Add(ConstraintClauses.Print(constraintClauses, context));
         }
 
         if (body != null)
         {
-            docs.Add(Block.Print(body));
+            docs.Add(Block.Print(body, context));
         }
         else
         {
             if (expressionBody != null)
             {
-                docs.Add(ArrowExpressionClause.Print(expressionBody));
+                docs.Add(ArrowExpressionClause.Print(expressionBody, context));
             }
         }
 
         if (semicolonToken.HasValue)
         {
-            docs.Add(Token.Print(semicolonToken.Value));
+            docs.Add(Token.Print(semicolonToken.Value, context));
         }
 
         return Doc.Group(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -119,9 +119,14 @@ internal static class BaseMethodDeclaration
             declarationGroup.Add(
                 Token.PrintWithSuffix(
                     conversionOperatorDeclarationSyntax.ImplicitOrExplicitKeyword,
-                    " ", context
+                    " ",
+                    context
                 ),
-                Token.PrintWithSuffix(conversionOperatorDeclarationSyntax.OperatorKeyword, " ", context),
+                Token.PrintWithSuffix(
+                    conversionOperatorDeclarationSyntax.OperatorKeyword,
+                    " ",
+                    context
+                ),
                 Node.Print(conversionOperatorDeclarationSyntax.Type, context)
             );
         }
@@ -160,7 +165,9 @@ internal static class BaseMethodDeclaration
         if (constructorInitializer != null)
         {
             var colonToken = Token.PrintWithSuffix(constructorInitializer.ColonToken, " ", context);
-            var argumentList = Doc.Group(ArgumentList.Print(constructorInitializer.ArgumentList, context));
+            var argumentList = Doc.Group(
+                ArgumentList.Print(constructorInitializer.ArgumentList, context)
+            );
 
             declarationGroup.Add(
                 Doc.Group(

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -173,7 +173,7 @@ internal static class BaseMethodDeclaration
                 Doc.Group(
                     Doc.Indent(Doc.Line),
                     Doc.Indent(colonToken),
-                    Token.Print(constructorInitializer.ThisOrBaseKeyword),
+                    Token.Print(constructorInitializer.ThisOrBaseKeyword, context),
                     Doc.Indent(argumentList)
                 )
             );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BasePropertyDeclaration
 {
-    public static Doc Print(BasePropertyDeclarationSyntax node)
+    public static Doc Print(BasePropertyDeclarationSyntax node, FormattingContext context)
     {
         EqualsValueClauseSyntax? initializer = null;
         ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifierSyntax = null;
@@ -16,7 +16,7 @@ internal static class BasePropertyDeclaration
             expressionBody = propertyDeclarationSyntax.ExpressionBody;
             initializer = propertyDeclarationSyntax.Initializer;
             explicitInterfaceSpecifierSyntax = propertyDeclarationSyntax.ExplicitInterfaceSpecifier;
-            identifier = () => Token.Print(propertyDeclarationSyntax.Identifier);
+            identifier = () => Token.Print(propertyDeclarationSyntax.Identifier, context);
             semicolonToken = propertyDeclarationSyntax.SemicolonToken;
         }
         else if (node is IndexerDeclarationSyntax indexerDeclarationSyntax)
@@ -25,45 +25,46 @@ internal static class BasePropertyDeclaration
             explicitInterfaceSpecifierSyntax = indexerDeclarationSyntax.ExplicitInterfaceSpecifier;
             identifier = () =>
                 Doc.Concat(
-                    Token.Print(indexerDeclarationSyntax.ThisKeyword),
-                    Node.Print(indexerDeclarationSyntax.ParameterList)
+                    Token.Print(indexerDeclarationSyntax.ThisKeyword, context),
+                    Node.Print(indexerDeclarationSyntax.ParameterList, context)
                 );
             semicolonToken = indexerDeclarationSyntax.SemicolonToken;
         }
         else if (node is EventDeclarationSyntax eventDeclarationSyntax)
         {
-            eventKeyword = Token.PrintWithSuffix(eventDeclarationSyntax.EventKeyword, " ");
+            eventKeyword = Token.PrintWithSuffix(eventDeclarationSyntax.EventKeyword, " ", context);
             explicitInterfaceSpecifierSyntax = eventDeclarationSyntax.ExplicitInterfaceSpecifier;
-            identifier = () => Token.Print(eventDeclarationSyntax.Identifier);
+            identifier = () => Token.Print(eventDeclarationSyntax.Identifier, context);
             semicolonToken = eventDeclarationSyntax.SemicolonToken;
         }
 
-        var docs = new List<Doc> { AttributeLists.Print(node, node.AttributeLists) };
+        var docs = new List<Doc> { AttributeLists.Print(node, node.AttributeLists, context) };
 
         return Doc.Group(
             Doc.Concat(
                 Doc.Concat(docs),
-                Modifiers.Print(node.Modifiers),
+                Modifiers.Print(node.Modifiers, context),
                 eventKeyword,
-                Node.Print(node.Type),
+                Node.Print(node.Type, context),
                 " ",
                 explicitInterfaceSpecifierSyntax != null
                   ? Doc.Concat(
-                        Node.Print(explicitInterfaceSpecifierSyntax.Name),
-                        Token.Print(explicitInterfaceSpecifierSyntax.DotToken)
+                        Node.Print(explicitInterfaceSpecifierSyntax.Name, context),
+                        Token.Print(explicitInterfaceSpecifierSyntax.DotToken, context)
                     )
                   : Doc.Null,
                 identifier != null ? identifier() : Doc.Null,
-                Contents(node, expressionBody),
-                initializer != null ? EqualsValueClause.Print(initializer) : Doc.Null,
-                semicolonToken.HasValue ? Token.Print(semicolonToken.Value) : Doc.Null
+                Contents(node, expressionBody, context),
+                initializer != null ? EqualsValueClause.Print(initializer, context) : Doc.Null,
+                semicolonToken.HasValue ? Token.Print(semicolonToken.Value, context) : Doc.Null
             )
         );
     }
 
     private static Doc Contents(
         BasePropertyDeclarationSyntax node,
-        ArrowExpressionClauseSyntax? expressionBody
+        ArrowExpressionClauseSyntax? expressionBody,
+        FormattingContext context
     )
     {
         Doc contents = string.Empty;
@@ -86,26 +87,30 @@ internal static class BasePropertyDeclaration
             contents = Doc.Group(
                 Doc.Concat(
                     separator,
-                    Token.Print(node.AccessorList.OpenBraceToken),
+                    Token.Print(node.AccessorList.OpenBraceToken, context),
                     Doc.Indent(
                         node.AccessorList.Accessors
-                            .Select(o => PrintAccessorDeclarationSyntax(o, separator))
+                            .Select(o => PrintAccessorDeclarationSyntax(o, separator, context))
                             .ToArray()
                     ),
                     separator,
-                    Token.Print(node.AccessorList.CloseBraceToken)
+                    Token.Print(node.AccessorList.CloseBraceToken, context)
                 )
             );
         }
         else if (expressionBody != null)
         {
-            contents = ArrowExpressionClause.Print(expressionBody);
+            contents = ArrowExpressionClause.Print(expressionBody, context);
         }
 
         return contents;
     }
 
-    private static Doc PrintAccessorDeclarationSyntax(AccessorDeclarationSyntax node, Doc separator)
+    private static Doc PrintAccessorDeclarationSyntax(
+        AccessorDeclarationSyntax node,
+        Doc separator,
+        FormattingContext context
+    )
     {
         var docs = new List<Doc>();
         if (node.AttributeLists.Count > 0 || node.Body != null || node.ExpressionBody != null)
@@ -117,20 +122,20 @@ internal static class BasePropertyDeclaration
             docs.Add(separator);
         }
 
-        docs.Add(AttributeLists.Print(node, node.AttributeLists));
-        docs.Add(Modifiers.Print(node.Modifiers));
-        docs.Add(Token.Print(node.Keyword));
+        docs.Add(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Add(Modifiers.Print(node.Modifiers, context));
+        docs.Add(Token.Print(node.Keyword, context));
 
         if (node.Body != null)
         {
-            docs.Add(Block.Print(node.Body));
+            docs.Add(Block.Print(node.Body, context));
         }
         else if (node.ExpressionBody != null)
         {
-            docs.Add(ArrowExpressionClause.Print(node.ExpressionBody));
+            docs.Add(ArrowExpressionClause.Print(node.ExpressionBody, context));
         }
 
-        docs.Add(Token.Print(node.SemicolonToken));
+        docs.Add(Token.Print(node.SemicolonToken, context));
 
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -22,7 +22,8 @@ internal static class BaseTypeDeclaration
                     Doc.Indent(
                         MembersWithForcedLines.Print(
                             typeDeclarationSyntax,
-                            typeDeclarationSyntax.Members
+                            typeDeclarationSyntax.Members,
+                            context
                         )
                     );
             }
@@ -55,7 +56,8 @@ internal static class BaseTypeDeclaration
                     Doc.Indent(
                         MembersWithForcedLines.Print(
                             enumDeclarationSyntax,
-                            enumDeclarationSyntax.Members
+                            enumDeclarationSyntax.Members,
+                            context
                         )
                     );
             }
@@ -102,15 +104,16 @@ internal static class BaseTypeDeclaration
             var baseListDoc = Doc.Concat(
                 Token.Print(node.BaseList.ColonToken, context),
                 " ",
-                Node.Print(node.BaseList.Types.First()),
+                Node.Print(node.BaseList.Types.First(), context),
                 node.BaseList.Types.Count > 1
                   ? Doc.Indent(
-                        Token.Print(node.BaseList.Types.GetSeparator(0)),
+                        Token.Print(node.BaseList.Types.GetSeparator(0), context),
                         Doc.Line,
                         SeparatedSyntaxList.Print(
                             node.BaseList.Types,
                             Node.Print,
                             Doc.Line,
+                            context,
                             startingIndex: 1
                         )
                     )
@@ -130,7 +133,7 @@ internal static class BaseTypeDeclaration
 
             docs.Add(
                 Doc.HardLine,
-                Token.Print(node.OpenBraceToken),
+                Token.Print(node.OpenBraceToken, context),
                 membersContent,
                 Doc.HardLine,
                 Token.Print(node.CloseBraceToken, context)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BaseTypeDeclaration
 {
-    public static Doc Print(BaseTypeDeclarationSyntax node)
+    public static Doc Print(BaseTypeDeclarationSyntax node, FormattingContext context)
     {
         ParameterListSyntax? parameterList = null;
         TypeParameterListSyntax? typeParameterList = null;
@@ -67,40 +67,40 @@ internal static class BaseTypeDeclaration
         var docs = new List<Doc>();
         if (node.AttributeLists.Any())
         {
-            docs.Add(AttributeLists.Print(node, node.AttributeLists));
+            docs.Add(AttributeLists.Print(node, node.AttributeLists, context));
         }
 
         if (node.Modifiers.Any())
         {
-            docs.Add(Modifiers.Print(node.Modifiers));
+            docs.Add(Modifiers.Print(node.Modifiers, context));
         }
 
         if (recordKeyword != null)
         {
-            docs.Add(Token.PrintWithSuffix(recordKeyword.Value, " "));
+            docs.Add(Token.PrintWithSuffix(recordKeyword.Value, " ", context));
         }
 
         if (keyword != null)
         {
-            docs.Add(Token.PrintWithSuffix(keyword.Value, " "));
+            docs.Add(Token.PrintWithSuffix(keyword.Value, " ", context));
         }
 
-        docs.Add(Token.Print(node.Identifier));
+        docs.Add(Token.Print(node.Identifier, context));
 
         if (typeParameterList != null)
         {
-            docs.Add(TypeParameterList.Print(typeParameterList));
+            docs.Add(TypeParameterList.Print(typeParameterList, context));
         }
 
         if (parameterList != null)
         {
-            docs.Add(ParameterList.Print(parameterList));
+            docs.Add(ParameterList.Print(parameterList, context));
         }
 
         if (node.BaseList != null)
         {
             var baseListDoc = Doc.Concat(
-                Token.Print(node.BaseList.ColonToken),
+                Token.Print(node.BaseList.ColonToken, context),
                 " ",
                 Node.Print(node.BaseList.Types.First()),
                 node.BaseList.Types.Count > 1
@@ -120,7 +120,7 @@ internal static class BaseTypeDeclaration
             docs.Add(Doc.Group(Doc.Indent(Doc.Line, baseListDoc)));
         }
 
-        docs.Add(ConstraintClauses.Print(constraintClauses));
+        docs.Add(ConstraintClauses.Print(constraintClauses, context));
 
         if (members != null)
         {
@@ -133,7 +133,7 @@ internal static class BaseTypeDeclaration
                 Token.Print(node.OpenBraceToken),
                 membersContent,
                 Doc.HardLine,
-                Token.Print(node.CloseBraceToken)
+                Token.Print(node.CloseBraceToken, context)
             );
         }
         else if (node.OpenBraceToken.RawSyntaxKind() != SyntaxKind.None)
@@ -148,15 +148,15 @@ internal static class BaseTypeDeclaration
 
             docs.Add(
                 separator,
-                Token.Print(node.OpenBraceToken),
+                Token.Print(node.OpenBraceToken, context),
                 separator,
-                Token.Print(node.CloseBraceToken)
+                Token.Print(node.CloseBraceToken, context)
             );
         }
 
         if (semicolonToken.HasValue)
         {
-            docs.Add(Token.Print(semicolonToken.Value));
+            docs.Add(Token.Print(semicolonToken.Value, context));
         }
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
@@ -3,9 +3,9 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 // this is loosely based on prettier/src/language-js/print/binaryish.js
 internal static class BinaryExpression
 {
-    public static Doc Print(BinaryExpressionSyntax node)
+    public static Doc Print(BinaryExpressionSyntax node, FormattingContext context)
     {
-        var docs = PrintBinaryExpression(node);
+        var docs = PrintBinaryExpression(node, context);
 
         var shouldNotIndent =
             node.Parent
@@ -45,11 +45,11 @@ internal static class BinaryExpression
         && three != four
         && five != six
      */
-    private static List<Doc> PrintBinaryExpression(SyntaxNode node)
+    private static List<Doc> PrintBinaryExpression(SyntaxNode node, FormattingContext context)
     {
         if (node is not BinaryExpressionSyntax binaryExpressionSyntax)
         {
-            return new List<Doc> { Doc.Group(Node.Print(node)) };
+            return new List<Doc> { Doc.Group(Node.Print(node, context)) };
         }
 
         if (depth > 200)
@@ -76,9 +76,9 @@ internal static class BinaryExpression
             if (binaryOnTheRight)
             {
                 docs.Add(
-                    Node.Print(binaryExpressionSyntax.Left),
+                    Node.Print(binaryExpressionSyntax.Left, context),
                     Doc.Line,
-                    Token.Print(binaryExpressionSyntax.OperatorToken),
+                    Token.Print(binaryExpressionSyntax.OperatorToken, context),
                     " "
                 );
             }
@@ -100,11 +100,11 @@ internal static class BinaryExpression
                 && ShouldFlatten(binaryExpressionSyntax.OperatorToken, childBinary.OperatorToken)
             )
             {
-                docs.AddRange(PrintBinaryExpression(childBinary));
+                docs.AddRange(PrintBinaryExpression(childBinary, context));
             }
             else
             {
-                docs.Add(Node.Print(possibleBinary));
+                docs.Add(Node.Print(possibleBinary, context));
             }
 
             if (binaryOnTheRight)
@@ -116,9 +116,9 @@ internal static class BinaryExpression
 
             var right = Doc.Concat(
                 Doc.Line,
-                Token.Print(binaryExpressionSyntax.OperatorToken),
+                Token.Print(binaryExpressionSyntax.OperatorToken, context),
                 " ",
-                Node.Print(binaryExpressionSyntax.Right)
+                Node.Print(binaryExpressionSyntax.Right, context)
             );
 
             docs.Add(shouldGroup ? Doc.Group(right) : right);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BinaryPattern.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BinaryPattern
 {
-    public static Doc Print(BinaryPatternSyntax node)
+    public static Doc Print(BinaryPatternSyntax node, FormattingContext context)
     {
         return Doc.IndentIf(
             node.Parent is SubpatternSyntax or IsPatternExpressionSyntax,
             Doc.Concat(
-                Node.Print(node.Left),
+                Node.Print(node.Left, context),
                 Doc.Line,
-                Token.PrintWithSuffix(node.OperatorToken, " "),
-                Node.Print(node.Right)
+                Token.PrintWithSuffix(node.OperatorToken, " ", context),
+                Node.Print(node.Right, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Block.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Block.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class Block
 {
-    public static Doc Print(BlockSyntax node)
+    public static Doc Print(BlockSyntax node, FormattingContext context)
     {
         if (
             node.Statements.Count == 0
@@ -12,9 +12,9 @@ internal static class Block
         {
             return Doc.Concat(
                 " ",
-                Token.Print(node.OpenBraceToken),
+                Token.Print(node.OpenBraceToken, context),
                 " ",
-                Token.Print(node.CloseBraceToken)
+                Token.Print(node.CloseBraceToken, context)
             );
         }
 
@@ -29,7 +29,7 @@ internal static class Block
         {
             innerDoc = Doc.Indent(
                 statementSeparator,
-                Doc.Join(statementSeparator, node.Statements.Select(Node.Print))
+                Doc.Join(statementSeparator, node.Statements.Select(o => Node.Print(o, context)))
             );
 
             DocUtilities.RemoveInitialDoubleHardLine(innerDoc);
@@ -37,9 +37,9 @@ internal static class Block
 
         var result = Doc.Group(
             node.Parent is ParenthesizedLambdaExpressionSyntax or BlockSyntax ? Doc.Null : Doc.Line,
-            Token.Print(node.OpenBraceToken),
+            Token.Print(node.OpenBraceToken, context),
             node.Statements.Count == 0 ? " " : Doc.Concat(innerDoc, statementSeparator),
-            Token.Print(node.CloseBraceToken)
+            Token.Print(node.CloseBraceToken, context)
         );
 
         return node.Parent is BlockSyntax ? Doc.Concat(ExtraNewLines.Print(node), result) : result;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BracketedArgumentList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BracketedArgumentList.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BracketedArgumentList
 {
-    public static Doc Print(BracketedArgumentListSyntax node)
+    public static Doc Print(BracketedArgumentListSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.OpenBracketToken),
+            Token.Print(node.OpenBracketToken, context),
             Doc.Indent(
                 Doc.SoftLine,
-                SeparatedSyntaxList.Print(node.Arguments, Node.Print, Doc.Line)
+                SeparatedSyntaxList.Print(node.Arguments, Node.Print, Doc.Line, context)
             ),
             Doc.SoftLine,
-            Token.Print(node.CloseBracketToken)
+            Token.Print(node.CloseBracketToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BracketedParameterList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BracketedParameterList.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BracketedParameterList
 {
-    public static Doc Print(BracketedParameterListSyntax node)
+    public static Doc Print(BracketedParameterListSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.OpenBracketToken),
-            SeparatedSyntaxList.Print(node.Parameters, Parameter.Print, " "),
-            Token.Print(node.CloseBracketToken)
+            Token.Print(node.OpenBracketToken, context),
+            SeparatedSyntaxList.Print(node.Parameters, Parameter.Print, " ", context),
+            Token.Print(node.CloseBracketToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BreakStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BreakStatement.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class BreakStatement
 {
-    public static Doc Print(BreakStatementSyntax node)
+    public static Doc Print(BreakStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.Print(node.BreakKeyword),
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.BreakKeyword, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
@@ -6,10 +6,10 @@ internal static class CasePatternSwitchLabel
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.Keyword, " "),
-            Node.Print(node.Pattern),
-            node.WhenClause != null ? WhenClause.Print(node.WhenClause) : Doc.Null,
-            Token.Print(node.ColonToken)
+            Token.PrintWithSuffix(node.Keyword, " ", context),
+            Node.Print(node.Pattern, context),
+            node.WhenClause != null ? WhenClause.Print(node.WhenClause, context) : Doc.Null,
+            Token.Print(node.ColonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CasePatternSwitchLabel.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CasePatternSwitchLabel
 {
-    public static Doc Print(CasePatternSwitchLabelSyntax node)
+    public static Doc Print(CasePatternSwitchLabelSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CaseSwitchLabel.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CaseSwitchLabel
 {
-    public static Doc Print(CaseSwitchLabelSyntax node)
+    public static Doc Print(CaseSwitchLabelSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.Keyword, " "),
-            Doc.Group(Node.Print(node.Value)),
-            Token.Print(node.ColonToken)
+            Token.PrintWithSuffix(node.Keyword, " ", context),
+            Doc.Group(Node.Print(node.Value, context)),
+            Token.Print(node.ColonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CastExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CastExpression.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CastExpression
 {
-    public static Doc Print(CastExpressionSyntax node)
+    public static Doc Print(CastExpressionSyntax node, FormattingContext context)
     {
         return
             node.Expression is ParenthesizedExpressionSyntax
@@ -13,16 +13,16 @@ internal static class CastExpression
                 && node.Type is not GenericNameSyntax
             )
           ? Doc.Concat(
-                Token.Print(node.OpenParenToken),
-                Node.Print(node.Type),
-                Token.Print(node.CloseParenToken),
-                Node.Print(node.Expression)
+                Token.Print(node.OpenParenToken, context),
+                Node.Print(node.Type, context),
+                Token.Print(node.CloseParenToken, context),
+                Node.Print(node.Expression, context)
             )
           : Doc.Group(
-                Token.Print(node.OpenParenToken),
-                Node.Print(node.Type),
-                Token.Print(node.CloseParenToken),
-                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression))
+                Token.Print(node.OpenParenToken, context),
+                Node.Print(node.Type, context),
+                Token.Print(node.CloseParenToken, context),
+                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context))
             );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CatchClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CatchClause.cs
@@ -2,37 +2,37 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CatchClause
 {
-    public static Doc Print(CatchClauseSyntax node)
+    public static Doc Print(CatchClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.CatchKeyword),
+            Token.Print(node.CatchKeyword, context),
             Doc.Group(
                 node.Declaration != null
                   ? Doc.Concat(
                         " ",
-                        Token.Print(node.Declaration.OpenParenToken),
-                        Node.Print(node.Declaration.Type),
+                        Token.Print(node.Declaration.OpenParenToken, context),
+                        Node.Print(node.Declaration.Type, context),
                         node.Declaration.Identifier.RawSyntaxKind() != SyntaxKind.None
                           ? " "
                           : Doc.Null,
-                        Token.Print(node.Declaration.Identifier),
-                        Token.Print(node.Declaration.CloseParenToken)
+                        Token.Print(node.Declaration.Identifier, context),
+                        Token.Print(node.Declaration.CloseParenToken, context)
                     )
                   : Doc.Null,
                 node.Filter != null
                   ? Doc.Indent(
                         Doc.Line,
-                        Token.PrintWithSuffix(node.Filter.WhenKeyword, " "),
-                        Token.Print(node.Filter.OpenParenToken),
+                        Token.PrintWithSuffix(node.Filter.WhenKeyword, " ", context),
+                        Token.Print(node.Filter.OpenParenToken, context),
                         Doc.Group(
-                            Doc.Indent(Node.Print(node.Filter.FilterExpression)),
+                            Doc.Indent(Node.Print(node.Filter.FilterExpression, context)),
                             Doc.SoftLine
                         ),
-                        Token.Print(node.Filter.CloseParenToken)
+                        Token.Print(node.Filter.CloseParenToken, context)
                     )
                   : Doc.Null
             ),
-            Block.Print(node.Block)
+            Block.Print(node.Block, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CheckedExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CheckedExpression.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CheckedExpression
 {
-    public static Doc Print(CheckedExpressionSyntax node)
+    public static Doc Print(CheckedExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
+            Token.Print(node.Keyword, context),
             Doc.Group(
-                Token.Print(node.OpenParenToken),
-                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression)),
+                Token.Print(node.OpenParenToken, context),
+                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context)),
                 Doc.SoftLine,
-                Token.Print(node.CloseParenToken)
+                Token.Print(node.CloseParenToken, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CheckedStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CheckedStatement.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CheckedStatement
 {
-    public static Doc Print(CheckedStatementSyntax node)
+    public static Doc Print(CheckedStatementSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.Keyword), Block.Print(node.Block));
+        return Doc.Concat(Token.Print(node.Keyword, context), Block.Print(node.Block, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ClassOrStructConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ClassOrStructConstraint.cs
@@ -4,6 +4,9 @@ internal static class ClassOrStructConstraint
 {
     public static Doc Print(ClassOrStructConstraintSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.ClassOrStructKeyword, context), Token.Print(node.QuestionToken, context));
+        return Doc.Concat(
+            Token.Print(node.ClassOrStructKeyword, context),
+            Token.Print(node.QuestionToken, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ClassOrStructConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ClassOrStructConstraint.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ClassOrStructConstraint
 {
-    public static Doc Print(ClassOrStructConstraintSyntax node)
+    public static Doc Print(ClassOrStructConstraintSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.ClassOrStructKeyword), Token.Print(node.QuestionToken));
+        return Doc.Concat(Token.Print(node.ClassOrStructKeyword, context), Token.Print(node.QuestionToken, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CommonForEachStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CommonForEachStatement.cs
@@ -2,38 +2,43 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CommonForEachStatement
 {
-    public static Doc Print(CommonForEachStatementSyntax node)
+    public static Doc Print(CommonForEachStatementSyntax node, FormattingContext context)
     {
         var variable = node switch
         {
             ForEachStatementSyntax forEach
-              => Doc.Concat(Node.Print(forEach.Type), " ", Token.Print(forEach.Identifier)),
-            ForEachVariableStatementSyntax forEachVariable => Node.Print(forEachVariable.Variable),
+              => Doc.Concat(
+                  Node.Print(forEach.Type, context),
+                  " ",
+                  Token.Print(forEach.Identifier, context)
+              ),
+            ForEachVariableStatementSyntax forEachVariable
+              => Node.Print(forEachVariable.Variable, context),
             _ => Doc.Null
         };
 
         var docs = Doc.Concat(
             ExtraNewLines.Print(node),
             Doc.Group(
-                Token.Print(node.AwaitKeyword),
+                Token.Print(node.AwaitKeyword, context),
                 node.AwaitKeyword.RawSyntaxKind() is not SyntaxKind.None ? " " : Doc.Null,
-                Token.Print(node.ForEachKeyword),
+                Token.Print(node.ForEachKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
+                Token.Print(node.OpenParenToken, context),
                 Doc.Group(
                     Doc.Indent(
                         Doc.SoftLine,
                         variable,
                         " ",
-                        Token.Print(node.InKeyword),
+                        Token.Print(node.InKeyword, context),
                         " ",
-                        Node.Print(node.Expression)
+                        Node.Print(node.Expression, context)
                     ),
                     Doc.SoftLine
                 ),
-                Token.Print(node.CloseParenToken)
+                Token.Print(node.CloseParenToken, context)
             ),
-            OptionalBraces.Print(node.Statement)
+            OptionalBraces.Print(node.Statement, context)
         );
 
         return docs;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
@@ -8,7 +8,10 @@ internal static class CompilationUnit
 
         NamespaceLikePrinter.Print(node, docs, context);
 
-        var finalTrivia = Token.PrintLeadingTriviaWithNewLines(node.EndOfFileToken.LeadingTrivia, context);
+        var finalTrivia = Token.PrintLeadingTriviaWithNewLines(
+            node.EndOfFileToken.LeadingTrivia,
+            context
+        );
         if (finalTrivia != Doc.Null)
         {
             // even though we include the initialNewLines above, a literalLine from directives trims the hardline, so add an extra one here

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class CompilationUnit
 {
-    public static Doc Print(CompilationUnitSyntax node)
+    public static Doc Print(CompilationUnitSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>();
 
-        NamespaceLikePrinter.Print(node, docs);
+        NamespaceLikePrinter.Print(node, docs, context);
 
-        var finalTrivia = Token.PrintLeadingTriviaWithNewLines(node.EndOfFileToken.LeadingTrivia);
+        var finalTrivia = Token.PrintLeadingTriviaWithNewLines(node.EndOfFileToken.LeadingTrivia, context);
         if (finalTrivia != Doc.Null)
         {
             // even though we include the initialNewLines above, a literalLine from directives trims the hardline, so add an extra one here

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalAccessExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalAccessExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ConditionalAccessExpression
 {
-    public static Doc Print(ConditionalAccessExpressionSyntax node)
+    public static Doc Print(ConditionalAccessExpressionSyntax node, FormattingContext context)
     {
-        return InvocationExpression.PrintMemberChain(node);
+        return InvocationExpression.PrintMemberChain(node, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
@@ -20,7 +20,10 @@ internal static class ConditionalExpression
             node.Parent is ReturnStatementSyntax
             && node.Condition is BinaryExpressionSyntax or IsPatternExpressionSyntax
                 ? Doc.Indent(
-                      Doc.Group(Doc.IfBreak(Doc.SoftLine, Doc.Null), Node.Print(node.Condition, context))
+                      Doc.Group(
+                          Doc.IfBreak(Doc.SoftLine, Doc.Null),
+                          Node.Print(node.Condition, context)
+                      )
                   )
                 : Node.Print(node.Condition, context),
             node.Parent is ConditionalExpressionSyntax or ArgumentSyntax or ReturnStatementSyntax

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
@@ -7,11 +7,11 @@ internal static class ConditionalExpression
         Doc[] innerContents =
         {
             Doc.Line,
-            Token.PrintWithSuffix(node.QuestionToken, " "),
-            Doc.Concat(Node.Print(node.WhenTrue)),
+            Token.PrintWithSuffix(node.QuestionToken, " ", context),
+            Doc.Concat(Node.Print(node.WhenTrue, context)),
             Doc.Line,
-            Token.PrintWithSuffix(node.ColonToken, " "),
-            Doc.Concat(Node.Print(node.WhenFalse))
+            Token.PrintWithSuffix(node.ColonToken, " ", context),
+            Doc.Concat(Node.Print(node.WhenFalse, context))
         };
 
         Doc[] outerContents =

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConditionalExpression.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ConditionalExpression
 {
-    public static Doc Print(ConditionalExpressionSyntax node)
+    public static Doc Print(ConditionalExpressionSyntax node, FormattingContext context)
     {
         Doc[] innerContents =
         {
@@ -20,9 +20,9 @@ internal static class ConditionalExpression
             node.Parent is ReturnStatementSyntax
             && node.Condition is BinaryExpressionSyntax or IsPatternExpressionSyntax
                 ? Doc.Indent(
-                      Doc.Group(Doc.IfBreak(Doc.SoftLine, Doc.Null), Node.Print(node.Condition))
+                      Doc.Group(Doc.IfBreak(Doc.SoftLine, Doc.Null), Node.Print(node.Condition, context))
                   )
-                : Node.Print(node.Condition),
+                : Node.Print(node.Condition, context),
             node.Parent is ConditionalExpressionSyntax or ArgumentSyntax or ReturnStatementSyntax
             || node.Condition is InvocationExpressionSyntax
                 ? Doc.Indent(innerContents)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstantPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstantPattern.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ConstantPattern
 {
-    public static Doc Print(ConstantPatternSyntax node)
+    public static Doc Print(ConstantPatternSyntax node, FormattingContext context)
     {
-        return Node.Print(node.Expression);
+        return Node.Print(node.Expression, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ConstructorConstraint.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ConstructorConstraint
 {
-    public static Doc Print(ConstructorConstraintSyntax node)
+    public static Doc Print(ConstructorConstraintSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.NewKeyword),
-            Token.Print(node.OpenParenToken),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.NewKeyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ContinueStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ContinueStatement.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ContinueStatement
 {
-    public static Doc Print(ContinueStatementSyntax node)
+    public static Doc Print(ContinueStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.Print(node.ContinueKeyword),
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.ContinueKeyword, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationExpression.cs
@@ -4,6 +4,10 @@ internal static class DeclarationExpression
 {
     public static Doc Print(DeclarationExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Type, context), " ", Node.Print(node.Designation, context));
+        return Doc.Concat(
+            Node.Print(node.Type, context),
+            " ",
+            Node.Print(node.Designation, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DeclarationExpression
 {
-    public static Doc Print(DeclarationExpressionSyntax node)
+    public static Doc Print(DeclarationExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Type), " ", Node.Print(node.Designation));
+        return Doc.Concat(Node.Print(node.Type, context), " ", Node.Print(node.Designation, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DeclarationPattern.cs
@@ -2,8 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DeclarationPattern
 {
-    public static Doc Print(DeclarationPatternSyntax node)
+    public static Doc Print(DeclarationPatternSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Type), " ", Node.Print(node.Designation));
+        return Doc.Concat(
+            Node.Print(node.Type, context),
+            " ",
+            Node.Print(node.Designation, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultConstraint.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DefaultConstraint
 {
-    public static Doc Print(DefaultConstraintSyntax node)
+    public static Doc Print(DefaultConstraintSyntax node, FormattingContext context)
     {
-        return Token.Print(node.DefaultKeyword);
+        return Token.Print(node.DefaultKeyword, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DefaultExpression
 {
-    public static Doc Print(DefaultExpressionSyntax node)
+    public static Doc Print(DefaultExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Type),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Type, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultSwitchLabel.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DefaultSwitchLabel.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DefaultSwitchLabel
 {
-    public static Doc Print(DefaultSwitchLabelSyntax node)
+    public static Doc Print(DefaultSwitchLabelSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.Print(node.Keyword),
-            Token.Print(node.ColonToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.ColonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
@@ -2,24 +2,24 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DelegateDeclaration
 {
-    public static Doc Print(DelegateDeclarationSyntax node)
+    public static Doc Print(DelegateDeclarationSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            Token.PrintWithSuffix(node.DelegateKeyword, " "),
-            Node.Print(node.ReturnType),
-            { " ", Token.Print(node.Identifier) }
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Token.PrintWithSuffix(node.DelegateKeyword, " ", context),
+            Node.Print(node.ReturnType, context),
+            { " ", Token.Print(node.Identifier, context) }
         };
         if (node.TypeParameterList != null)
         {
-            docs.Add(Node.Print(node.TypeParameterList));
+            docs.Add(Node.Print(node.TypeParameterList, context));
         }
         docs.Add(
-            Node.Print(node.ParameterList),
-            ConstraintClauses.Print(node.ConstraintClauses),
-            Token.Print(node.SemicolonToken)
+            Node.Print(node.ParameterList, context),
+            ConstraintClauses.Print(node.ConstraintClauses, context),
+            Token.Print(node.SemicolonToken, context)
         );
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DiscardDesignation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DiscardDesignation.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DiscardDesignation
 {
-    public static Doc Print(DiscardDesignationSyntax node)
+    public static Doc Print(DiscardDesignationSyntax node, FormattingContext context)
     {
-        return Token.Print(node.UnderscoreToken);
+        return Token.Print(node.UnderscoreToken, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DiscardPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DiscardPattern.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DiscardPattern
 {
-    public static Doc Print(DiscardPatternSyntax node)
+    public static Doc Print(DiscardPatternSyntax node, FormattingContext context)
     {
-        return Token.Print(node.UnderscoreToken);
+        return Token.Print(node.UnderscoreToken, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
@@ -8,7 +8,8 @@ internal static class DoStatement
             ExtraNewLines.Print(node),
             Token.PrintWithSuffix(
                 node.DoKeyword,
-                node.Statement is not BlockSyntax ? " " : Doc.Null, context
+                node.Statement is not BlockSyntax ? " " : Doc.Null,
+                context
             ),
             Node.Print(node.Statement, context),
             node.Statement is BlockSyntax ? " " : Doc.HardLine,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DoStatement.cs
@@ -2,21 +2,21 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class DoStatement
 {
-    public static Doc Print(DoStatementSyntax node)
+    public static Doc Print(DoStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
             Token.PrintWithSuffix(
                 node.DoKeyword,
-                node.Statement is not BlockSyntax ? " " : Doc.Null
+                node.Statement is not BlockSyntax ? " " : Doc.Null, context
             ),
-            Node.Print(node.Statement),
+            Node.Print(node.Statement, context),
             node.Statement is BlockSyntax ? " " : Doc.HardLine,
-            Token.PrintWithSuffix(node.WhileKeyword, " "),
-            Token.Print(node.OpenParenToken),
-            Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition)), Doc.SoftLine),
-            Token.Print(node.CloseParenToken),
-            Token.Print(node.SemicolonToken)
+            Token.PrintWithSuffix(node.WhileKeyword, " ", context),
+            Token.Print(node.OpenParenToken, context),
+            Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition, context)), Doc.SoftLine),
+            Token.Print(node.CloseParenToken, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElementAccessExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElementAccessExpression.cs
@@ -2,8 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ElementAccessExpression
 {
-    public static Doc Print(ElementAccessExpressionSyntax node)
+    public static Doc Print(ElementAccessExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Expression), Node.Print(node.ArgumentList));
+        return Doc.Concat(
+            Node.Print(node.Expression, context),
+            Node.Print(node.ArgumentList, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElementBindingExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElementBindingExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ElementBindingExpression
 {
-    public static Doc Print(ElementBindingExpressionSyntax node)
+    public static Doc Print(ElementBindingExpressionSyntax node, FormattingContext context)
     {
-        return Node.Print(node.ArgumentList);
+        return Node.Print(node.ArgumentList, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElseClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ElseClause.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ElseClause
 {
-    public static Doc Print(ElseClauseSyntax node)
+    public static Doc Print(ElseClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.ElseKeyword),
+            Token.Print(node.ElseKeyword, context),
             node.Statement is IfStatementSyntax ifStatementSyntax
-              ? Doc.Concat(" ", IfStatement.Print(ifStatementSyntax))
-              : OptionalBraces.Print(node.Statement)
+              ? Doc.Concat(" ", IfStatement.Print(ifStatementSyntax, context))
+              : OptionalBraces.Print(node.Statement, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EmptyStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EmptyStatement.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class EmptyStatement
 {
-    public static Doc Print(EmptyStatementSyntax node)
+    public static Doc Print(EmptyStatementSyntax node, FormattingContext context)
     {
-        return Token.Print(node.SemicolonToken);
+        return Token.Print(node.SemicolonToken, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EnumMemberDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EnumMemberDeclaration.cs
@@ -2,17 +2,17 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class EnumMemberDeclaration
 {
-    public static Doc Print(EnumMemberDeclarationSyntax node)
+    public static Doc Print(EnumMemberDeclarationSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            Token.Print(node.Identifier)
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Token.Print(node.Identifier, context)
         };
         if (node.EqualsValue != null)
         {
-            docs.Add(EqualsValueClause.Print(node.EqualsValue));
+            docs.Add(EqualsValueClause.Print(node.EqualsValue, context));
         }
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EqualsValueClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EqualsValueClause.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class EqualsValueClause
 {
-    public static Doc Print(EqualsValueClauseSyntax node)
+    public static Doc Print(EqualsValueClauseSyntax node, FormattingContext context)
     {
         Doc separator = Doc.Line;
         if (node.Parent is PropertyDeclarationSyntax)
@@ -30,8 +30,8 @@ internal static class EqualsValueClause
 
         Doc result = Doc.Group(
             " ",
-            Token.PrintWithSuffix(node.EqualsToken, separator),
-            Node.Print(node.Value)
+            Token.PrintWithSuffix(node.EqualsToken, separator, context),
+            Node.Print(node.Value, context)
         );
 
         if (separator is LineDoc)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExpressionStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExpressionStatement.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ExpressionStatement
 {
-    public static Doc Print(ExpressionStatementSyntax node)
+    public static Doc Print(ExpressionStatementSyntax node, FormattingContext context)
     {
         return Doc.Group(
             ExtraNewLines.Print(node),
-            Node.Print(node.Expression),
-            Token.Print(node.SemicolonToken)
+            Node.Print(node.Expression, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExternAliasDirective.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ExternAliasDirective.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ExternAliasDirective
 {
-    public static Doc Print(ExternAliasDirectiveSyntax node)
+    public static Doc Print(ExternAliasDirectiveSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.ExternKeyword, " "),
-            Token.PrintWithSuffix(node.AliasKeyword, " "),
-            Token.Print(node.Identifier),
-            Token.Print(node.SemicolonToken)
+            Token.PrintWithSuffix(node.ExternKeyword, " ", context),
+            Token.PrintWithSuffix(node.AliasKeyword, " ", context),
+            Token.Print(node.Identifier, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FileScopedNamespaceDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FileScopedNamespaceDeclaration.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class FileScopedNamespaceDeclaration
 {
-    public static Doc Print(FileScopedNamespaceDeclarationSyntax node)
+    public static Doc Print(FileScopedNamespaceDeclarationSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            Token.Print(node.NamespaceKeyword),
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Token.Print(node.NamespaceKeyword, context),
             " ",
-            Node.Print(node.Name),
-            Token.Print(node.SemicolonToken),
+            Node.Print(node.Name, context),
+            Token.Print(node.SemicolonToken, context),
             Doc.HardLine
         };
 
-        NamespaceLikePrinter.Print(node, docs);
+        NamespaceLikePrinter.Print(node, docs, context);
 
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FinallyClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FinallyClause.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class FinallyClause
 {
-    public static Doc Print(FinallyClauseSyntax node)
+    public static Doc Print(FinallyClauseSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.FinallyKeyword), Node.Print(node.Block));
+        return Doc.Concat(Token.Print(node.FinallyKeyword, context), Node.Print(node.Block, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FinallyClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FinallyClause.cs
@@ -4,6 +4,9 @@ internal static class FinallyClause
 {
     public static Doc Print(FinallyClauseSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.FinallyKeyword, context), Node.Print(node.Block, context));
+        return Doc.Concat(
+            Token.Print(node.FinallyKeyword, context),
+            Node.Print(node.Block, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FixedStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FixedStatement.cs
@@ -10,7 +10,10 @@ internal static class FixedStatement
                 Token.Print(node.FixedKeyword, context),
                 " ",
                 Token.Print(node.OpenParenToken, context),
-                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Declaration, context)), Doc.SoftLine),
+                Doc.Group(
+                    Doc.Indent(Doc.SoftLine, Node.Print(node.Declaration, context)),
+                    Doc.SoftLine
+                ),
                 Token.Print(node.CloseParenToken, context),
                 Doc.IfBreak(Doc.Null, Doc.SoftLine)
             ),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FixedStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FixedStatement.cs
@@ -2,23 +2,23 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class FixedStatement
 {
-    public static Doc Print(FixedStatementSyntax node)
+    public static Doc Print(FixedStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
             Doc.Group(
-                Token.Print(node.FixedKeyword),
+                Token.Print(node.FixedKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
-                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Declaration)), Doc.SoftLine),
-                Token.Print(node.CloseParenToken),
+                Token.Print(node.OpenParenToken, context),
+                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Declaration, context)), Doc.SoftLine),
+                Token.Print(node.CloseParenToken, context),
                 Doc.IfBreak(Doc.Null, Doc.SoftLine)
             ),
             node.Statement is BlockSyntax blockSyntax
-              ? Block.Print(blockSyntax)
+              ? Block.Print(blockSyntax, context)
               : Doc.IndentIf(
                     node.Statement is not FixedStatementSyntax,
-                    Doc.Concat(Doc.HardLine, Node.Print(node.Statement))
+                    Doc.Concat(Doc.HardLine, Node.Print(node.Statement, context))
                 )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
@@ -2,41 +2,41 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ForStatement
 {
-    public static Doc Print(ForStatementSyntax node)
+    public static Doc Print(ForStatementSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
             ExtraNewLines.Print(node),
             Doc.Group(
-                Token.Print(node.ForKeyword),
+                Token.Print(node.ForKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
+                Token.Print(node.OpenParenToken, context),
                 Doc.Group(
                     Doc.Indent(
                         Doc.SoftLine,
                         Doc.Group(
                             node.Declaration != null
-                              ? VariableDeclaration.Print(node.Declaration)
+                              ? VariableDeclaration.Print(node.Declaration, context)
                               : Doc.Null,
-                            SeparatedSyntaxList.Print(node.Initializers, Node.Print, " "),
-                            Token.Print(node.FirstSemicolonToken)
+                            SeparatedSyntaxList.Print(node.Initializers, Node.Print, " ", context),
+                            Token.Print(node.FirstSemicolonToken, context)
                         ),
                         node.Condition != null
-                          ? Doc.Concat(Doc.Line, Node.Print(node.Condition))
+                          ? Doc.Concat(Doc.Line, Node.Print(node.Condition, context))
                           : Doc.Line,
-                        Token.Print(node.SecondSemicolonToken),
+                        Token.Print(node.SecondSemicolonToken, context),
                         Doc.Line,
                         Doc.Group(
                             Doc.Indent(
-                                SeparatedSyntaxList.Print(node.Incrementors, Node.Print, Doc.Line)
+                                SeparatedSyntaxList.Print(node.Incrementors, Node.Print, Doc.Line, context)
                             )
                         )
                     ),
                     Doc.SoftLine
                 ),
-                Token.Print(node.CloseParenToken)
+                Token.Print(node.CloseParenToken, context)
             ),
-            OptionalBraces.Print(node.Statement)
+            OptionalBraces.Print(node.Statement, context)
         };
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
@@ -28,7 +28,12 @@ internal static class ForStatement
                         Doc.Line,
                         Doc.Group(
                             Doc.Indent(
-                                SeparatedSyntaxList.Print(node.Incrementors, Node.Print, Doc.Line, context)
+                                SeparatedSyntaxList.Print(
+                                    node.Incrementors,
+                                    Node.Print,
+                                    Doc.Line,
+                                    context
+                                )
                             )
                         )
                     ),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FromClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FromClause.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class FromClause
 {
-    public static Doc Print(FromClauseSyntax node)
+    public static Doc Print(FromClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.FromKeyword, " "),
-            node.Type != null ? Doc.Concat(Node.Print(node.Type), " ") : Doc.Null,
-            Token.PrintWithSuffix(node.Identifier, " "),
-            Token.PrintWithSuffix(node.InKeyword, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.FromKeyword, " ", context),
+            node.Type != null ? Doc.Concat(Node.Print(node.Type, context), " ") : Doc.Null,
+            Token.PrintWithSuffix(node.Identifier, " ", context),
+            Token.PrintWithSuffix(node.InKeyword, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FunctionPointerType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/FunctionPointerType.cs
@@ -2,47 +2,52 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class FunctionPointerType
 {
-    public static Doc Print(FunctionPointerTypeSyntax node)
+    public static Doc Print(FunctionPointerTypeSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.DelegateKeyword),
-            Token.PrintWithSuffix(node.AsteriskToken, " "),
+            Token.Print(node.DelegateKeyword, context),
+            Token.PrintWithSuffix(node.AsteriskToken, " ", context),
             node.CallingConvention != null
-              ? PrintCallingConvention(node.CallingConvention)
+              ? PrintCallingConvention(node.CallingConvention, context)
               : Doc.Null,
-            Token.Print(node.ParameterList.LessThanToken),
+            Token.Print(node.ParameterList.LessThanToken, context),
             Doc.Indent(
                 Doc.Group(
                     Doc.SoftLine,
                     SeparatedSyntaxList.Print(
                         node.ParameterList.Parameters,
-                        o =>
+                        (o, _) =>
                             Doc.Concat(
-                                AttributeLists.Print(o, o.AttributeLists),
-                                Modifiers.Print(o.Modifiers),
-                                Node.Print(o.Type)
+                                AttributeLists.Print(o, o.AttributeLists, context),
+                                Modifiers.Print(o.Modifiers, context),
+                                Node.Print(o.Type, context)
                             ),
-                        Doc.Line
+                        Doc.Line,
+                        context
                     )
                 )
             ),
-            Token.Print(node.ParameterList.GreaterThanToken)
+            Token.Print(node.ParameterList.GreaterThanToken, context)
         );
     }
 
-    private static Doc PrintCallingConvention(FunctionPointerCallingConventionSyntax node)
+    private static Doc PrintCallingConvention(
+        FunctionPointerCallingConventionSyntax node,
+        FormattingContext context
+    )
     {
         return Doc.Concat(
-            Token.Print(node.ManagedOrUnmanagedKeyword),
+            Token.Print(node.ManagedOrUnmanagedKeyword, context),
             node.UnmanagedCallingConventionList != null
               ? Doc.Concat(
-                    Token.Print(node.UnmanagedCallingConventionList.OpenBracketToken),
+                    Token.Print(node.UnmanagedCallingConventionList.OpenBracketToken, context),
                     SeparatedSyntaxList.Print(
                         node.UnmanagedCallingConventionList.CallingConventions,
-                        o => Token.Print(o.Name),
-                        " "
+                        (o, _) => Token.Print(o.Name, context),
+                        " ",
+                        context
                     ),
-                    Token.Print(node.UnmanagedCallingConventionList.CloseBracketToken)
+                    Token.Print(node.UnmanagedCallingConventionList.CloseBracketToken, context)
                 )
               : Doc.Null
         );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GenericName.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GenericName.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class GenericName
 {
-    public static Doc Print(GenericNameSyntax node)
+    public static Doc Print(GenericNameSyntax node, FormattingContext context)
     {
-        return Doc.Group(Token.Print(node.Identifier), Node.Print(node.TypeArgumentList));
+        return Doc.Group(Token.Print(node.Identifier, context), Node.Print(node.TypeArgumentList, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GenericName.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GenericName.cs
@@ -4,6 +4,9 @@ internal static class GenericName
 {
     public static Doc Print(GenericNameSyntax node, FormattingContext context)
     {
-        return Doc.Group(Token.Print(node.Identifier, context), Node.Print(node.TypeArgumentList, context));
+        return Doc.Group(
+            Token.Print(node.Identifier, context),
+            Node.Print(node.TypeArgumentList, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GlobalStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GlobalStatement.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class GlobalStatement
 {
-    public static Doc Print(GlobalStatementSyntax node)
+    public static Doc Print(GlobalStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            Node.Print(node.Statement)
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Node.Print(node.Statement, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GotoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GotoStatement.cs
@@ -2,17 +2,17 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class GotoStatement
 {
-    public static Doc Print(GotoStatementSyntax node)
+    public static Doc Print(GotoStatementSyntax node, FormattingContext context)
     {
         var expression =
-            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression)) : string.Empty;
+            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression, context)) : string.Empty;
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.Print(node.GotoKeyword),
+            Token.Print(node.GotoKeyword, context),
             node.CaseOrDefaultKeyword.RawSyntaxKind() != SyntaxKind.None ? " " : Doc.Null,
-            Token.Print(node.CaseOrDefaultKeyword),
+            Token.Print(node.CaseOrDefaultKeyword, context),
             expression,
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GotoStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GotoStatement.cs
@@ -5,7 +5,9 @@ internal static class GotoStatement
     public static Doc Print(GotoStatementSyntax node, FormattingContext context)
     {
         var expression =
-            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression, context)) : string.Empty;
+            node.Expression != null
+                ? Doc.Concat(" ", Node.Print(node.Expression, context))
+                : string.Empty;
         return Doc.Concat(
             ExtraNewLines.Print(node),
             Token.Print(node.GotoKeyword, context),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GroupClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/GroupClause.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class GroupClause
 {
-    public static Doc Print(GroupClauseSyntax node)
+    public static Doc Print(GroupClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.GroupKeyword, " "),
-            Node.Print(node.GroupExpression),
+            Token.PrintWithSuffix(node.GroupKeyword, " ", context),
+            Node.Print(node.GroupExpression, context),
             " ",
-            Token.PrintWithSuffix(node.ByKeyword, " "),
-            Node.Print(node.ByExpression)
+            Token.PrintWithSuffix(node.ByKeyword, " ", context),
+            Node.Print(node.ByExpression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IdentifierName.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IdentifierName.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class IdentifierName
 {
-    public static Doc Print(IdentifierNameSyntax node)
+    public static Doc Print(IdentifierNameSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Identifier);
+        return Token.Print(node.Identifier, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
@@ -15,7 +15,10 @@ internal static class IfStatement
                 Token.Print(node.IfKeyword, context),
                 " ",
                 Token.Print(node.OpenParenToken, context),
-                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition, context)), Doc.SoftLine),
+                Doc.Group(
+                    Doc.Indent(Doc.SoftLine, Node.Print(node.Condition, context)),
+                    Doc.SoftLine
+                ),
                 Token.Print(node.CloseParenToken, context)
             ),
             OptionalBraces.Print(node.Statement, context)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class IfStatement
 {
-    public static Doc Print(IfStatementSyntax node)
+    public static Doc Print(IfStatementSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>();
         if (node.Parent is not ElseClauseSyntax)
@@ -12,18 +12,18 @@ internal static class IfStatement
 
         docs.Add(
             Doc.Group(
-                Token.Print(node.IfKeyword),
+                Token.Print(node.IfKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
-                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition)), Doc.SoftLine),
-                Token.Print(node.CloseParenToken)
+                Token.Print(node.OpenParenToken, context),
+                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition, context)), Doc.SoftLine),
+                Token.Print(node.CloseParenToken, context)
             ),
-            OptionalBraces.Print(node.Statement)
+            OptionalBraces.Print(node.Statement, context)
         );
 
         if (node.Else != null)
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Else));
+            docs.Add(Doc.HardLine, Node.Print(node.Else, context));
         }
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ImplicitArrayCreationExpression
 {
-    public static Doc Print(ImplicitArrayCreationExpressionSyntax node)
+    public static Doc Print(ImplicitArrayCreationExpressionSyntax node, FormattingContext context)
     {
-        var commas = node.Commas.Select(Token.Print).ToArray();
+        var commas = node.Commas.Select(o => Token.Print(o, context)).ToArray();
         return Doc.Group(
-            Token.Print(node.NewKeyword),
-            Token.Print(node.OpenBracketToken),
+            Token.Print(node.NewKeyword, context),
+            Token.Print(node.OpenBracketToken, context),
             Doc.Concat(commas),
-            Token.Print(node.CloseBracketToken),
+            Token.Print(node.CloseBracketToken, context),
             Doc.Line,
-            InitializerExpression.Print(node.Initializer)
+            InitializerExpression.Print(node.Initializer, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitElementAccess.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitElementAccess.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ImplicitElementAccess
 {
-    public static Doc Print(ImplicitElementAccessSyntax node)
+    public static Doc Print(ImplicitElementAccessSyntax node, FormattingContext context)
     {
-        return Node.Print(node.ArgumentList);
+        return Node.Print(node.ArgumentList, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitObjectCreationExpression.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ImplicitObjectCreationExpression
 {
-    public static Doc Print(ImplicitObjectCreationExpressionSyntax node)
+    public static Doc Print(ImplicitObjectCreationExpressionSyntax node, FormattingContext context)
     {
         return ObjectCreationExpression.BreakParentIfNested(
             node,
             Doc.Group(
-                Token.Print(node.NewKeyword),
-                ArgumentList.Print(node.ArgumentList),
+                Token.Print(node.NewKeyword, context),
+                ArgumentList.Print(node.ArgumentList, context),
                 node.Initializer != null
-                  ? Doc.Concat(Doc.Line, InitializerExpression.Print(node.Initializer))
+                  ? Doc.Concat(Doc.Line, InitializerExpression.Print(node.Initializer, context))
                   : Doc.Null
             )
         );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ImplicitStackAllocArrayCreationExpression
 {
-    public static Doc Print(ImplicitStackAllocArrayCreationExpressionSyntax node)
+    public static Doc Print(ImplicitStackAllocArrayCreationExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.StackAllocKeyword),
-            Token.Print(node.OpenBracketToken),
-            Token.PrintWithSuffix(node.CloseBracketToken, " "),
-            Node.Print(node.Initializer)
+            Token.Print(node.StackAllocKeyword, context),
+            Token.Print(node.OpenBracketToken, context),
+            Token.PrintWithSuffix(node.CloseBracketToken, " ", context),
+            Node.Print(node.Initializer, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ImplicitStackAllocArrayCreationExpression.cs
@@ -2,7 +2,10 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ImplicitStackAllocArrayCreationExpression
 {
-    public static Doc Print(ImplicitStackAllocArrayCreationExpressionSyntax node, FormattingContext context)
+    public static Doc Print(
+        ImplicitStackAllocArrayCreationExpressionSyntax node,
+        FormattingContext context
+    )
     {
         return Doc.Concat(
             Token.Print(node.StackAllocKeyword, context),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IncompleteMember.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IncompleteMember.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class IncompleteMember
 {
-    public static Doc Print(IncompleteMemberSyntax node)
+    public static Doc Print(IncompleteMemberSyntax node, FormattingContext context)
     {
         return string.Empty;
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InitializerExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InitializerExpression.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class InitializerExpression
 {
-    public static Doc Print(InitializerExpressionSyntax node)
+    public static Doc Print(InitializerExpressionSyntax node, FormattingContext context)
     {
         Doc separator = node.Parent is AssignmentExpressionSyntax or EqualsValueClauseSyntax
             ? Doc.Line
@@ -13,13 +13,13 @@ internal static class InitializerExpression
 
         var result = Doc.Concat(
             separator,
-            Token.Print(node.OpenBraceToken),
+            Token.Print(node.OpenBraceToken, context),
             Doc.Indent(
                 alwaysBreak ? Doc.HardLine : Doc.Line,
                 SeparatedSyntaxList.Print(
                     node.Expressions,
                     Node.Print,
-                    alwaysBreak ? Doc.HardLine : Doc.Line
+                    alwaysBreak ? Doc.HardLine : Doc.Line, context
                 )
             ),
             node.Expressions.Any()
@@ -27,7 +27,7 @@ internal static class InitializerExpression
                   ? Doc.HardLine
                   : Doc.Line
               : Doc.Null,
-            Token.Print(node.CloseBraceToken)
+            Token.Print(node.CloseBraceToken, context)
         );
         return
             node.Parent

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InitializerExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InitializerExpression.cs
@@ -19,7 +19,8 @@ internal static class InitializerExpression
                 SeparatedSyntaxList.Print(
                     node.Expressions,
                     Node.Print,
-                    alwaysBreak ? Doc.HardLine : Doc.Line, context
+                    alwaysBreak ? Doc.HardLine : Doc.Line,
+                    context
                 )
             ),
             node.Expressions.Any()

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
@@ -4,7 +4,10 @@ internal static class InterpolatedStringExpression
 {
     public static Doc Print(InterpolatedStringExpressionSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Token.PrintWithoutLeadingTrivia(node.StringStartToken, context) };
+        var docs = new List<Doc>
+        {
+            Token.PrintWithoutLeadingTrivia(node.StringStartToken, context)
+        };
 
         docs.AddRange(node.Contents.Select(o => Node.Print(o, context)));
         docs.Add(Token.Print(node.StringEndToken, context));

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class InterpolatedStringExpression
 {
-    public static Doc Print(InterpolatedStringExpressionSyntax node)
+    public static Doc Print(InterpolatedStringExpressionSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Token.PrintWithoutLeadingTrivia(node.StringStartToken) };
+        var docs = new List<Doc> { Token.PrintWithoutLeadingTrivia(node.StringStartToken, context) };
 
-        docs.AddRange(node.Contents.Select(Node.Print));
-        docs.Add(Token.Print(node.StringEndToken));
+        docs.AddRange(node.Contents.Select(o => Node.Print(o, context)));
+        docs.Add(Token.Print(node.StringEndToken, context));
 
         return Doc.Concat(
             // pull out the leading trivia so it doesn't get forced flat
-            Token.PrintLeadingTrivia(node.StringStartToken),
+            Token.PrintLeadingTrivia(node.StringStartToken, context),
             Doc.ForceFlat(docs)
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringText.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringText.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class InterpolatedStringText
 {
-    public static Doc Print(InterpolatedStringTextSyntax node)
+    public static Doc Print(InterpolatedStringTextSyntax node, FormattingContext context)
     {
-        return Token.Print(node.TextToken);
+        return Token.Print(node.TextToken, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
@@ -4,7 +4,11 @@ internal static class Interpolation
 {
     public static Doc Print(InterpolationSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Token.Print(node.OpenBraceToken, context), Node.Print(node.Expression, context) };
+        var docs = new List<Doc>
+        {
+            Token.Print(node.OpenBraceToken, context),
+            Node.Print(node.Expression, context)
+        };
         if (node.AlignmentClause != null)
         {
             docs.Add(

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
@@ -2,25 +2,25 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class Interpolation
 {
-    public static Doc Print(InterpolationSyntax node)
+    public static Doc Print(InterpolationSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Token.Print(node.OpenBraceToken), Node.Print(node.Expression) };
+        var docs = new List<Doc> { Token.Print(node.OpenBraceToken, context), Node.Print(node.Expression, context) };
         if (node.AlignmentClause != null)
         {
             docs.Add(
-                Token.PrintWithSuffix(node.AlignmentClause.CommaToken, " "),
-                Node.Print(node.AlignmentClause.Value)
+                Token.PrintWithSuffix(node.AlignmentClause.CommaToken, " ", context),
+                Node.Print(node.AlignmentClause.Value, context)
             );
         }
         if (node.FormatClause != null)
         {
             docs.Add(
-                Token.Print(node.FormatClause.ColonToken),
-                Token.Print(node.FormatClause.FormatStringToken)
+                Token.Print(node.FormatClause.ColonToken, context),
+                Token.Print(node.FormatClause.FormatStringToken, context)
             );
         }
 
-        docs.Add(Token.Print(node.CloseBraceToken));
+        docs.Add(Token.Print(node.CloseBraceToken, context));
         return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -124,14 +124,22 @@ internal static class InvocationExpression
         }
         else if (expression is ConditionalAccessExpressionSyntax conditionalAccessExpressionSyntax)
         {
-            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.Expression, printedNodes, context);
+            FlattenAndPrintNodes(
+                conditionalAccessExpressionSyntax.Expression,
+                printedNodes,
+                context
+            );
             printedNodes.Add(
                 new PrintedNode(
                     conditionalAccessExpressionSyntax,
                     Token.Print(conditionalAccessExpressionSyntax.OperatorToken, context)
                 )
             );
-            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.WhenNotNull, printedNodes, context);
+            FlattenAndPrintNodes(
+                conditionalAccessExpressionSyntax.WhenNotNull,
+                printedNodes,
+                context
+            );
         }
         else if (
             expression is PostfixUnaryExpressionSyntax

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -11,16 +11,16 @@ internal record PrintedNode(CSharpSyntaxNode Node, Doc Doc);
 // https://github.com/prettier/prettier/pull/7889
 internal static class InvocationExpression
 {
-    public static Doc Print(InvocationExpressionSyntax node)
+    public static Doc Print(InvocationExpressionSyntax node, FormattingContext context)
     {
-        return PrintMemberChain(node);
+        return PrintMemberChain(node, context);
     }
 
-    public static Doc PrintMemberChain(ExpressionSyntax node)
+    public static Doc PrintMemberChain(ExpressionSyntax node, FormattingContext context)
     {
         var printedNodes = new List<PrintedNode>();
 
-        FlattenAndPrintNodes(node, printedNodes);
+        FlattenAndPrintNodes(node, printedNodes, context);
 
         var groups = printedNodes.Any(o => o.Node is InvocationExpressionSyntax)
           ? GroupPrintedNodesPrettierStyle(printedNodes)
@@ -75,7 +75,8 @@ internal static class InvocationExpression
 
     private static void FlattenAndPrintNodes(
         ExpressionSyntax expression,
-        List<PrintedNode> printedNodes
+        List<PrintedNode> printedNodes,
+        FormattingContext context
     )
     {
         /*
@@ -100,37 +101,37 @@ internal static class InvocationExpression
         */
         if (expression is InvocationExpressionSyntax invocationExpressionSyntax)
         {
-            FlattenAndPrintNodes(invocationExpressionSyntax.Expression, printedNodes);
+            FlattenAndPrintNodes(invocationExpressionSyntax.Expression, printedNodes, context);
             printedNodes.Add(
                 new PrintedNode(
                     invocationExpressionSyntax,
-                    ArgumentList.Print(invocationExpressionSyntax.ArgumentList)
+                    ArgumentList.Print(invocationExpressionSyntax.ArgumentList, context)
                 )
             );
         }
         else if (expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
         {
-            FlattenAndPrintNodes(memberAccessExpressionSyntax.Expression, printedNodes);
+            FlattenAndPrintNodes(memberAccessExpressionSyntax.Expression, printedNodes, context);
             printedNodes.Add(
                 new PrintedNode(
                     memberAccessExpressionSyntax,
                     Doc.Concat(
-                        Token.Print(memberAccessExpressionSyntax.OperatorToken),
-                        Node.Print(memberAccessExpressionSyntax.Name)
+                        Token.Print(memberAccessExpressionSyntax.OperatorToken, context),
+                        Node.Print(memberAccessExpressionSyntax.Name, context)
                     )
                 )
             );
         }
         else if (expression is ConditionalAccessExpressionSyntax conditionalAccessExpressionSyntax)
         {
-            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.Expression, printedNodes);
+            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.Expression, printedNodes, context);
             printedNodes.Add(
                 new PrintedNode(
                     conditionalAccessExpressionSyntax,
-                    Token.Print(conditionalAccessExpressionSyntax.OperatorToken)
+                    Token.Print(conditionalAccessExpressionSyntax.OperatorToken, context)
                 )
             );
-            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.WhenNotNull, printedNodes);
+            FlattenAndPrintNodes(conditionalAccessExpressionSyntax.WhenNotNull, printedNodes, context);
         }
         else if (
             expression is PostfixUnaryExpressionSyntax
@@ -139,17 +140,17 @@ internal static class InvocationExpression
             } postfixUnaryExpression
         )
         {
-            FlattenAndPrintNodes(postfixUnaryExpression.Operand, printedNodes);
+            FlattenAndPrintNodes(postfixUnaryExpression.Operand, printedNodes, context);
             printedNodes.Add(
                 new PrintedNode(
                     postfixUnaryExpression,
-                    Token.Print(postfixUnaryExpression.OperatorToken)
+                    Token.Print(postfixUnaryExpression.OperatorToken, context)
                 )
             );
         }
         else
         {
-            printedNodes.Add(new PrintedNode(expression, Node.Print(expression)));
+            printedNodes.Add(new PrintedNode(expression, Node.Print(expression, context)));
         }
     }
 

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
@@ -2,47 +2,47 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class IsPatternExpression
 {
-    public static Doc Print(IsPatternExpressionSyntax node)
+    public static Doc Print(IsPatternExpressionSyntax node, FormattingContext context)
     {
         if (node.Parent is not (IfStatementSyntax or ParenthesizedExpressionSyntax))
         {
             return Doc.Group(
-                Node.Print(node.Expression),
-                Doc.Indent(Doc.Line, Token.Print(node.IsKeyword), " ", Node.Print(node.Pattern))
+                Node.Print(node.Expression, context),
+                Doc.Indent(Doc.Line, Token.Print(node.IsKeyword, context), " ", Node.Print(node.Pattern, context))
             );
         }
 
         if (node.Pattern is not RecursivePatternSyntax recursivePattern)
         {
             return Doc.Group(
-                Node.Print(node.Expression),
+                Node.Print(node.Expression, context),
                 Doc.Line,
-                Token.Print(node.IsKeyword),
+                Token.Print(node.IsKeyword, context),
                 " ",
-                Node.Print(node.Pattern)
+                Node.Print(node.Pattern, context)
             );
         }
 
         if (recursivePattern.Type is null)
         {
             return Doc.Group(
-                Node.Print(node.Expression),
+                Node.Print(node.Expression, context),
                 " ",
-                Token.Print(node.IsKeyword),
+                Token.Print(node.IsKeyword, context),
                 Doc.Line,
-                RecursivePattern.Print(recursivePattern)
+                RecursivePattern.Print(recursivePattern, context)
             );
         }
 
         return Doc.Group(
             Doc.Group(
-                Node.Print(node.Expression),
+                Node.Print(node.Expression, context),
                 Doc.Line,
-                Token.Print(node.IsKeyword),
+                Token.Print(node.IsKeyword, context),
                 " ",
-                Node.Print(recursivePattern.Type)
+                Node.Print(recursivePattern.Type, context)
             ),
-            RecursivePattern.PrintWithOutType(recursivePattern)
+            RecursivePattern.PrintWithOutType(recursivePattern, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IsPatternExpression.cs
@@ -8,7 +8,12 @@ internal static class IsPatternExpression
         {
             return Doc.Group(
                 Node.Print(node.Expression, context),
-                Doc.Indent(Doc.Line, Token.Print(node.IsKeyword, context), " ", Node.Print(node.Pattern, context))
+                Doc.Indent(
+                    Doc.Line,
+                    Token.Print(node.IsKeyword, context),
+                    " ",
+                    Node.Print(node.Pattern, context)
+                )
             );
         }
 

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/JoinClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/JoinClause.cs
@@ -2,26 +2,26 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class JoinClause
 {
-    public static Doc Print(JoinClauseSyntax node)
+    public static Doc Print(JoinClauseSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.PrintWithSuffix(node.JoinKeyword, " "),
-            node.Type != null ? Doc.Concat(Node.Print(node.Type), " ") : Doc.Null,
-            Token.PrintWithSuffix(node.Identifier, " "),
-            Token.PrintWithSuffix(node.InKeyword, " "),
-            Node.Print(node.InExpression),
+            Token.PrintWithSuffix(node.JoinKeyword, " ", context),
+            node.Type != null ? Doc.Concat(Node.Print(node.Type, context), " ") : Doc.Null,
+            Token.PrintWithSuffix(node.Identifier, " ", context),
+            Token.PrintWithSuffix(node.InKeyword, " ", context),
+            Node.Print(node.InExpression, context),
             Doc.Indent(
                 Doc.Line,
-                Token.PrintWithSuffix(node.OnKeyword, " "),
-                Node.Print(node.LeftExpression),
+                Token.PrintWithSuffix(node.OnKeyword, " ", context),
+                Node.Print(node.LeftExpression, context),
                 " ",
-                Token.PrintWithSuffix(node.EqualsKeyword, " "),
-                Node.Print(node.RightExpression),
+                Token.PrintWithSuffix(node.EqualsKeyword, " ", context),
+                Node.Print(node.RightExpression, context),
                 node.Into != null
                   ? Doc.Concat(
                         Doc.Line,
-                        Token.PrintWithSuffix(node.Into.IntoKeyword, " "),
-                        Token.Print(node.Into.Identifier)
+                        Token.PrintWithSuffix(node.Into.IntoKeyword, " ", context),
+                        Token.Print(node.Into.Identifier, context)
                     )
                   : Doc.Null
             )

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LabeledStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LabeledStatement.cs
@@ -2,22 +2,22 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LabeledStatement
 {
-    public static Doc Print(LabeledStatementSyntax node)
+    public static Doc Print(LabeledStatementSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
             ExtraNewLines.Print(node),
-            AttributeLists.Print(node, node.AttributeLists),
-            Token.Print(node.Identifier),
-            Token.Print(node.ColonToken)
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Token.Print(node.Identifier, context),
+            Token.Print(node.ColonToken, context)
         };
         if (node.Statement is BlockSyntax blockSyntax)
         {
-            docs.Add(Block.Print(blockSyntax));
+            docs.Add(Block.Print(blockSyntax, context));
         }
         else
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Statement));
+            docs.Add(Doc.HardLine, Node.Print(node.Statement, context));
         }
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LetClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LetClause.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LetClause
 {
-    public static Doc Print(LetClauseSyntax node)
+    public static Doc Print(LetClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.LetKeyword, " "),
-            Token.PrintWithSuffix(node.Identifier, " "),
-            Token.PrintWithSuffix(node.EqualsToken, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.LetKeyword, " ", context),
+            Token.PrintWithSuffix(node.Identifier, " ", context),
+            Token.PrintWithSuffix(node.EqualsToken, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LiteralExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LiteralExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LiteralExpression
 {
-    public static Doc Print(LiteralExpressionSyntax node)
+    public static Doc Print(LiteralExpressionSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Token);
+        return Token.Print(node.Token, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalDeclarationStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalDeclarationStatement.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LocalDeclarationStatement
 {
-    public static Doc Print(LocalDeclarationStatementSyntax node)
+    public static Doc Print(LocalDeclarationStatementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.AwaitKeyword, " "),
-            Token.PrintWithSuffix(node.UsingKeyword, " "),
-            Modifiers.Print(node.Modifiers),
-            VariableDeclaration.Print(node.Declaration),
-            Token.Print(node.SemicolonToken)
+            Token.PrintWithSuffix(node.AwaitKeyword, " ", context),
+            Token.PrintWithSuffix(node.UsingKeyword, " ", context),
+            Modifiers.Print(node.Modifiers, context),
+            VariableDeclaration.Print(node.Declaration, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalFunctionStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LocalFunctionStatement.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LocalFunctionStatement
 {
-    public static Doc Print(LocalFunctionStatementSyntax node)
+    public static Doc Print(LocalFunctionStatementSyntax node, FormattingContext context)
     {
-        return BaseMethodDeclaration.Print(node);
+        return BaseMethodDeclaration.Print(node, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LockStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LockStatement.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class LockStatement
 {
-    public static Doc Print(LockStatementSyntax node)
+    public static Doc Print(LockStatementSyntax node, FormattingContext context)
     {
-        var statement = Node.Print(node.Statement);
+        var statement = Node.Print(node.Statement, context);
 
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.LockKeyword, " "),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Expression),
-            Token.Print(node.CloseParenToken),
+            Token.PrintWithSuffix(node.LockKeyword, " ", context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Expression, context),
+            Token.Print(node.CloseParenToken, context),
             node.Statement is BlockSyntax ? statement : Doc.Indent(Doc.HardLine, statement)
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MakeRefExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MakeRefExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class MakeRefExpression
 {
-    public static Doc Print(MakeRefExpressionSyntax node)
+    public static Doc Print(MakeRefExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Expression),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Expression, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MemberAccessExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MemberAccessExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class MemberAccessExpression
 {
-    public static Doc Print(MemberAccessExpressionSyntax node)
+    public static Doc Print(MemberAccessExpressionSyntax node, FormattingContext context)
     {
-        return InvocationExpression.PrintMemberChain(node);
+        return InvocationExpression.PrintMemberChain(node, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MemberBindingExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/MemberBindingExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class MemberBindingExpression
 {
-    public static Doc Print(MemberBindingExpressionSyntax node)
+    public static Doc Print(MemberBindingExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.OperatorToken), Node.Print(node.Name));
+        return Doc.Concat(Token.Print(node.OperatorToken, context), Node.Print(node.Name, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameEquals.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameEquals.cs
@@ -4,6 +4,10 @@ internal static class NameEquals
 {
     public static Doc Print(NameEqualsSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Name, context), " ", Token.PrintWithSuffix(node.EqualsToken, " ", context));
+        return Doc.Concat(
+            Node.Print(node.Name, context),
+            " ",
+            Token.PrintWithSuffix(node.EqualsToken, " ", context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameEquals.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NameEquals.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class NameEquals
 {
-    public static Doc Print(NameEqualsSyntax node)
+    public static Doc Print(NameEqualsSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Name), " ", Token.PrintWithSuffix(node.EqualsToken, " "));
+        return Doc.Concat(Node.Print(node.Name, context), " ", Token.PrintWithSuffix(node.EqualsToken, " ", context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NamespaceDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NamespaceDeclaration.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class NamespaceDeclaration
 {
-    public static Doc Print(NamespaceDeclarationSyntax node)
+    public static Doc Print(NamespaceDeclarationSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            Token.Print(node.NamespaceKeyword),
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Token.Print(node.NamespaceKeyword, context),
             " ",
-            Node.Print(node.Name)
+            Node.Print(node.Name, context)
         };
 
         var innerDocs = new List<Doc>();
@@ -20,7 +20,7 @@ internal static class NamespaceDeclaration
         if (hasMembers || hasUsing || hasExterns)
         {
             innerDocs.Add(Doc.HardLine);
-            NamespaceLikePrinter.Print(node, innerDocs);
+            NamespaceLikePrinter.Print(node, innerDocs, context);
         }
         else
         {
@@ -32,11 +32,11 @@ internal static class NamespaceDeclaration
         docs.Add(
             Doc.Group(
                 Doc.Line,
-                Token.Print(node.OpenBraceToken),
+                Token.Print(node.OpenBraceToken, context),
                 Doc.Indent(innerDocs),
                 hasMembers || hasUsing || hasExterns ? Doc.HardLine : Doc.Null,
-                Token.Print(node.CloseBraceToken),
-                Token.Print(node.SemicolonToken)
+                Token.Print(node.CloseBraceToken, context),
+                Token.Print(node.SemicolonToken, context)
             )
         );
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NullableType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NullableType.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class NullableType
 {
-    public static Doc Print(NullableTypeSyntax node)
+    public static Doc Print(NullableTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.ElementType), Token.Print(node.QuestionToken));
+        return Doc.Concat(Node.Print(node.ElementType, context), Token.Print(node.QuestionToken, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NullableType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NullableType.cs
@@ -4,6 +4,9 @@ internal static class NullableType
 {
     public static Doc Print(NullableTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.ElementType, context), Token.Print(node.QuestionToken, context));
+        return Doc.Concat(
+            Node.Print(node.ElementType, context),
+            Token.Print(node.QuestionToken, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
@@ -14,7 +14,8 @@ internal static class ObjectCreationExpression
                         ArgumentListLike.Print(
                             node.ArgumentList.OpenParenToken,
                             node.ArgumentList.Arguments,
-                            node.ArgumentList.CloseParenToken, context
+                            node.ArgumentList.CloseParenToken,
+                            context
                         )
                     )
                   : Doc.Null,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ObjectCreationExpression.cs
@@ -2,24 +2,24 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ObjectCreationExpression
 {
-    public static Doc Print(ObjectCreationExpressionSyntax node)
+    public static Doc Print(ObjectCreationExpressionSyntax node, FormattingContext context)
     {
         return BreakParentIfNested(
             node,
             Doc.Group(
-                Token.PrintWithSuffix(node.NewKeyword, " "),
-                Node.Print(node.Type),
+                Token.PrintWithSuffix(node.NewKeyword, " ", context),
+                Node.Print(node.Type, context),
                 node.ArgumentList != null
                   ? Doc.Group(
                         ArgumentListLike.Print(
                             node.ArgumentList.OpenParenToken,
                             node.ArgumentList.Arguments,
-                            node.ArgumentList.CloseParenToken
+                            node.ArgumentList.CloseParenToken, context
                         )
                     )
                   : Doc.Null,
                 node.Initializer != null
-                  ? Doc.Concat(Doc.Line, InitializerExpression.Print(node.Initializer))
+                  ? Doc.Concat(Doc.Line, InitializerExpression.Print(node.Initializer, context))
                   : Doc.Null
             )
         );

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OmittedArraySizeExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OmittedArraySizeExpression.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class OmittedArraySizeExpression
 {
-    public static Doc Print(OmittedArraySizeExpressionSyntax node)
+    public static Doc Print(OmittedArraySizeExpressionSyntax node, FormattingContext context)
     {
         return Doc.Null;
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OmittedTypeArgument.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OmittedTypeArgument.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class OmittedTypeArgument
 {
-    public static Doc Print(OmittedTypeArgumentSyntax node)
+    public static Doc Print(OmittedTypeArgumentSyntax node, FormattingContext context)
     {
         return Doc.Null;
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
@@ -2,22 +2,22 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class OrderByClause
 {
-    public static Doc Print(OrderByClauseSyntax node)
+    public static Doc Print(OrderByClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.OrderByKeyword),
+            Token.Print(node.OrderByKeyword, context),
             SeparatedSyntaxList.Print(
                 node.Orderings,
-                orderingNode =>
+                (orderingNode, _) =>
                     Doc.Concat(
                         " ",
-                        Node.Print(orderingNode.Expression),
+                        Node.Print(orderingNode.Expression, context),
                         string.IsNullOrEmpty(orderingNode.AscendingOrDescendingKeyword.Text)
                           ? Doc.Null
                           : " ",
-                        Token.Print(orderingNode.AscendingOrDescendingKeyword)
+                        Token.Print(orderingNode.AscendingOrDescendingKeyword, context)
                     ),
-                Doc.Null
+                Doc.Null, context
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/OrderByClause.cs
@@ -17,7 +17,8 @@ internal static class OrderByClause
                           : " ",
                         Token.Print(orderingNode.AscendingOrDescendingKeyword, context)
                     ),
-                Doc.Null, context
+                Doc.Null,
+                context
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class Parameter
 {
-    public static Doc Print(ParameterSyntax node)
+    public static Doc Print(ParameterSyntax node, FormattingContext context)
     {
         var hasAttribute = node.AttributeLists.Any();
         var groupId = hasAttribute ? Guid.NewGuid().ToString() : string.Empty;
@@ -10,24 +10,24 @@ internal static class Parameter
 
         if (hasAttribute)
         {
-            docs.Add(AttributeLists.Print(node, node.AttributeLists));
+            docs.Add(AttributeLists.Print(node, node.AttributeLists, context));
             docs.Add(Doc.IndentIfBreak(Doc.Line, groupId));
         }
 
         if (node.Modifiers.Any())
         {
-            docs.Add(Modifiers.Print(node.Modifiers));
+            docs.Add(Modifiers.Print(node.Modifiers, context));
         }
 
         if (node.Type != null)
         {
-            docs.Add(Node.Print(node.Type), " ");
+            docs.Add(Node.Print(node.Type, context), " ");
         }
 
-        docs.Add(Token.Print(node.Identifier));
+        docs.Add(Token.Print(node.Identifier, context));
         if (node.Default != null)
         {
-            docs.Add(EqualsValueClause.Print(node.Default));
+            docs.Add(EqualsValueClause.Print(node.Default, context));
         }
 
         return hasAttribute

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ParameterList
 {
-    public static Doc Print(ParameterListSyntax node)
+    public static Doc Print(ParameterListSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.OpenParenToken),
+            Token.Print(node.OpenParenToken, context),
             node.Parameters.Count > 0
               ? Doc.Concat(
                     Doc.Indent(
                         Doc.SoftLine,
-                        SeparatedSyntaxList.Print(node.Parameters, Parameter.Print, Doc.Line)
+                        SeparatedSyntaxList.Print(node.Parameters, Parameter.Print, Doc.Line, context)
                     ),
                     Doc.SoftLine
                 )
               : Doc.Null,
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParameterList.cs
@@ -10,7 +10,12 @@ internal static class ParameterList
               ? Doc.Concat(
                     Doc.Indent(
                         Doc.SoftLine,
-                        SeparatedSyntaxList.Print(node.Parameters, Parameter.Print, Doc.Line, context)
+                        SeparatedSyntaxList.Print(
+                            node.Parameters,
+                            Parameter.Print,
+                            Doc.Line,
+                            context
+                        )
                     ),
                     Doc.SoftLine
                 )

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ParenthesizedExpression
 {
-    public static Doc Print(ParenthesizedExpressionSyntax node)
+    public static Doc Print(ParenthesizedExpressionSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.OpenParenToken),
-            Doc.Indent(Doc.SoftLine, Node.Print(node.Expression)),
+            Token.Print(node.OpenParenToken, context),
+            Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context)),
             Doc.SoftLine,
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ParenthesizedLambdaExpression
 {
-    public static Doc Print(ParenthesizedLambdaExpressionSyntax node)
+    public static Doc Print(ParenthesizedLambdaExpressionSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
-            AttributeLists.Print(node, node.AttributeLists),
-            Modifiers.Print(node.Modifiers),
-            node.ReturnType != null ? Doc.Concat(Node.Print(node.ReturnType), " ") : Doc.Null,
-            ParameterList.Print(node.ParameterList),
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            node.ReturnType != null ? Doc.Concat(Node.Print(node.ReturnType, context), " ") : Doc.Null,
+            ParameterList.Print(node.ParameterList, context),
             " ",
-            Token.Print(node.ArrowToken)
+            Token.Print(node.ArrowToken, context)
         };
         if (node.ExpressionBody != null)
         {
-            docs.Add(Doc.Group(Doc.Indent(Doc.Line, Node.Print(node.ExpressionBody))));
+            docs.Add(Doc.Group(Doc.Indent(Doc.Line, Node.Print(node.ExpressionBody, context))));
         }
         else if (node.Block != null)
         {
@@ -28,7 +28,7 @@ internal static class ParenthesizedLambdaExpression
                 docs.Add(" ");
             }
 
-            docs.Add(Block.Print(node.Block));
+            docs.Add(Block.Print(node.Block, context));
         }
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedLambdaExpression.cs
@@ -8,7 +8,9 @@ internal static class ParenthesizedLambdaExpression
         {
             AttributeLists.Print(node, node.AttributeLists, context),
             Modifiers.Print(node.Modifiers, context),
-            node.ReturnType != null ? Doc.Concat(Node.Print(node.ReturnType, context), " ") : Doc.Null,
+            node.ReturnType != null
+                ? Doc.Concat(Node.Print(node.ReturnType, context), " ")
+                : Doc.Null,
             ParameterList.Print(node.ParameterList, context),
             " ",
             Token.Print(node.ArrowToken, context)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedPattern.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ParenthesizedPattern
 {
-    public static Doc Print(ParenthesizedPatternSyntax node)
+    public static Doc Print(ParenthesizedPatternSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.OpenParenToken),
-            Doc.Indent(Doc.SoftLine, Node.Print(node.Pattern)),
+            Token.Print(node.OpenParenToken, context),
+            Doc.Indent(Doc.SoftLine, Node.Print(node.Pattern, context)),
             Doc.SoftLine,
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedVariableDesignation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedVariableDesignation.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ParenthesizedVariableDesignation
 {
-    public static Doc Print(ParenthesizedVariableDesignationSyntax node)
+    public static Doc Print(ParenthesizedVariableDesignationSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.OpenParenToken),
+            Token.Print(node.OpenParenToken, context),
             Doc.Indent(
                 Doc.SoftLine,
-                SeparatedSyntaxList.Print(node.Variables, Node.Print, Doc.Line)
+                SeparatedSyntaxList.Print(node.Variables, Node.Print, Doc.Line, context)
             ),
             Doc.SoftLine,
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PointerType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PointerType.cs
@@ -4,6 +4,9 @@ internal static class PointerType
 {
     public static Doc Print(PointerTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.ElementType, context), Token.Print(node.AsteriskToken, context));
+        return Doc.Concat(
+            Node.Print(node.ElementType, context),
+            Token.Print(node.AsteriskToken, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PointerType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PointerType.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class PointerType
 {
-    public static Doc Print(PointerTypeSyntax node)
+    public static Doc Print(PointerTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.ElementType), Token.Print(node.AsteriskToken));
+        return Doc.Concat(Node.Print(node.ElementType, context), Token.Print(node.AsteriskToken, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PostfixUnaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PostfixUnaryExpression.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class PostfixUnaryExpression
 {
-    public static Doc Print(PostfixUnaryExpressionSyntax node)
+    public static Doc Print(PostfixUnaryExpressionSyntax node, FormattingContext context)
     {
         if (
             node.Kind() is SyntaxKind.SuppressNullableWarningExpression
             && node.Operand is InvocationExpressionSyntax
         )
         {
-            return InvocationExpression.PrintMemberChain(node);
+            return InvocationExpression.PrintMemberChain(node, context);
         }
 
-        return Doc.Concat(Node.Print(node.Operand), Token.Print(node.OperatorToken));
+        return Doc.Concat(Node.Print(node.Operand, context), Token.Print(node.OperatorToken, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PostfixUnaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PostfixUnaryExpression.cs
@@ -12,6 +12,9 @@ internal static class PostfixUnaryExpression
             return InvocationExpression.PrintMemberChain(node, context);
         }
 
-        return Doc.Concat(Node.Print(node.Operand, context), Token.Print(node.OperatorToken, context));
+        return Doc.Concat(
+            Node.Print(node.Operand, context),
+            Token.Print(node.OperatorToken, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PredefinedType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PredefinedType.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class PredefinedType
 {
-    public static Doc Print(PredefinedTypeSyntax node)
+    public static Doc Print(PredefinedTypeSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Keyword);
+        return Token.Print(node.Keyword, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrefixUnaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrefixUnaryExpression.cs
@@ -4,6 +4,9 @@ internal static class PrefixUnaryExpression
 {
     public static Doc Print(PrefixUnaryExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.OperatorToken, context), Node.Print(node.Operand, context));
+        return Doc.Concat(
+            Token.Print(node.OperatorToken, context),
+            Node.Print(node.Operand, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrefixUnaryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrefixUnaryExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class PrefixUnaryExpression
 {
-    public static Doc Print(PrefixUnaryExpressionSyntax node)
+    public static Doc Print(PrefixUnaryExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.OperatorToken), Node.Print(node.Operand));
+        return Doc.Concat(Token.Print(node.OperatorToken, context), Node.Print(node.Operand, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrimaryConstructorBaseType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrimaryConstructorBaseType.cs
@@ -4,6 +4,9 @@ internal static class PrimaryConstructorBaseType
 {
     public static Doc Print(PrimaryConstructorBaseTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Type, context), ArgumentList.Print(node.ArgumentList, context));
+        return Doc.Concat(
+            Node.Print(node.Type, context),
+            ArgumentList.Print(node.ArgumentList, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrimaryConstructorBaseType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/PrimaryConstructorBaseType.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class PrimaryConstructorBaseType
 {
-    public static Doc Print(PrimaryConstructorBaseTypeSyntax node)
+    public static Doc Print(PrimaryConstructorBaseTypeSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Node.Print(node.Type), ArgumentList.Print(node.ArgumentList));
+        return Doc.Concat(Node.Print(node.Type, context), ArgumentList.Print(node.ArgumentList, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QualifiedName.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QualifiedName.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class QualifiedName
 {
-    public static Doc Print(QualifiedNameSyntax node)
+    public static Doc Print(QualifiedNameSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.Left),
-            Token.Print(node.DotToken),
-            Node.Print(node.Right)
+            Node.Print(node.Left, context),
+            Token.Print(node.DotToken, context),
+            Node.Print(node.Right, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
@@ -2,18 +2,18 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class QueryBody
 {
-    public static Doc Print(QueryBodySyntax node)
+    public static Doc Print(QueryBodySyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Doc.Join(Doc.Line, node.Clauses.Select(Node.Print)) };
+        var docs = new List<Doc> { Doc.Join(Doc.Line, node.Clauses.Select(o => Node.Print(o, context))) };
         if (node.Clauses.Count > 0)
         {
             docs.Add(Doc.Line);
         }
 
-        docs.Add(Node.Print(node.SelectOrGroup));
+        docs.Add(Node.Print(node.SelectOrGroup, context));
         if (node.Continuation != null)
         {
-            docs.Add(" ", QueryContinuation.Print(node.Continuation));
+            docs.Add(" ", QueryContinuation.Print(node.Continuation, context));
         }
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
@@ -4,7 +4,10 @@ internal static class QueryBody
 {
     public static Doc Print(QueryBodySyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Doc.Join(Doc.Line, node.Clauses.Select(o => Node.Print(o, context))) };
+        var docs = new List<Doc>
+        {
+            Doc.Join(Doc.Line, node.Clauses.Select(o => Node.Print(o, context)))
+        };
         if (node.Clauses.Count > 0)
         {
             docs.Add(Doc.Line);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryContinuation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryContinuation.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class QueryContinuation
 {
-    public static Doc Print(QueryContinuationSyntax node)
+    public static Doc Print(QueryContinuationSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.IntoKeyword, " "),
-            Token.PrintWithSuffix(node.Identifier, Doc.Line),
-            QueryBody.Print(node.Body)
+            Token.PrintWithSuffix(node.IntoKeyword, " ", context),
+            Token.PrintWithSuffix(node.Identifier, Doc.Line, context),
+            QueryBody.Print(node.Body, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class QueryExpression
 {
-    public static Doc Print(QueryExpressionSyntax node)
+    public static Doc Print(QueryExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(FromClause.Print(node.FromClause), Doc.Line, QueryBody.Print(node.Body));
+        return Doc.Concat(FromClause.Print(node.FromClause, context), Doc.Line, QueryBody.Print(node.Body, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryExpression.cs
@@ -4,6 +4,10 @@ internal static class QueryExpression
 {
     public static Doc Print(QueryExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(FromClause.Print(node.FromClause, context), Doc.Line, QueryBody.Print(node.Body, context));
+        return Doc.Concat(
+            FromClause.Print(node.FromClause, context),
+            Doc.Line,
+            QueryBody.Print(node.Body, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RangeExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RangeExpression.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RangeExpression
 {
-    public static Doc Print(RangeExpressionSyntax node)
+    public static Doc Print(RangeExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            node.LeftOperand != null ? Node.Print(node.LeftOperand) : Doc.Null,
-            Token.Print(node.OperatorToken),
-            node.RightOperand != null ? Node.Print(node.RightOperand) : Doc.Null
+            node.LeftOperand != null ? Node.Print(node.LeftOperand, context) : Doc.Null,
+            Token.Print(node.OperatorToken, context),
+            node.RightOperand != null ? Node.Print(node.RightOperand, context) : Doc.Null
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
@@ -2,22 +2,26 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RecursivePattern
 {
-    public static Doc PrintWithOutType(RecursivePatternSyntax node)
+    public static Doc PrintWithOutType(RecursivePatternSyntax node, FormattingContext context)
     {
-        return Print(node, false);
+        return Print(node, false, context);
     }
 
-    public static Doc Print(RecursivePatternSyntax node)
+    public static Doc Print(RecursivePatternSyntax node, FormattingContext context)
     {
-        return Print(node, true);
+        return Print(node, true, context);
     }
 
-    private static Doc Print(RecursivePatternSyntax node, bool includeType)
+    private static Doc Print(
+        RecursivePatternSyntax node,
+        bool includeType,
+        FormattingContext context
+    )
     {
         var result = new List<Doc>();
         if (node.Type != null && includeType)
         {
-            result.Add(Node.Print(node.Type));
+            result.Add(Node.Print(node.Type, context));
         }
 
         if (node.PositionalPatternClause != null)
@@ -26,25 +30,26 @@ internal static class RecursivePattern
                 node.Parent is SwitchExpressionArmSyntax or CasePatternSwitchLabelSyntax
                   ? Doc.Null
                   : Doc.SoftLine,
-                Token.PrintLeadingTrivia(node.PositionalPatternClause.OpenParenToken),
+                Token.PrintLeadingTrivia(node.PositionalPatternClause.OpenParenToken, context),
                 Doc.Group(
-                    Token.PrintWithoutLeadingTrivia(node.PositionalPatternClause.OpenParenToken),
+                    Token.PrintWithoutLeadingTrivia(node.PositionalPatternClause.OpenParenToken, context),
                     Doc.Indent(
                         Doc.SoftLine,
                         SeparatedSyntaxList.Print(
                             node.PositionalPatternClause.Subpatterns,
-                            subpatternNode =>
+                            (subpatternNode, _) =>
                                 Doc.Concat(
                                     subpatternNode.NameColon != null
-                                      ? BaseExpressionColon.Print(subpatternNode.NameColon)
+                                      ? BaseExpressionColon.Print(subpatternNode.NameColon, context)
                                       : Doc.Null,
-                                    Node.Print(subpatternNode.Pattern)
+                                    Node.Print(subpatternNode.Pattern, context)
                                 ),
-                            Doc.Line
+                            Doc.Line,
+                            context
                         )
                     ),
                     Doc.SoftLine,
-                    Token.Print(node.PositionalPatternClause.CloseParenToken)
+                    Token.Print(node.PositionalPatternClause.CloseParenToken, context)
                 )
             );
         }
@@ -62,26 +67,27 @@ internal static class RecursivePattern
             else
             {
                 result.Add(
-                    Token.PrintLeadingTrivia(node.PropertyPatternClause.OpenBraceToken),
+                    Token.PrintLeadingTrivia(node.PropertyPatternClause.OpenBraceToken, context),
                     Doc.Group(
                         node.Type != null ? Doc.Line : Doc.Null,
-                        Token.PrintWithoutLeadingTrivia(node.PropertyPatternClause.OpenBraceToken),
+                        Token.PrintWithoutLeadingTrivia(node.PropertyPatternClause.OpenBraceToken, context),
                         Doc.Indent(
                             node.PropertyPatternClause.Subpatterns.Any() ? Doc.Line : Doc.Null,
                             SeparatedSyntaxList.Print(
                                 node.PropertyPatternClause.Subpatterns,
-                                subpatternNode =>
+                                (subpatternNode, _) =>
                                     Doc.Group(
                                         subpatternNode.ExpressionColon != null
-                                          ? Node.Print(subpatternNode.ExpressionColon)
+                                          ? Node.Print(subpatternNode.ExpressionColon, context)
                                           : Doc.Null,
-                                        Node.Print(subpatternNode.Pattern)
+                                        Node.Print(subpatternNode.Pattern, context)
                                     ),
-                                Doc.Line
+                                Doc.Line,
+                                context
                             )
                         ),
                         Doc.Line,
-                        Token.Print(node.PropertyPatternClause.CloseBraceToken)
+                        Token.Print(node.PropertyPatternClause.CloseBraceToken, context)
                     )
                 );
             }
@@ -89,7 +95,7 @@ internal static class RecursivePattern
 
         if (node.Designation != null)
         {
-            result.Add(" ", Node.Print(node.Designation));
+            result.Add(" ", Node.Print(node.Designation, context));
         }
 
         return Doc.Concat(result);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
@@ -32,7 +32,10 @@ internal static class RecursivePattern
                   : Doc.SoftLine,
                 Token.PrintLeadingTrivia(node.PositionalPatternClause.OpenParenToken, context),
                 Doc.Group(
-                    Token.PrintWithoutLeadingTrivia(node.PositionalPatternClause.OpenParenToken, context),
+                    Token.PrintWithoutLeadingTrivia(
+                        node.PositionalPatternClause.OpenParenToken,
+                        context
+                    ),
                     Doc.Indent(
                         Doc.SoftLine,
                         SeparatedSyntaxList.Print(
@@ -70,7 +73,10 @@ internal static class RecursivePattern
                     Token.PrintLeadingTrivia(node.PropertyPatternClause.OpenBraceToken, context),
                     Doc.Group(
                         node.Type != null ? Doc.Line : Doc.Null,
-                        Token.PrintWithoutLeadingTrivia(node.PropertyPatternClause.OpenBraceToken, context),
+                        Token.PrintWithoutLeadingTrivia(
+                            node.PropertyPatternClause.OpenBraceToken,
+                            context
+                        ),
                         Doc.Indent(
                             node.PropertyPatternClause.Subpatterns.Any() ? Doc.Line : Doc.Null,
                             SeparatedSyntaxList.Print(

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
@@ -4,6 +4,9 @@ internal static class RefExpression
 {
     public static Doc Print(RefExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.PrintWithSuffix(node.RefKeyword, " ", context), Node.Print(node.Expression, context));
+        return Doc.Concat(
+            Token.PrintWithSuffix(node.RefKeyword, " ", context),
+            Node.Print(node.Expression, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RefExpression
 {
-    public static Doc Print(RefExpressionSyntax node)
+    public static Doc Print(RefExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.PrintWithSuffix(node.RefKeyword, " "), Node.Print(node.Expression));
+        return Doc.Concat(Token.PrintWithSuffix(node.RefKeyword, " ", context), Node.Print(node.Expression, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefType.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RefType
 {
-    public static Doc Print(RefTypeSyntax node)
+    public static Doc Print(RefTypeSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.RefKeyword, " "),
-            Token.PrintWithSuffix(node.ReadOnlyKeyword, " "),
-            Node.Print(node.Type)
+            Token.PrintWithSuffix(node.RefKeyword, " ", context),
+            Token.PrintWithSuffix(node.ReadOnlyKeyword, " ", context),
+            Node.Print(node.Type, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefTypeExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefTypeExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RefTypeExpression
 {
-    public static Doc Print(RefTypeExpressionSyntax node)
+    public static Doc Print(RefTypeExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Expression),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Expression, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefValueExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RefValueExpression.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RefValueExpression
 {
-    public static Doc Print(RefValueExpressionSyntax node)
+    public static Doc Print(RefValueExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Expression),
-            Token.PrintWithSuffix(node.Comma, " "),
-            Node.Print(node.Type),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Expression, context),
+            Token.PrintWithSuffix(node.Comma, " ", context),
+            Node.Print(node.Type, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RelationalPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RelationalPattern.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class RelationalPattern
 {
-    public static Doc Print(RelationalPatternSyntax node)
+    public static Doc Print(RelationalPatternSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.OperatorToken, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.OperatorToken, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
@@ -6,7 +6,11 @@ internal static class ReturnStatement
     {
         return Doc.Group(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.ReturnKeyword, node.Expression != null ? " " : Doc.Null, context),
+            Token.PrintWithSuffix(
+                node.ReturnKeyword,
+                node.Expression != null ? " " : Doc.Null,
+                context
+            ),
             node.Expression != null
               ? node.Expression is BinaryExpressionSyntax
                   ? Doc.Indent(Node.Print(node.Expression, context))

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ReturnStatement.cs
@@ -2,17 +2,17 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ReturnStatement
 {
-    public static Doc Print(ReturnStatementSyntax node)
+    public static Doc Print(ReturnStatementSyntax node, FormattingContext context)
     {
         return Doc.Group(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.ReturnKeyword, node.Expression != null ? " " : Doc.Null),
+            Token.PrintWithSuffix(node.ReturnKeyword, node.Expression != null ? " " : Doc.Null, context),
             node.Expression != null
               ? node.Expression is BinaryExpressionSyntax
-                  ? Doc.Indent(Node.Print(node.Expression))
-                  : Node.Print(node.Expression)
+                  ? Doc.Indent(Node.Print(node.Expression, context))
+                  : Node.Print(node.Expression, context)
               : Doc.Null,
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SelectClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SelectClause.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SelectClause
 {
-    public static Doc Print(SelectClauseSyntax node)
+    public static Doc Print(SelectClauseSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.SelectKeyword, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.SelectKeyword, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SimpleBaseType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SimpleBaseType.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SimpleBaseType
 {
-    public static Doc Print(SimpleBaseTypeSyntax node)
+    public static Doc Print(SimpleBaseTypeSyntax node, FormattingContext context)
     {
-        return Node.Print(node.Type);
+        return Node.Print(node.Type, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SimpleLambdaExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SimpleLambdaExpression.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SimpleLambdaExpression
 {
-    public static Doc Print(SimpleLambdaExpressionSyntax node)
+    public static Doc Print(SimpleLambdaExpressionSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Modifiers.Print(node.Modifiers),
-            Node.Print(node.Parameter),
+            Modifiers.Print(node.Modifiers, context),
+            Node.Print(node.Parameter, context),
             " ",
-            Token.Print(node.ArrowToken),
+            Token.Print(node.ArrowToken, context),
             node.Body is BlockSyntax blockSyntax
-              ? Block.Print(blockSyntax)
-              : Doc.Indent(Doc.Line, Node.Print(node.Body))
+              ? Block.Print(blockSyntax, context)
+              : Doc.Indent(Doc.Line, Node.Print(node.Body, context))
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SingleVariableDesignation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SingleVariableDesignation.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SingleVariableDesignation
 {
-    public static Doc Print(SingleVariableDesignationSyntax node)
+    public static Doc Print(SingleVariableDesignationSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Identifier);
+        return Token.Print(node.Identifier, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SizeOfExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SizeOfExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SizeOfExpression
 {
-    public static Doc Print(SizeOfExpressionSyntax node)
+    public static Doc Print(SizeOfExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Type),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Type, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/StackAllocArrayCreationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/StackAllocArrayCreationExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class StackAllocArrayCreationExpression
 {
-    public static Doc Print(StackAllocArrayCreationExpressionSyntax node)
+    public static Doc Print(StackAllocArrayCreationExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.StackAllocKeyword, " "),
-            Node.Print(node.Type),
+            Token.PrintWithSuffix(node.StackAllocKeyword, " ", context),
+            Node.Print(node.Type, context),
             node.Initializer != null
-              ? Doc.Concat(" ", InitializerExpression.Print(node.Initializer))
+              ? Doc.Concat(" ", InitializerExpression.Print(node.Initializer, context))
               : string.Empty
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -18,7 +18,11 @@ internal static class SwitchExpression
                                 Doc.Indent(
                                     Doc.Concat(
                                         Doc.Line,
-                                        Token.PrintWithSuffix(o.EqualsGreaterThanToken, " ", context),
+                                        Token.PrintWithSuffix(
+                                            o.EqualsGreaterThanToken,
+                                            " ",
+                                            context
+                                        ),
                                         Node.Print(o.Expression, context)
                                     )
                                 )

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SwitchExpression
 {
-    public static Doc Print(SwitchExpressionSyntax node)
+    public static Doc Print(SwitchExpressionSyntax node, FormattingContext context)
     {
         var sections = Doc.Group(
             Doc.Indent(
                 Doc.HardLine,
                 SeparatedSyntaxList.Print(
                     node.Arms,
-                    o =>
+                    (o, _) =>
                         Doc.Concat(
                             ExtraNewLines.Print(o),
                             Doc.Group(
@@ -18,13 +18,14 @@ internal static class SwitchExpression
                                 Doc.Indent(
                                     Doc.Concat(
                                         Doc.Line,
-                                        Token.PrintWithSuffix(o.EqualsGreaterThanToken, " "),
-                                        Node.Print(o.Expression)
+                                        Token.PrintWithSuffix(o.EqualsGreaterThanToken, " ", context),
+                                        Node.Print(o.Expression, context)
                                     )
                                 )
                             )
                         ),
-                    Doc.HardLine
+                    Doc.HardLine,
+                    context
                 )
             ),
             Doc.HardLine
@@ -33,13 +34,13 @@ internal static class SwitchExpression
         DocUtilities.RemoveInitialDoubleHardLine(sections);
 
         return Doc.Concat(
-            Node.Print(node.GoverningExpression),
+            Node.Print(node.GoverningExpression, context),
             " ",
-            Token.Print(node.SwitchKeyword),
+            Token.Print(node.SwitchKeyword, context),
             Doc.HardLine,
-            Token.Print(node.OpenBraceToken),
+            Token.Print(node.OpenBraceToken, context),
             sections,
-            Token.Print(node.CloseBraceToken)
+            Token.Print(node.CloseBraceToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchExpression.cs
@@ -13,8 +13,8 @@ internal static class SwitchExpression
                         Doc.Concat(
                             ExtraNewLines.Print(o),
                             Doc.Group(
-                                Node.Print(o.Pattern),
-                                o.WhenClause != null ? Node.Print(o.WhenClause) : Doc.Null,
+                                Node.Print(o.Pattern, context),
+                                o.WhenClause != null ? Node.Print(o.WhenClause, context) : Doc.Null,
                                 Doc.Indent(
                                     Doc.Concat(
                                         Doc.Line,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
@@ -4,7 +4,10 @@ internal static class SwitchSection
 {
     public static Doc Print(SwitchSectionSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Doc.Join(Doc.HardLine, node.Labels.Select(o => Node.Print(o, context))) };
+        var docs = new List<Doc>
+        {
+            Doc.Join(Doc.HardLine, node.Labels.Select(o => Node.Print(o, context)))
+        };
         if (node.Statements.Count == 1 && node.Statements[0] is BlockSyntax blockSyntax)
         {
             docs.Add(Block.Print(blockSyntax, context));
@@ -14,7 +17,10 @@ internal static class SwitchSection
             docs.Add(
                 Doc.Indent(
                     Doc.HardLine,
-                    Doc.Join(Doc.HardLine, node.Statements.Select(o => Node.Print(o, context)).ToArray())
+                    Doc.Join(
+                        Doc.HardLine,
+                        node.Statements.Select(o => Node.Print(o, context)).ToArray()
+                    )
                 )
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
@@ -2,19 +2,19 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SwitchSection
 {
-    public static Doc Print(SwitchSectionSyntax node)
+    public static Doc Print(SwitchSectionSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Doc.Join(Doc.HardLine, node.Labels.Select(Node.Print)) };
+        var docs = new List<Doc> { Doc.Join(Doc.HardLine, node.Labels.Select(o => Node.Print(o, context))) };
         if (node.Statements.Count == 1 && node.Statements[0] is BlockSyntax blockSyntax)
         {
-            docs.Add(Block.Print(blockSyntax));
+            docs.Add(Block.Print(blockSyntax, context));
         }
         else
         {
             docs.Add(
                 Doc.Indent(
                     Doc.HardLine,
-                    Doc.Join(Doc.HardLine, node.Statements.Select(Node.Print).ToArray())
+                    Doc.Join(Doc.HardLine, node.Statements.Select(o => Node.Print(o, context)).ToArray())
                 )
             );
         }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class SwitchStatement
 {
-    public static Doc Print(SwitchStatementSyntax node)
+    public static Doc Print(SwitchStatementSyntax node, FormattingContext context)
     {
         var sections =
             node.Sections.Count == 0
@@ -11,7 +11,7 @@ internal static class SwitchStatement
                       Doc.Indent(
                           Doc.Concat(
                               Doc.HardLine,
-                              Doc.Join(Doc.HardLine, node.Sections.Select(SwitchSection.Print))
+                              Doc.Join(Doc.HardLine, node.Sections.Select(o => SwitchSection.Print(o, context)))
                           )
                       ),
                       Doc.HardLine
@@ -23,21 +23,21 @@ internal static class SwitchStatement
 
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintLeadingTrivia(node.SwitchKeyword),
+            Token.PrintLeadingTrivia(node.SwitchKeyword, context),
             Doc.Group(
-                Token.PrintWithoutLeadingTrivia(node.SwitchKeyword),
+                Token.PrintWithoutLeadingTrivia(node.SwitchKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
+                Token.Print(node.OpenParenToken, context),
                 Doc.GroupWithId(
                     groupId,
-                    Doc.Indent(Doc.SoftLine, Node.Print(node.Expression)),
+                    Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context)),
                     Doc.SoftLine
                 ),
-                Token.Print(node.CloseParenToken),
+                Token.Print(node.CloseParenToken, context),
                 node.Sections.Count == 0 ? " " : Doc.Line,
-                Token.Print(node.OpenBraceToken),
+                Token.Print(node.OpenBraceToken, context),
                 sections,
-                Token.Print(node.CloseBraceToken)
+                Token.Print(node.CloseBraceToken, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchStatement.cs
@@ -11,7 +11,10 @@ internal static class SwitchStatement
                       Doc.Indent(
                           Doc.Concat(
                               Doc.HardLine,
-                              Doc.Join(Doc.HardLine, node.Sections.Select(o => SwitchSection.Print(o, context)))
+                              Doc.Join(
+                                  Doc.HardLine,
+                                  node.Sections.Select(o => SwitchSection.Print(o, context))
+                              )
                           )
                       ),
                       Doc.HardLine

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThisExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThisExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ThisExpression
 {
-    public static Doc Print(ThisExpressionSyntax node)
+    public static Doc Print(ThisExpressionSyntax node, FormattingContext context)
     {
-        return Token.Print(node.Token);
+        return Token.Print(node.Token, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowExpression.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ThrowExpression
 {
-    public static Doc Print(ThrowExpressionSyntax node)
+    public static Doc Print(ThrowExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.ThrowKeyword, " "),
-            Node.Print(node.Expression)
+            Token.PrintWithSuffix(node.ThrowKeyword, " ", context),
+            Node.Print(node.Expression, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowStatement.cs
@@ -2,15 +2,15 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class ThrowStatement
 {
-    public static Doc Print(ThrowStatementSyntax node)
+    public static Doc Print(ThrowStatementSyntax node, FormattingContext context)
     {
         var expression =
-            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression)) : string.Empty;
+            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression, context)) : string.Empty;
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.Print(node.ThrowKeyword),
+            Token.Print(node.ThrowKeyword, context),
             expression,
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ThrowStatement.cs
@@ -5,7 +5,9 @@ internal static class ThrowStatement
     public static Doc Print(ThrowStatementSyntax node, FormattingContext context)
     {
         var expression =
-            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression, context)) : string.Empty;
+            node.Expression != null
+                ? Doc.Concat(" ", Node.Print(node.Expression, context))
+                : string.Empty;
         return Doc.Concat(
             ExtraNewLines.Print(node),
             Token.Print(node.ThrowKeyword, context),

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TryStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TryStatement.cs
@@ -2,20 +2,20 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TryStatement
 {
-    public static Doc Print(TryStatementSyntax node)
+    public static Doc Print(TryStatementSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
             ExtraNewLines.Print(node),
-            AttributeLists.Print(node, node.AttributeLists),
-            Token.Print(node.TryKeyword),
-            Block.Print(node.Block),
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Token.Print(node.TryKeyword, context),
+            Block.Print(node.Block, context),
             node.Catches.Any() ? Doc.HardLine : Doc.Null,
-            Doc.Join(Doc.HardLine, node.Catches.Select(CatchClause.Print))
+            Doc.Join(Doc.HardLine, node.Catches.Select(o => CatchClause.Print(o, context)))
         };
         if (node.Finally != null)
         {
-            docs.Add(Doc.HardLine, FinallyClause.Print(node.Finally));
+            docs.Add(Doc.HardLine, FinallyClause.Print(node.Finally, context));
         }
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleElement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleElement.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TupleElement
 {
-    public static Doc Print(TupleElementSyntax node)
+    public static Doc Print(TupleElementSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.Type),
+            Node.Print(node.Type, context),
             node.Identifier.RawSyntaxKind() != SyntaxKind.None
-              ? Doc.Concat(" ", Token.Print(node.Identifier))
+              ? Doc.Concat(" ", Token.Print(node.Identifier, context))
               : Doc.Null
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleExpression.cs
@@ -4,6 +4,11 @@ internal static class TupleExpression
 {
     public static Doc Print(TupleExpressionSyntax node, FormattingContext context) =>
         Doc.Group(
-            ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken, context)
+            ArgumentListLike.Print(
+                node.OpenParenToken,
+                node.Arguments,
+                node.CloseParenToken,
+                context
+            )
         );
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleExpression.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TupleExpression
 {
-    public static Doc Print(TupleExpressionSyntax node) =>
+    public static Doc Print(TupleExpressionSyntax node, FormattingContext context) =>
         Doc.Group(
-            ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken)
+            ArgumentListLike.Print(node.OpenParenToken, node.Arguments, node.CloseParenToken, context)
         );
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleType.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TupleType.cs
@@ -2,12 +2,12 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TupleType
 {
-    public static Doc Print(TupleTypeSyntax node)
+    public static Doc Print(TupleTypeSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.OpenParenToken),
-            SeparatedSyntaxList.Print(node.Elements, Node.Print, " "),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.OpenParenToken, context),
+            SeparatedSyntaxList.Print(node.Elements, Node.Print, " ", context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeArgumentList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeArgumentList.cs
@@ -18,7 +18,8 @@ internal static class TypeArgumentList
                     Node.Print,
                     node.Arguments.FirstOrDefault() is OmittedTypeArgumentSyntax
                       ? Doc.Null
-                      : Doc.Line, context
+                      : Doc.Line,
+                    context
                 )
             ),
             separator,

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeArgumentList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeArgumentList.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeArgumentList
 {
-    public static Doc Print(TypeArgumentListSyntax node)
+    public static Doc Print(TypeArgumentListSyntax node, FormattingContext context)
     {
         Doc separator =
             node.Arguments.Count > 1 || node.Arguments.Any(o => o is GenericNameSyntax)
@@ -10,7 +10,7 @@ internal static class TypeArgumentList
                 : Doc.Null;
 
         return Doc.Concat(
-            Token.Print(node.LessThanToken),
+            Token.Print(node.LessThanToken, context),
             Doc.Indent(
                 separator,
                 SeparatedSyntaxList.Print(
@@ -18,11 +18,11 @@ internal static class TypeArgumentList
                     Node.Print,
                     node.Arguments.FirstOrDefault() is OmittedTypeArgumentSyntax
                       ? Doc.Null
-                      : Doc.Line
+                      : Doc.Line, context
                 )
             ),
             separator,
-            Token.Print(node.GreaterThanToken)
+            Token.Print(node.GreaterThanToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeConstraint.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeConstraint.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeConstraint
 {
-    public static Doc Print(TypeConstraintSyntax node)
+    public static Doc Print(TypeConstraintSyntax node, FormattingContext context)
     {
-        return Node.Print(node.Type);
+        return Node.Print(node.Type, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeOfExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeOfExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeOfExpression
 {
-    public static Doc Print(TypeOfExpressionSyntax node)
+    public static Doc Print(TypeOfExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.Print(node.Keyword),
-            Token.Print(node.OpenParenToken),
-            Node.Print(node.Type),
-            Token.Print(node.CloseParenToken)
+            Token.Print(node.Keyword, context),
+            Token.Print(node.OpenParenToken, context),
+            Node.Print(node.Type, context),
+            Token.Print(node.CloseParenToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameter.cs
@@ -2,18 +2,18 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeParameter
 {
-    public static Doc Print(TypeParameterSyntax node)
+    public static Doc Print(TypeParameterSyntax node, FormattingContext context)
     {
         var hasAttribute = node.AttributeLists.Any();
         var groupId = hasAttribute ? Guid.NewGuid().ToString() : string.Empty;
 
         var result = Doc.Concat(
-            AttributeLists.Print(node, node.AttributeLists),
+            AttributeLists.Print(node, node.AttributeLists, context),
             hasAttribute ? Doc.IndentIfBreak(Doc.Line, groupId) : Doc.Null,
             node.VarianceKeyword.RawSyntaxKind() != SyntaxKind.None
-              ? Token.PrintWithSuffix(node.VarianceKeyword, " ")
+              ? Token.PrintWithSuffix(node.VarianceKeyword, " ", context)
               : Doc.Null,
-            Token.Print(node.Identifier)
+            Token.Print(node.Identifier, context)
         );
 
         return hasAttribute ? Doc.GroupWithId(groupId, result) : result;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterConstraintClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterConstraintClause.cs
@@ -2,14 +2,14 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeParameterConstraintClause
 {
-    public static Doc Print(TypeParameterConstraintClauseSyntax node)
+    public static Doc Print(TypeParameterConstraintClauseSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.PrintWithSuffix(node.WhereKeyword, " "),
-            Node.Print(node.Name),
+            Token.PrintWithSuffix(node.WhereKeyword, " ", context),
+            Node.Print(node.Name, context),
             " ",
-            Token.PrintWithSuffix(node.ColonToken, " "),
-            Doc.Indent(SeparatedSyntaxList.Print(node.Constraints, Node.Print, Doc.Line))
+            Token.PrintWithSuffix(node.ColonToken, " ", context),
+            Doc.Indent(SeparatedSyntaxList.Print(node.Constraints, Node.Print, Doc.Line, context))
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypeParameterList.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypeParameterList
 {
-    public static Doc Print(TypeParameterListSyntax node)
+    public static Doc Print(TypeParameterListSyntax node, FormattingContext context)
     {
         if (node.Parameters.Count == 0)
         {
@@ -13,13 +13,13 @@ internal static class TypeParameterList
             node.Parameters.Count > 1 || node.Parameters.First().AttributeLists.Any();
 
         return Doc.Group(
-            Token.Print(node.LessThanToken),
+            Token.Print(node.LessThanToken, context),
             Doc.Indent(
                 shouldBreakMore ? Doc.SoftLine : Doc.Null,
-                SeparatedSyntaxList.Print(node.Parameters, TypeParameter.Print, Doc.Line)
+                SeparatedSyntaxList.Print(node.Parameters, TypeParameter.Print, Doc.Line, context)
             ),
             shouldBreakMore ? Doc.SoftLine : Doc.Null,
-            Token.Print(node.GreaterThanToken)
+            Token.Print(node.GreaterThanToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypePattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TypePattern.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class TypePattern
 {
-    public static Doc Print(TypePatternSyntax node)
+    public static Doc Print(TypePatternSyntax node, FormattingContext context)
     {
-        return Node.Print(node.Type);
+        return Node.Print(node.Type, context);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
@@ -4,6 +4,9 @@ internal static class UnaryPattern
 {
     public static Doc Print(UnaryPatternSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.PrintWithSuffix(node.OperatorToken, " ", context), Node.Print(node.Pattern, context));
+        return Doc.Concat(
+            Token.PrintWithSuffix(node.OperatorToken, " ", context),
+            Node.Print(node.Pattern, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnaryPattern.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class UnaryPattern
 {
-    public static Doc Print(UnaryPatternSyntax node)
+    public static Doc Print(UnaryPatternSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.PrintWithSuffix(node.OperatorToken, " "), Node.Print(node.Pattern));
+        return Doc.Concat(Token.PrintWithSuffix(node.OperatorToken, " ", context), Node.Print(node.Pattern, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnsafeStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnsafeStatement.cs
@@ -4,6 +4,9 @@ internal static class UnsafeStatement
 {
     public static Doc Print(UnsafeStatementSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.UnsafeKeyword, context), Node.Print(node.Block, context));
+        return Doc.Concat(
+            Token.Print(node.UnsafeKeyword, context),
+            Node.Print(node.Block, context)
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnsafeStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UnsafeStatement.cs
@@ -2,8 +2,8 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class UnsafeStatement
 {
-    public static Doc Print(UnsafeStatementSyntax node)
+    public static Doc Print(UnsafeStatementSyntax node, FormattingContext context)
     {
-        return Doc.Concat(Token.Print(node.UnsafeKeyword), Node.Print(node.Block));
+        return Doc.Concat(Token.Print(node.UnsafeKeyword, context), Node.Print(node.Block, context));
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingDirective.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingDirective.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class UsingDirective
 {
-    public static Doc Print(UsingDirectiveSyntax node)
+    public static Doc Print(UsingDirectiveSyntax node, FormattingContext context)
     {
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.GlobalKeyword, " "),
-            Token.PrintWithSuffix(node.UsingKeyword, " "),
-            Token.PrintWithSuffix(node.StaticKeyword, " "),
-            node.Alias == null ? Doc.Null : NameEquals.Print(node.Alias),
-            Node.Print(node.Name),
-            Token.Print(node.SemicolonToken)
+            Token.PrintWithSuffix(node.GlobalKeyword, " ", context),
+            Token.PrintWithSuffix(node.UsingKeyword, " ", context),
+            Token.PrintWithSuffix(node.StaticKeyword, " ", context),
+            node.Alias == null ? Doc.Null : NameEquals.Print(node.Alias, context),
+            Node.Print(node.Name, context),
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingStatement.cs
@@ -2,42 +2,42 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class UsingStatement
 {
-    public static Doc Print(UsingStatementSyntax node)
+    public static Doc Print(UsingStatementSyntax node, FormattingContext context)
     {
         var docs = new List<Doc>
         {
             ExtraNewLines.Print(node),
             Doc.Group(
-                Token.Print(node.AwaitKeyword),
+                Token.Print(node.AwaitKeyword, context),
                 node.AwaitKeyword.RawSyntaxKind() != SyntaxKind.None ? " " : Doc.Null,
-                Token.Print(node.UsingKeyword),
+                Token.Print(node.UsingKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
+                Token.Print(node.OpenParenToken, context),
                 Doc.Group(
                     Doc.Indent(
                         Doc.SoftLine,
                         node.Declaration != null
-                          ? VariableDeclaration.Print(node.Declaration)
+                          ? VariableDeclaration.Print(node.Declaration, context)
                           : Doc.Null,
-                        node.Expression != null ? Node.Print(node.Expression) : Doc.Null
+                        node.Expression != null ? Node.Print(node.Expression, context) : Doc.Null
                     ),
                     Doc.SoftLine
                 ),
-                Token.Print(node.CloseParenToken),
+                Token.Print(node.CloseParenToken, context),
                 Doc.IfBreak(Doc.Null, Doc.SoftLine)
             )
         };
         if (node.Statement is UsingStatementSyntax)
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Statement));
+            docs.Add(Doc.HardLine, Node.Print(node.Statement, context));
         }
         else if (node.Statement is BlockSyntax blockSyntax)
         {
-            docs.Add(Block.Print(blockSyntax));
+            docs.Add(Block.Print(blockSyntax, context));
         }
         else
         {
-            docs.Add(Doc.Indent(Doc.HardLine, Node.Print(node.Statement)));
+            docs.Add(Doc.Indent(Doc.HardLine, Node.Print(node.Statement, context)));
         }
 
         return Doc.Concat(docs);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VarPattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VarPattern.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class VarPattern
 {
-    public static Doc Print(VarPatternSyntax node)
+    public static Doc Print(VarPatternSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Token.PrintWithSuffix(node.VarKeyword, " "),
-            Node.Print(node.Designation)
+            Token.PrintWithSuffix(node.VarKeyword, " ", context),
+            Node.Print(node.Designation, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclaration.cs
@@ -2,18 +2,18 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class VariableDeclaration
 {
-    public static Doc Print(VariableDeclarationSyntax node)
+    public static Doc Print(VariableDeclarationSyntax node, FormattingContext context)
     {
         if (node.Variables.Count > 1)
         {
             return Doc.Concat(
-                Node.Print(node.Type),
+                Node.Print(node.Type, context),
                 " ",
                 Doc.Indent(
                     SeparatedSyntaxList.Print(
                         node.Variables,
                         VariableDeclarator.Print,
-                        node.Parent is ForStatementSyntax ? Doc.Line : Doc.HardLine
+                        node.Parent is ForStatementSyntax ? Doc.Line : Doc.HardLine, context
                     )
                 )
             );
@@ -22,11 +22,11 @@ internal static class VariableDeclaration
         var variable = node.Variables[0];
 
         var leftDoc = Doc.Concat(
-            Node.Print(node.Type),
+            Node.Print(node.Type, context),
             " ",
-            Token.Print(variable.Identifier),
+            Token.Print(variable.Identifier, context),
             variable.ArgumentList != null
-              ? BracketedArgumentList.Print(variable.ArgumentList)
+              ? BracketedArgumentList.Print(variable.ArgumentList, context)
               : Doc.Null
         );
 
@@ -37,8 +37,8 @@ internal static class VariableDeclaration
           : RightHandSide.Print(
                 node,
                 Doc.Concat(leftDoc, " "),
-                Token.Print(initializer.EqualsToken),
-                initializer.Value
+                Token.Print(initializer.EqualsToken, context),
+                initializer.Value, context
             );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclaration.cs
@@ -13,7 +13,8 @@ internal static class VariableDeclaration
                     SeparatedSyntaxList.Print(
                         node.Variables,
                         VariableDeclarator.Print,
-                        node.Parent is ForStatementSyntax ? Doc.Line : Doc.HardLine, context
+                        node.Parent is ForStatementSyntax ? Doc.Line : Doc.HardLine,
+                        context
                     )
                 )
             );
@@ -38,7 +39,8 @@ internal static class VariableDeclaration
                 node,
                 Doc.Concat(leftDoc, " "),
                 Token.Print(initializer.EqualsToken, context),
-                initializer.Value, context
+                initializer.Value,
+                context
             );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclarator.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclarator.cs
@@ -2,16 +2,16 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class VariableDeclarator
 {
-    public static Doc Print(VariableDeclaratorSyntax node)
+    public static Doc Print(VariableDeclaratorSyntax node, FormattingContext context)
     {
-        var docs = new List<Doc> { Token.Print(node.Identifier) };
+        var docs = new List<Doc> { Token.Print(node.Identifier, context) };
         if (node.ArgumentList != null)
         {
-            docs.Add(BracketedArgumentList.Print(node.ArgumentList));
+            docs.Add(BracketedArgumentList.Print(node.ArgumentList, context));
         }
         if (node.Initializer != null)
         {
-            docs.Add(EqualsValueClause.Print(node.Initializer));
+            docs.Add(EqualsValueClause.Print(node.Initializer, context));
         }
         return Doc.Concat(docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhenClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhenClause.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class WhenClause
 {
-    public static Doc Print(WhenClauseSyntax node)
+    public static Doc Print(WhenClauseSyntax node, FormattingContext context)
     {
         return Doc.Group(
             Doc.Indent(

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhenClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhenClause.cs
@@ -7,8 +7,8 @@ internal static class WhenClause
         return Doc.Group(
             Doc.Indent(
                 Doc.Line,
-                Token.PrintWithSuffix(node.WhenKeyword, " "),
-                Node.Print(node.Condition)
+                Token.PrintWithSuffix(node.WhenKeyword, " ", context),
+                Node.Print(node.Condition, context)
             )
         );
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhereClause.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhereClause.cs
@@ -2,11 +2,11 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class WhereClause
 {
-    public static Doc Print(WhereClauseSyntax node)
+    public static Doc Print(WhereClauseSyntax node, FormattingContext context)
     {
         return Doc.Group(
-            Token.Print(node.WhereKeyword),
-            Doc.Indent(Doc.Line, Node.Print(node.Condition))
+            Token.Print(node.WhereKeyword, context),
+            Doc.Indent(Doc.Line, Node.Print(node.Condition, context))
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhileStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WhileStatement.cs
@@ -2,18 +2,21 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class WhileStatement
 {
-    public static Doc Print(WhileStatementSyntax node)
+    public static Doc Print(WhileStatementSyntax node, FormattingContext context)
     {
         var result = Doc.Concat(
             ExtraNewLines.Print(node),
             Doc.Group(
-                Token.Print(node.WhileKeyword),
+                Token.Print(node.WhileKeyword, context),
                 " ",
-                Token.Print(node.OpenParenToken),
-                Doc.Group(Doc.Indent(Doc.SoftLine, Node.Print(node.Condition)), Doc.SoftLine),
-                Token.Print(node.CloseParenToken)
+                Token.Print(node.OpenParenToken, context),
+                Doc.Group(
+                    Doc.Indent(Doc.SoftLine, Node.Print(node.Condition, context)),
+                    Doc.SoftLine
+                ),
+                Token.Print(node.CloseParenToken, context)
             ),
-            OptionalBraces.Print(node.Statement)
+            OptionalBraces.Print(node.Statement, context)
         );
 
         return result;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WithExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/WithExpression.cs
@@ -2,13 +2,13 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class WithExpression
 {
-    public static Doc Print(WithExpressionSyntax node)
+    public static Doc Print(WithExpressionSyntax node, FormattingContext context)
     {
         return Doc.Concat(
-            Node.Print(node.Expression),
+            Node.Print(node.Expression, context),
             " ",
-            Token.PrintWithSuffix(node.WithKeyword, Doc.Line),
-            Node.Print(node.Initializer)
+            Token.PrintWithSuffix(node.WithKeyword, Doc.Line, context),
+            Node.Print(node.Initializer, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/YieldStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/YieldStatement.cs
@@ -2,16 +2,18 @@ namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal static class YieldStatement
 {
-    public static Doc Print(YieldStatementSyntax node)
+    public static Doc Print(YieldStatementSyntax node, FormattingContext context)
     {
         Doc expression =
-            node.Expression != null ? Doc.Concat(" ", Node.Print(node.Expression)) : string.Empty;
+            node.Expression != null
+                ? Doc.Concat(" ", Node.Print(node.Expression, context))
+                : string.Empty;
         return Doc.Concat(
             ExtraNewLines.Print(node),
-            Token.PrintWithSuffix(node.YieldKeyword, " "),
-            Token.Print(node.ReturnOrBreakKeyword),
+            Token.PrintWithSuffix(node.YieldKeyword, " ", context),
+            Token.Print(node.ReturnOrBreakKeyword, context),
             expression,
-            Token.Print(node.SemicolonToken)
+            Token.Print(node.SemicolonToken, context)
         );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -8,23 +8,28 @@ internal static class Token
     [ThreadStatic]
     public static bool NextTriviaNeedsLine;
 
-    public static Doc PrintWithoutLeadingTrivia(SyntaxToken syntaxToken)
+    public static Doc PrintWithoutLeadingTrivia(SyntaxToken syntaxToken, FormattingContext context)
     {
-        return PrintSyntaxToken(syntaxToken, null, skipLeadingTrivia: true);
+        return PrintSyntaxToken(syntaxToken, context, skipLeadingTrivia: true);
     }
 
-    public static Doc Print(SyntaxToken syntaxToken)
+    public static Doc Print(SyntaxToken syntaxToken, FormattingContext context)
     {
-        return PrintSyntaxToken(syntaxToken);
+        return PrintSyntaxToken(syntaxToken, context);
     }
 
-    public static Doc PrintWithSuffix(SyntaxToken syntaxToken, Doc suffixDoc)
+    public static Doc PrintWithSuffix(
+        SyntaxToken syntaxToken,
+        Doc suffixDoc,
+        FormattingContext context
+    )
     {
-        return PrintSyntaxToken(syntaxToken, suffixDoc);
+        return PrintSyntaxToken(syntaxToken, context, suffixDoc);
     }
 
     private static Doc PrintSyntaxToken(
         SyntaxToken syntaxToken,
+        FormattingContext context,
         Doc? suffixDoc = null,
         bool skipLeadingTrivia = false
     )
@@ -37,7 +42,7 @@ internal static class Token
         var docs = new List<Doc>();
         if (!skipLeadingTrivia && !ShouldSkipNextLeadingTrivia)
         {
-            var leadingTrivia = PrintLeadingTrivia(syntaxToken);
+            var leadingTrivia = PrintLeadingTrivia(syntaxToken, context);
             if (leadingTrivia != Doc.Null)
             {
                 docs.Add(leadingTrivia);
@@ -88,7 +93,7 @@ internal static class Token
         };
     }
 
-    public static Doc PrintLeadingTrivia(SyntaxToken syntaxToken)
+    public static Doc PrintLeadingTrivia(SyntaxToken syntaxToken, FormattingContext context)
     {
         var isClosingBrace = syntaxToken.RawSyntaxKind() == SyntaxKind.CloseBraceToken;
 
@@ -101,6 +106,7 @@ internal static class Token
 
         var printedTrivia = PrivatePrintLeadingTrivia(
             syntaxToken.LeadingTrivia,
+            context,
             skipLastHardline: isClosingBrace
         );
 
@@ -113,18 +119,22 @@ internal static class Token
           : printedTrivia;
     }
 
-    public static Doc PrintLeadingTrivia(SyntaxTriviaList leadingTrivia)
+    public static Doc PrintLeadingTrivia(SyntaxTriviaList leadingTrivia, FormattingContext context)
     {
-        return PrivatePrintLeadingTrivia(leadingTrivia);
+        return PrivatePrintLeadingTrivia(leadingTrivia, context);
     }
 
-    public static Doc PrintLeadingTriviaWithNewLines(SyntaxTriviaList leadingTrivia)
+    public static Doc PrintLeadingTriviaWithNewLines(
+        SyntaxTriviaList leadingTrivia,
+        FormattingContext context
+    )
     {
-        return PrivatePrintLeadingTrivia(leadingTrivia, includeInitialNewLines: true);
+        return PrivatePrintLeadingTrivia(leadingTrivia, context, includeInitialNewLines: true);
     }
 
     private static Doc PrivatePrintLeadingTrivia(
         SyntaxTriviaList leadingTrivia,
+        FormattingContext context,
         bool includeInitialNewLines = false,
         bool skipLastHardline = false
     )

--- a/Src/CSharpier/SyntaxPrinter/UnhandledNode.cs
+++ b/Src/CSharpier/SyntaxPrinter/UnhandledNode.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class UnhandledNode
 {
-    public static Doc Print(SyntaxNode node)
+    public static Doc Print(SyntaxNode node, FormattingContext context)
     {
 #if DEBUG
         return node.GetType().FullName ?? string.Empty;


### PR DESCRIPTION
This is my plan for ditching the ugly ThreadStatics. The data in them can instead be passed with FormattingContext. None of those changes were made yet, this is just refactoring to pass FormattingContext everywhere I think it will be needed.