### PR TITLE
docs: Added neovim plugin option

### DIFF
--- a/Docs/Editors.md
+++ b/Docs/Editors.md
@@ -7,6 +7,7 @@ Running CSharpier on save is recommended. It will speed up your development time
 
 ### Visual Studio
 Use the [official 2022 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier)
+\
 Use the [official 2019 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier2019)
 ### Visual Studio Code
 Use the [official extension](https://marketplace.visualstudio.com/items?itemName=csharpier.csharpier-vscode)

--- a/Docs/Editors.md
+++ b/Docs/Editors.md
@@ -6,9 +6,11 @@ hide_table_of_contents: true
 Running CSharpier on save is recommended. It will speed up your development time.
 
 ### Visual Studio
-Use the [official 2022 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier)  
+Use the [official 2022 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier)
 Use the [official 2019 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier2019)
 ### Visual Studio Code
 Use the [official extension](https://marketplace.visualstudio.com/items?itemName=csharpier.csharpier-vscode)
 ### Rider
 Use the [official plugin](https://plugins.jetbrains.com/plugin/18243-csharpier)
+### Neovim
+Use [neoformat](https://github.com/sbdchd/neoformat)

--- a/Src/Website/docs/Editors.md
+++ b/Src/Website/docs/Editors.md
@@ -6,7 +6,8 @@ hide_table_of_contents: true
 Running CSharpier on save is recommended. It will speed up your development time.
 
 ### Visual Studio
-Use the [official 2022 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier)  
+Use the [official 2022 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier)
+\
 Use the [official 2019 extension](https://marketplace.visualstudio.com/items?itemName=csharpier.CSharpier2019)
 ### Visual Studio Code
 Use the [official extension](https://marketplace.visualstudio.com/items?itemName=csharpier.csharpier-vscode)

--- a/Src/Website/docs/Editors.md
+++ b/Src/Website/docs/Editors.md
@@ -12,3 +12,5 @@ Use the [official 2019 extension](https://marketplace.visualstudio.com/items?ite
 Use the [official extension](https://marketplace.visualstudio.com/items?itemName=csharpier.csharpier-vscode)
 ### Rider
 Use the [official plugin](https://plugins.jetbrains.com/plugin/18243-csharpier)
+### Neovim
+Use [neoformat](https://github.com/sbdchd/neoformat)


### PR DESCRIPTION
I recently merged a PR to [neoformat](https://github.com/sbdchd/neoformat) to support `csharpier` out of the box. This PR updates the editor plugin docs to reference it as an option for `neovim` users.

[Referenced neoformat PR](https://github.com/sbdchd/neoformat/pull/428)