### PR TITLE
Ignore .editorconfig file included in the .csharpierignore file

### DIFF
--- a/Src/CSharpier.Cli/EditorConfig/EditorConfigParser.cs
+++ b/Src/CSharpier.Cli/EditorConfig/EditorConfigParser.cs
@@ -7,7 +7,8 @@ internal static class EditorConfigParser
     /// <summary>Finds all configs above the given directory as well as within the subtree of this directory</summary>
     public static List<EditorConfigSections> FindForDirectoryName(
         string directoryName,
-        IFileSystem fileSystem
+        IFileSystem fileSystem,
+        IgnoreFile ignoreFile
     )
     {
         if (directoryName is "")
@@ -18,6 +19,7 @@ internal static class EditorConfigParser
         var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(directoryName);
         var editorConfigFiles = directoryInfo
             .EnumerateFiles(".editorconfig", SearchOption.AllDirectories)
+            .Where(x => !ignoreFile.IsIgnored(x.FullName))
             .ToList();
 
         // already found any in this directory above

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using Microsoft.Extensions.Logging;
 
 namespace CSharpier.Cli;
 

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -48,19 +48,20 @@ internal class OptionsProvider
 
         IList<EditorConfigSections>? editorConfigSections = null;
 
+        var ignoreFile = await IgnoreFile.Create(directoryName, fileSystem, cancellationToken);
+        
         try
         {
             editorConfigSections = EditorConfigParser.FindForDirectoryName(
                 directoryName,
-                fileSystem
+                fileSystem,
+                ignoreFile
             );
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, $"Failure parsing editorconfig files for {directoryName}");
+            logger.LogError(ex, "Failure parsing editorconfig files for {DirectoryName}", directoryName);
         }
-
-        var ignoreFile = await IgnoreFile.Create(directoryName, fileSystem, cancellationToken);
 
         return new OptionsProvider(
             editorConfigSections ?? Array.Empty<EditorConfigSections>(),

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -49,7 +49,7 @@ internal class OptionsProvider
         IList<EditorConfigSections>? editorConfigSections = null;
 
         var ignoreFile = await IgnoreFile.Create(directoryName, fileSystem, cancellationToken);
-        
+
         try
         {
             editorConfigSections = EditorConfigParser.FindForDirectoryName(
@@ -60,7 +60,11 @@ internal class OptionsProvider
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failure parsing editorconfig files for {DirectoryName}", directoryName);
+            logger.LogError(
+                ex,
+                "Failure parsing editorconfig files for {DirectoryName}",
+                directoryName
+            );
         }
 
         return new OptionsProvider(

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -519,6 +519,56 @@ indent_size = 2
         );
         result.TabWidth.Should().Be(1);
     }
+    
+    [Test]
+    public async Task Should_Ignore_Invalid_EditorConfig()
+    {
+        var context = new TestContext();
+        context.WhenAFileExists(
+            "c:/test/.editorconfig",
+            @"
+[*]
+indent_size = 2
+INVALID
+"
+        );
+
+        var result = await context.CreateProviderAndGetOptionsFor("c:/test", "c:/test/test.cs");
+        
+        result.TabWidth.Should().Be(4);
+    }
+    
+    [Test]
+    public async Task Should_Ignore_Ignored_EditorConfig()
+    {
+        var context = new TestContext();
+        context.WhenAFileExists(
+            "c:/test/subfolder/.editorconfig",
+            @"
+    [*]
+    indent_size = 2
+    "
+        );
+
+        context.WhenAFileExists(
+            "c:/test/.editorconfig",
+            @"
+    [*]
+    indent_size = 1
+    "
+        );
+        
+        context.WhenAFileExists(
+            "c:/test/.csharpierignore",
+            "/subfolder/.editorconfig"
+        );
+
+        var result = await context.CreateProviderAndGetOptionsFor(
+            "c:/test",
+            "c:/test/subfolder/test.cs"
+        );
+        result.TabWidth.Should().Be(1);
+    }
 
     [Test]
     public async Task Should_Prefer_Closer_CSharpierrc()

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -519,7 +519,7 @@ indent_size = 2
         );
         result.TabWidth.Should().Be(1);
     }
-    
+
     [Test]
     public async Task Should_Ignore_Invalid_EditorConfig()
     {
@@ -534,10 +534,10 @@ INVALID
         );
 
         var result = await context.CreateProviderAndGetOptionsFor("c:/test", "c:/test/test.cs");
-        
+
         result.TabWidth.Should().Be(4);
     }
-    
+
     [Test]
     public async Task Should_Ignore_Ignored_EditorConfig()
     {
@@ -557,11 +557,8 @@ INVALID
     indent_size = 1
     "
         );
-        
-        context.WhenAFileExists(
-            "c:/test/.csharpierignore",
-            "/subfolder/.editorconfig"
-        );
+
+        context.WhenAFileExists("c:/test/.csharpierignore", "/subfolder/.editorconfig");
 
         var result = await context.CreateProviderAndGetOptionsFor(
             "c:/test",


### PR DESCRIPTION
This will resolves issue #1023.

Any .editorconfig file included in the .csharpierignore file will not be parsed. By default we ignore everything in node_modules, but it still tries to parse the .editconfig file.