### PR TITLE
Cleaning up action

### DIFF
--- a/.github/workflows/format_repositories.yml
+++ b/.github/workflows/format_repositories.yml
@@ -12,9 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: csharpier
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '7.0.400'
+      - uses: actions/setup-dotnet@v3
       - uses: actions/checkout@v2
         with:
           repository: belav/csharpier-repos

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -8,11 +8,7 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            7.0.400
-            6.0.300
+      - uses: actions/setup-dotnet@v3
       - run: >
           dotnet test Src/CSharpier.Tests/CSharpier.Tests.csproj
           --configuration Release
@@ -29,11 +25,7 @@ jobs:
       NUGET_KEY: ${{secrets.NUGET_API_KEY}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            7.0.400
-            6.0.300
+      - uses: actions/setup-dotnet@v3
       - name: Publish CSharpier.Core library on version change
         uses: alirezanet/publish-nuget@v3.0.4
         with:

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -8,11 +8,7 @@ jobs:
     name: Run Tests
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            7.0.400
-            6.0.300
+      - uses: actions/setup-dotnet@v3
       - run: >
           dotnet test CSharpier.sln
           --configuration Release
@@ -25,11 +21,7 @@ jobs:
     name: Check Formatting
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            7.0.400
-            6.0.300
+      - uses: actions/setup-dotnet@v3
       - run: |
           dotnet tool restore
           dotnet csharpier . --check
@@ -38,10 +30,6 @@ jobs:
     name: Build CSharpier.MSBuild
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            7.0.400
-            6.0.300
+      - uses: actions/setup-dotnet@v3
       - run: |
           dotnet build Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj


### PR DESCRIPTION
It looks like the newest setup-dotnet will read the global.json file, which appears to eliminate the need to specify the version at all