### PR TITLE
Potential fix for multiple processes trying to save formatting cache

### DIFF
--- a/Src/CSharpier.Cli/FormattingCache.cs
+++ b/Src/CSharpier.Cli/FormattingCache.cs
@@ -110,17 +110,35 @@ internal static class FormattingCacheFactory
         {
             this.fileSystem.FileInfo.FromFileName(this.cacheFile).EnsureDirectoryExists();
 
-            await this.fileSystem.File.WriteAllTextAsync(
-                this.cacheFile,
-                JsonSerializer.Serialize(
-                    this.cacheDictionary
+            async Task WriteFile()
+            {
+                await this.fileSystem.File.WriteAllTextAsync(
+                    this.cacheFile,
+                    JsonSerializer.Serialize(
+                        this.cacheDictionary
 #if DEBUG
-                    ,
-                    new JsonSerializerOptions { WriteIndented = true }
+                        ,
+                        new JsonSerializerOptions { WriteIndented = true }
 #endif
-                ),
-                cancellationToken
-            );
+                    ),
+                    cancellationToken
+                );
+            }
+
+            var wait = 1;
+            for (var x = 0; x < 10; x++)
+            {
+                try
+                {
+                    await WriteFile();
+                    return;
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(wait), cancellationToken);
+                    wait *= 2;
+                }
+            }
         }
     }
 

--- a/Src/CSharpier.Cli/FormattingCache.cs
+++ b/Src/CSharpier.Cli/FormattingCache.cs
@@ -125,8 +125,8 @@ internal static class FormattingCacheFactory
                 );
             }
 
-            var wait = 1;
-            for (var x = 0; x < 10; x++)
+            // in my testing we don't normally have to wait more than a couple MS, but just in case
+            for (var x = 0; x < 20; x++)
             {
                 try
                 {
@@ -135,8 +135,7 @@ internal static class FormattingCacheFactory
                 }
                 catch (Exception)
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(wait), cancellationToken);
-                    wait *= 2;
+                    await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
                 }
             }
         }

--- a/Src/CSharpier/DebugLogger.cs
+++ b/Src/CSharpier/DebugLogger.cs
@@ -17,7 +17,6 @@ public class DebugLogger
             }
             catch (Exception)
             {
-                File.AppendAllText(@"C:\projects\csharpier\debug.txt", message + "\n");
                 // we don't care if this fails
             }
         }


### PR DESCRIPTION
closes #728

I'm not in love with this fix, but it will ensure that csharpier doesn't crash when multiple csharpier processes try to write the formatting cache at the same time. Maybe the waiting time doubling is overkill, and it should just wait 1ms and try 10 times. 20 times? I'll think about it more again in the morning. I'd like to get a fix out tomorrow because I'm going on vacation for 5 days after tomorrow.

One downside is that in the case of 4 projects being formatted at the same time, the first time csharpier runs using MSbuild if all 4 build at the same time only 1 of the projects will end up in the cache. But after you build 4 times, chances are good that the cache will catch up. The other option would be to reread the cache before writing it and tying to merge things together.

Or another option would be to have separate caches based on the folder that is being formatted, then this problem should be avoided completely.... hmm.... May be worth digging into how prettier/black deal with this behind the scenes.