### PR TITLE
docs: Fix the CI example codes to be valid

### DIFF
--- a/Docs/ContinuousIntegration.md
+++ b/Docs/ContinuousIntegration.md
@@ -22,9 +22,9 @@ Normally when using a code formatter like CSharpier, you'll want to ensure that 
 2. Use your preferred CI/CD tool to run the following commands.
    ```bash
    dotnet tool restore
-   dotnet-csharpier --check
+   dotnet tool run dotnet-csharpier --check .
    ```   
-   An example of a github action to accomplish this
+   An example of a GitHub Actions to accomplish this
    ```yaml
    name: Validate PR
    on:
@@ -38,7 +38,7 @@ Normally when using a code formatter like CSharpier, you'll want to ensure that 
          - uses: actions/checkout@v2
          - run: |
            dotnet tool restore
-           dotnet csharpier --check
+           dotnet tool run dotnet-csharpier --check .
    
    ```
 

--- a/Docs/ContinuousIntegration.md
+++ b/Docs/ContinuousIntegration.md
@@ -24,7 +24,7 @@ Normally when using a code formatter like CSharpier, you'll want to ensure that 
    dotnet tool restore
    dotnet tool run dotnet-csharpier --check .
    ```   
-   An example of a GitHub Actions to accomplish this
+   An example Github Actions workflow to accomplish this
    ```yaml
    name: Validate PR
    on:


### PR DESCRIPTION
- Fixed the format of the dotnet local tool command to be as shown in the .NET docs.
- Fixed typo for "github actions"

I'm not good at dotnet, but the current actions example didn't really work.
I fix the command to work by referring to the [.NET docs](https://docs.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use).