### PR TITLE
Offer a pre-commit hook that runs the .NET tool

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: csharpier
+  name: Run CSharpier on C# files
+  entry: dotnet tool run dotnet-csharpier
+  language: dotnet
+  types:
+    - c#
+  description: CSharpier is an opinionated C# formatter inspired by Prettier.

--- a/Docs/Pre-commit.md
+++ b/Docs/Pre-commit.md
@@ -5,8 +5,22 @@ hide_table_of_contents: true
 
 CSharpier can be used with a pre-commit hook to ensure that all staged files are formatted before being committed.
 
+## [pre-commit](https://pre-commit.com)
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+    - repo: https://github.com/belav/csharpier
+      rev: 0.23.0 # Replace with the latest Git tag.
+      hooks:
+        - id: csharpier
+```
+
+[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
+[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+
 ## [Husky.Net](https://github.com/alirezanet/husky.net)
-Husky.Net makes setting up a pre-commit hook simple. 
 
 From the root of your repository
 ```bash

--- a/Src/Website/docs/Pre-commit.md
+++ b/Src/Website/docs/Pre-commit.md
@@ -5,8 +5,22 @@ hide_table_of_contents: true
 
 CSharpier can be used with a pre-commit hook to ensure that all staged files are formatted before being committed.
 
+## [pre-commit](https://pre-commit.com)
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+    - repo: https://github.com/belav/csharpier
+      rev: 0.23.0 # Replace with the latest Git tag.
+      hooks:
+        - id: csharpier
+```
+
+[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
+[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+
 ## [Husky.Net](https://github.com/alirezanet/husky.net)
-Husky.Net makes setting up a pre-commit hook simple. 
 
 From the root of your repository
 ```bash

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100"
+    "version": "7.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
.NET pre-commit hooks rely on `dotnet pack`, which uses the .NET SDK version specified in `global.json`. Relax the .NET SDK version constraint from ~7.0.100 to ^7.0.100, maximizing compatibility.