### PR TITLE
Formatting struct primary constructor

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/StructDeclarations.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/StructDeclarations.test
@@ -1,3 +1,12 @@
 struct BasicStruct { }
 
 public readonly struct ReadonlyStruct { }
+
+public struct NamedItem2(
+    string name1________________________________,
+    string name2________________________________
+)
+{
+    public string Name1 => name1;
+    public string Name2 => name1;
+}

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -35,6 +35,7 @@ internal static class BaseTypeDeclaration
             else if (node is StructDeclarationSyntax structDeclarationSyntax)
             {
                 keyword = structDeclarationSyntax.Keyword;
+                parameterList = structDeclarationSyntax.ParameterList;
             }
             else if (node is InterfaceDeclarationSyntax interfaceDeclarationSyntax)
             {


### PR DESCRIPTION
closes #969

looks like I missed that structs could also have primary constructors when I made this work for classes.
