### PR TITLE
Remove pre-commit hook; document options (#820)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,0 @@
-- id: csharpier
-  name: Run CSharpier on C# files
-  entry: dotnet tool run dotnet-csharpier
-  language: dotnet
-  types:
-    - c#
-  description: CSharpier is an opinionated C# formatter inspired by Prettier.

--- a/Docs/Pre-commit.md
+++ b/Docs/Pre-commit.md
@@ -7,18 +7,60 @@ CSharpier can be used with a pre-commit hook to ensure that all staged files are
 
 ## [pre-commit](https://pre-commit.com)
 
+[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
+[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+
+
+### [MegaLinter](https://megalinter.io/)
+
+CSharpier runs as part of
+[MegaLinter's pre-commit hooks](https://megalinter.io/latest/mega-linter-runner/#pre-commit-hook).
+
+
+### Standalone
+
+If you prefer not to run the other linters included in MegaLinter, you can
+alternatively run CSharpier as a local pre-commit hook.
+
 Add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-    - repo: https://github.com/belav/csharpier
-      rev: 0.23.0 # Replace with the latest Git tag.
-      hooks:
-        - id: csharpier
+  - repo: local
+    hooks:
+      - id: dotnet-tool-restore
+        name: Install .NET tools
+        entry: dotnet tool restore
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages:
+          - commit
+          - push
+          - post-checkout
+          - post-rewrite
+        description: Install the .NET tools listed at .config/dotnet-tools.json.
+      - id: csharpier
+        name: Run CSharpier on C# files
+        entry: dotnet tool run dotnet-csharpier
+        language: system
+        types:
+          - c#
+        description: CSharpier is an opinionated C# formatter inspired by Prettier.
 ```
 
-[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
-[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+Add the following to your `.config/dotnet-tools.json`:
+
+```json
+{
+  "tools": {
+    "CSharpier": {
+      "version": "0.22.1",
+      "commands": ["dotnet-csharpier"]
+    }
+  }
+}
+```
 
 ## [Husky.Net](https://github.com/alirezanet/husky.net)
 

--- a/Src/Website/docs/Pre-commit.md
+++ b/Src/Website/docs/Pre-commit.md
@@ -7,18 +7,60 @@ CSharpier can be used with a pre-commit hook to ensure that all staged files are
 
 ## [pre-commit](https://pre-commit.com)
 
+[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
+[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+
+
+### [MegaLinter](https://megalinter.io/)
+
+CSharpier runs as part of
+[MegaLinter's pre-commit hooks](https://megalinter.io/latest/mega-linter-runner/#pre-commit-hook).
+
+
+### Standalone
+
+If you prefer not to run the other linters included in MegaLinter, you can
+alternatively run CSharpier as a local pre-commit hook.
+
 Add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-    - repo: https://github.com/belav/csharpier
-      rev: 0.23.0 # Replace with the latest Git tag.
-      hooks:
-        - id: csharpier
+  - repo: local
+    hooks:
+      - id: dotnet-tool-restore
+        name: Install .NET tools
+        entry: dotnet tool restore
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages:
+          - commit
+          - push
+          - post-checkout
+          - post-rewrite
+        description: Install the .NET tools listed at .config/dotnet-tools.json.
+      - id: csharpier
+        name: Run CSharpier on C# files
+        entry: dotnet tool run dotnet-csharpier
+        language: system
+        types:
+          - c#
+        description: CSharpier is an opinionated C# formatter inspired by Prettier.
 ```
 
-[Install pre-commit via your preferred Python package manager.](https://pre-commit.com/#install)
-[Run `pre-commit install` to install the Git hook scripts.](https://pre-commit.com/#3-install-the-git-hook-scripts)
+Add the following to your `.config/dotnet-tools.json`:
+
+```json
+{
+  "tools": {
+    "CSharpier": {
+      "version": "0.22.1",
+      "commands": ["dotnet-csharpier"]
+    }
+  }
+}
+```
 
 ## [Husky.Net](https://github.com/alirezanet/husky.net)
 


### PR DESCRIPTION
Resolves #820.

pre-commit doesn't currently support additional dependencies for .NET hooks, so the CSharpier hook didn't work, because CSharpier relies on additional dependencies. Document how to run CSharpier via MegaLinter's pre-commit hooks or a standalone local pre-commit hook.