### PR TITLE
Add support for ARM64 version of VS2022

### DIFF
--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
@@ -13,6 +13,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="83d6b6a0-9e25-4034-80f3-38445d8a8837" Version="1.4.3" Language="en-US" Publisher="CSharpier" />
+        <Identity Id="83d6b6a0-9e25-4034-80f3-38445d8a8837" Version="1.4.4" Language="en-US" Publisher="CSharpier" />
         <DisplayName>CSharpier</DisplayName>
         <Description xml:space="preserve">CSharpier is an opinionated code formatter for c#. It uses Roslyn to parse your code and re-prints it using its own rules.</Description>
         <MoreInfo>https://github.com/belav/csharpier</MoreInfo>

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudio2019/source.extension.vsixmanifest
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudio2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="edd8b38c-baa1-46c6-b82e-1da7a0ba597b" Version="1.4.3" Language="en-US" Publisher="CSharpier" />
+        <Identity Id="edd8b38c-baa1-46c6-b82e-1da7a0ba597b" Version="1.4.4" Language="en-US" Publisher="CSharpier" />
         <DisplayName>CSharpier 2019</DisplayName>
         <Description xml:space="preserve">CSharpier is an opinionated code formatter for c#. It uses Roslyn to parse your code and re-prints it using its own rules.</Description>
         <MoreInfo>https://github.com/belav/csharpier</MoreInfo>

--- a/Src/CSharpier.VisualStudio/ChangeLog.md
+++ b/Src/CSharpier.VisualStudio/ChangeLog.md
@@ -1,4 +1,7 @@
-﻿## [1.4.3]
+﻿## [1.4.4]
+- Add support for ARM64
+
+## [1.4.3]
 - Fix for format on save sometimes not working in VS2022 17.7
 
 ## [1.4.2]


### PR DESCRIPTION
According to the [official docs](https://learn.microsoft.com/en-us/visualstudio/extensibility/arm64/target-arm64-visual-studio-extension?view=vs-2022) there should be only a need for a specific InstallationTarget to support ARM64 version of Visual Studio. 

I've added it and it seems to be working correctly in my experimental release.

I know that I am probably the only user of ARM version of VS2022, but still I'd really like to use CSharpier ;)