### PR TITLE
Only read files that are UTF8 or UTF8 BOM

### DIFF
--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -40,4 +40,5 @@ jobs:
             7.0.100
             6.0.300
       - run: |
+          dotnet restore Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -40,5 +40,4 @@ jobs:
             7.0.100
             6.0.300
       - run: |
-          dotnet restore Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,6 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.0"/>
     <PackageVersion Include="System.Text.Json" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
-    <PackageVersion Include="UTF.Unknown" Version="2.3.0"/>
     <PackageVersion Include="YamlDotNet" Version="11.1.1"/>
   </ItemGroup>
 </Project>

--- a/Src/CSharpier.Cli.Tests/CliTests.cs
+++ b/Src/CSharpier.Cli.Tests/CliTests.cs
@@ -222,7 +222,9 @@ public class CliTests
 
         result.ErrorOutput
             .Should()
-            .Be($"Error {output} - Failed to compile so was not formatted.{Environment.NewLine}");
+            .Be(
+                $"Error {output} - Failed to compile so was not formatted.{Environment.NewLine}  (1,26): error CS1513: }} expected{Environment.NewLine}"
+            );
         result.ExitCode.Should().Be(1);
     }
 

--- a/Src/CSharpier.Cli/CSharpier.Cli.csproj
+++ b/Src/CSharpier.Cli/CSharpier.Cli.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="System.IO.Abstractions.TestingHelpers"/>
     <PackageReference Include="System.IO.Hashing"/>
     <PackageReference Include="System.Text.Encoding.CodePages"/>
-    <PackageReference Include="UTF.Unknown"/>
     <PackageReference Include="YamlDotNet"/>
   </ItemGroup>
   <ItemGroup>

--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace CSharpier.Cli;
 
+using System.Text;
+
 internal static class CommandLineFormatter
 {
     public static async Task<int> Format(
@@ -366,7 +368,13 @@ internal static class CommandLineFormatter
 
         if (codeFormattingResult.Errors.Any())
         {
-            fileIssueLogger.WriteError("Failed to compile so was not formatted.");
+            var errorMessage = new StringBuilder();
+            errorMessage.AppendLine("Failed to compile so was not formatted.");
+            foreach (var message in codeFormattingResult.Errors)
+            {
+                errorMessage.AppendLine(message.ToString());
+            }
+            fileIssueLogger.WriteError(errorMessage.ToString());
             Interlocked.Increment(ref commandLineFormatterResult.FailedCompilation);
             return;
         }

--- a/Src/CSharpier.Cli/FileReader.cs
+++ b/Src/CSharpier.Cli/FileReader.cs
@@ -28,7 +28,10 @@ internal static class FileReader
             // this is kind of a "hack" - read the file without the BOM then
             // streamReader.CurrentEncoding below will correctly be UTF8 or UTF8-BOM
             // https://stackoverflow.com/a/27976558
-            using var streamReader = new StreamReader(fileStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            using var streamReader = new StreamReader(
+                fileStream,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+            );
 
             var fileContents = await streamReader.ReadToEndAsync();
 

--- a/Src/CSharpier.Cli/FileReader.cs
+++ b/Src/CSharpier.Cli/FileReader.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using System.Text;
-using UtfUnknown;
 
 namespace CSharpier.Cli;
 

--- a/Src/CSharpier.Cli/FileReader.cs
+++ b/Src/CSharpier.Cli/FileReader.cs
@@ -28,7 +28,7 @@ internal static class FileReader
             // this is kind of a "hack" - read the file without the BOM then
             // streamReader.CurrentEncoding below will correctly be UTF8 or UTF8-BOM
             // https://stackoverflow.com/a/27976558
-            using var streamReader = new StreamReader(fileStream, new UTF8Encoding(false));
+            using var streamReader = new StreamReader(fileStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var fileContents = await streamReader.ReadToEndAsync();
 

--- a/Src/CSharpier.Cli/FileReader.cs
+++ b/Src/CSharpier.Cli/FileReader.cs
@@ -25,6 +25,9 @@ internal static class FileReader
         {
             await using var fileStream = fileSystem.File.OpenRead(filePath);
 
+            // this is kind of a "hack" - read the file without the BOM then
+            // streamReader.CurrentEncoding below will correctly be UTF8 or UTF8-BOM
+            // https://stackoverflow.com/a/27976558
             using var streamReader = new StreamReader(fileStream, new UTF8Encoding(false));
 
             var fileContents = await streamReader.ReadToEndAsync();

--- a/Src/CSharpier.Cli/FileReader.cs
+++ b/Src/CSharpier.Cli/FileReader.cs
@@ -25,24 +25,16 @@ internal static class FileReader
         try
         {
             await using var fileStream = fileSystem.File.OpenRead(filePath);
-            var detectionResult = CharsetDetector.DetectFromStream(fileStream);
-            var encoding = detectionResult?.Detected?.Encoding;
-            if (encoding == null)
-            {
-                unableToDetectEncoding = true;
-                encoding = Encoding.Default;
-            }
 
-            fileStream.Seek(0, SeekOrigin.Begin);
-
-            // this fixes an issue with ANSI encoded files like csharpier-repos\AutoMapper\src\UnitTests\Internationalization.cs
-            var encodingToRead = encoding.CodePage == 852 ? Encoding.GetEncoding(1252) : encoding;
-
-            using var streamReader = new StreamReader(fileStream, encodingToRead);
+            using var streamReader = new StreamReader(fileStream, new UTF8Encoding(false));
 
             var fileContents = await streamReader.ReadToEndAsync();
 
-            return new FileReaderResult(encoding, fileContents, unableToDetectEncoding);
+            return new FileReaderResult(
+                streamReader.CurrentEncoding,
+                fileContents,
+                unableToDetectEncoding
+            );
         }
         finally
         {

--- a/Src/CSharpier.Tests/CSharpier.Tests.csproj
+++ b/Src/CSharpier.Tests/CSharpier.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="NUnit"/>
     <PackageReference Include="NUnit3TestAdapter"/>
-    <PackageReference Include="UTF.Unknown"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CSharpier.Cli\CSharpier.Cli.csproj"/>

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncodingAnsi.cst
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncodingAnsi.cst
@@ -1,4 +1,0 @@
-public class AnsiCharacters
-{
-    public string ∆ше;
-}

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncoding_UTF8.cst
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncoding_UTF8.cst
@@ -2,3 +2,9 @@ public class ClassName
 {
     public void MethodName() { }
 }
+
+public enum MeetingLocation
+{
+    Café,
+    Restaurant
+}

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncoding_UTF8BOM.cst
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/FileEncoding_UTF8BOM.cst
@@ -2,3 +2,9 @@
 {
     public void MethodName() { }
 }
+
+public enum MeetingLocation
+{
+    Café,
+    Restaurant
+}


### PR DESCRIPTION
closes #768

Previously UTF.Unknown was used to try to determine file encodings. This was problematic because if a file was too small, it would end up with several possible encodings. The encoding it considered most likely was not always correct. As opposed to trying to read a file as each encoding type, CSharpier now only supports UTF8 files. This is consistent with the IDE plugins, which stream files to CSharpier as UTF8. If a file is UTF8-BOM, it will retain the BOM.