### PR TITLE
Checks compatible target framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.22.1
+## What's Changed
+#### Fix for CSharpier.MsBuild so it selects a compatible framework if the project does not target net6 or net7 [#797](https://github.com/belav/csharpier/pull/797)
+This fix auto selects `net7.0` for projects that do not target `net6.0` or `net7.0`. This means the `CSharpier_FrameworkVersion` property is only required if a project is targeting < `net6.0` and `net7.0` is not installed.
+
+Thanks go to @samtrion for submitting the fix.
+
 # 0.22.0
 ## Breaking Changes
 #### Support only UTF8 and UTF8-BOM files [#787](https://github.com/belav/csharpier/pull/787)
@@ -23,12 +30,17 @@ CSharpier now only supports UTF8 & UTF8-BOM files. This is consistent with the I
 
 Thanks go to @Meligy for reporting the problem.
 
+#### CSharpier.MSBuild support for .NET 7 [#773](https://github.com/belav/csharpier/issues/773)
+CSharpier.MSBuild now multi-targets net6.0 and net7.0. As a side effect of multi-targeting, the `CSharpier_FrameworkVersion` property is now required for projects that do not target `net6.0` or `net7.0`. See https://csharpier.com/docs/MsBuild#target-frameworks
+
+Thanks go to @OneCyrus for reporting it
+
 ## What's Changed
 #### Fix for CSharpier.MsBuild "Specified condition "$(CSharpier_Check)" evaluates to "" instead of a boolean" [#788](https://github.com/belav/csharpier/pull/788)
 When projects referencing CSharpier.MsBuild were reloaded, they would get the error "Specified condition "$(CSharpier_Check)" evaluates to "" instead of a boolean" and fail to load.
 
 
-Thanks go to @samtrion for reporting it
+Thanks go to @samtrion for submitting the fix.
 
 #### List Pattern support for subpattern within a slice [#779](https://github.com/belav/csharpier/issues/779)
 
@@ -63,11 +75,6 @@ var trailingComment = $"{someValue /* Comment shouldn't cause new line */}";
 ```
 
 Thanks go to @IT-CASADO for reporting it
-
-#### CSharpier.MSBuild not working with .NET 7 [#773](https://github.com/belav/csharpier/issues/773)
-CSharpier.MSBuild now multi-targets net6.0 and net7.0.
-
-Thanks go to @OneCyrus for reporting it
 
 #### Always put generic type constraints onto a new line [#527](https://github.com/belav/csharpier/issues/527)
 ```c#

--- a/CSharpier.Build.props
+++ b/CSharpier.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.22.0</Version>
+    <Version>0.21.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/belav/csharpier</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Docs/MSBuild.md
+++ b/Docs/MSBuild.md
@@ -1,3 +1,4 @@
+
 ---
 title: MsBuild Package
 hide_table_of_contents: true
@@ -9,8 +10,8 @@ Install-Package CSharpier.MSBuild
 ```
 
 ## Target Frameworks
-By default CSharpier.MsBuild will run CSharpier using the target framework of the project it is running on.  
-This can be controlled with the following property. This property is required if the csproj is targeting < net6.0 (netstandard2.0, net48, etc)
+CSharpier.MSBuild will be run with net6.0 or net7.0 if the project targets one of the two frameworks. In cases where the project targets something else (net48, netstandard2.0) `CSharpier_FrameworkVersion` will default to net7.0
+This can be controlled with the following property. This property is required if the csproj is targeting < net6.0 (netstandard2.0, net48, etc) and net7.0 is not installed.
 ```xml
   <PropertyGroup>
     <CSharpier_FrameworkVersion>net6.0</CSharpier_FrameworkVersion>

--- a/Src/CSharpier.MsBuild/README.md
+++ b/Src/CSharpier.MsBuild/README.md
@@ -2,5 +2,5 @@ This can be tested by
 
 - Making any changes you want
 - Running the script at `[RepositoryRoot]/Scripts/BuildPackages.ps1`
-- Running this from the root `docker build . -f /Src/CSharpier.MsBuild.Test/Dockerfile`
+- Running this from the root `docker build . -f ./Src/CSharpier.MsBuild.Test/Dockerfile`
 

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == ''">$(TargetFramework)</CSharpier_FrameworkVersion>
+        <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' != 'net6.0' and '$(CSharpier_FrameworkVersion)' != 'net7.0'">net7.0</CSharpier_FrameworkVersion>
         <CSharpierDllPath>$(MSBuildThisFileDirectory)../tools/csharpier/$(CSharpier_FrameworkVersion)/dotnet-csharpier.dll</CSharpierDllPath>
         <CSharpierArgs Condition="'$(CSharpier_Check)' == 'true'">$(CSharpierArgs) --check</CSharpierArgs>
     </PropertyGroup>


### PR DESCRIPTION
Checks if a compatible target framework is used. If not, .NET 7 is used.

This prevents error messages like the following.
```
C:\Users\<username>\.nuget\packages\csharpier.msbuild\0.22.0\build\../tools/csharpier/netstandard2.0/dotnet-csharpier.dll  C:\sources\Test1\src\Console1" exited with code 1.
```