### PR TITLE
fix: support EditorConfig comments

### DIFF
--- a/Src/CSharpier.Cli/EditorConfig/ConfigFileParser.cs
+++ b/Src/CSharpier.Cli/EditorConfig/ConfigFileParser.cs
@@ -1,13 +1,25 @@
 using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 using IniParser;
+using IniParser.Model.Configuration;
+using IniParser.Parser;
 
 namespace CSharpier.Cli.EditorConfig;
 
 internal static class ConfigFileParser
 {
+    // According to https://spec.editorconfig.org/#file-format
+    // "Comment: starts with a ; or a #."
+    private static readonly Regex CommentRegex = new("^[;#].*$");
+    
+    private static readonly IniParserConfiguration Configuration = new()
+    {
+        CommentRegex = CommentRegex,
+    };
+    
     public static ConfigFile Parse(string filePath, IFileSystem fileSystem)
     {
-        var parser = new FileIniDataParser();
+        var parser = new FileIniDataParser(new IniDataParser(Configuration));
 
         using var stream = fileSystem.File.OpenRead(filePath);
         using var streamReader = new StreamReader(stream);

--- a/Src/CSharpier.Cli/EditorConfig/ConfigFileParser.cs
+++ b/Src/CSharpier.Cli/EditorConfig/ConfigFileParser.cs
@@ -11,12 +11,10 @@ internal static class ConfigFileParser
     // According to https://spec.editorconfig.org/#file-format
     // "Comment: starts with a ; or a #."
     private static readonly Regex CommentRegex = new("^[;#].*$");
-    
-    private static readonly IniParserConfiguration Configuration = new()
-    {
-        CommentRegex = CommentRegex,
-    };
-    
+
+    private static readonly IniParserConfiguration Configuration =
+        new() { CommentRegex = CommentRegex, };
+
     public static ConfigFile Parse(string filePath, IFileSystem fileSystem)
     {
         var parser = new FileIniDataParser(new IniDataParser(Configuration));

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -215,6 +215,35 @@ end_of_line = crlf
         result.EndOfLine.Should().Be(EndOfLine.CRLF);
     }
 
+    [Test]
+    public async Task Should_Support_EditorConfig_With_Comments()
+    {
+        var context = new TestContext();
+        context.WhenAFileExists(
+            "c:/test/.editorconfig",
+            @"
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+max_line_length = 10
+; Windows-style line endings
+end_of_line = crlf
+"
+        );
+
+        var result = await context.CreateProviderAndGetOptionsFor("c:/test", "c:/test/test.cs");
+
+        result.UseTabs.Should().BeFalse();
+        result.TabWidth.Should().Be(2);
+        result.Width.Should().Be(10);
+        result.EndOfLine.Should().Be(EndOfLine.CRLF);
+    }
+    
     [TestCase("tab_width")]
     [TestCase("indent_size")]
     public async Task Should_Support_EditorConfig_Tabs(string propertyName)

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -243,7 +243,7 @@ end_of_line = crlf
         result.Width.Should().Be(10);
         result.EndOfLine.Should().Be(EndOfLine.CRLF);
     }
-    
+
     [TestCase("tab_width")]
     [TestCase("indent_size")]
     public async Task Should_Support_EditorConfig_Tabs(string propertyName)


### PR DESCRIPTION
The spec very clearly states that comments are supported. Without this fix a basic config file like the example given on the EditorConfig website will cause a crash.

```
# EditorConfig is awesome: https://EditorConfig.org

# top-most EditorConfig file
root = true

# Unix-style newlines with a newline ending every file
[*]
end_of_line = lf
insert_final_newline = true

# ...
```

Spec: https://spec.editorconfig.org/#file-format