### PR TITLE
Use NETCoreSdkVersion to determine which CSharpier tool version to use during builds

### DIFF
--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
-    <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == ''">$(TargetFramework)</CSharpier_FrameworkVersion>
-    <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' != 'net6.0' and '$(CSharpier_FrameworkVersion)' != 'net7.0' and '$(CSharpier_FrameworkVersion)' != 'net8.0'">net7.0</CSharpier_FrameworkVersion>
+    <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '8.0'))">net8.0</CSharpier_FrameworkVersion>
+    <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '7.0'))">net7.0</CSharpier_FrameworkVersion>
+    <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0'))">net6.0</CSharpier_FrameworkVersion>
     <CSharpierDllPath>$(MSBuildThisFileDirectory)../tools/csharpier/$(CSharpier_FrameworkVersion)/dotnet-csharpier.dll</CSharpierDllPath>
     <CSharpierArgs Condition="'$(CSharpier_Check)' == 'true'">$(CSharpierArgs) --check</CSharpierArgs>
     <CSharpierArgs Condition="'$(CSharpier_LogLevel)' != ''">$(CSharpierArgs) --loglevel $(CSharpier_LogLevel)</CSharpierArgs>


### PR DESCRIPTION
Relevant issues:
https://github.com/belav/csharpier/issues/1027
https://github.com/belav/csharpier/issues/1022
https://github.com/belav/csharpier/issues/1019

Instead of using the current TargetFramework that is being built as part of the MSBuild process we use the SDK version that the MSBuild process is using to determine which version of the CSharpier dotnet tool we should use.

The goal is to allow those who only keep one version of an SDK and runtime installed on their machine the ability to use CSharpier in a more reliable manner.

