### PR TITLE
Sort usings with Ordinal culture (#1051)

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/UsingDirectives.cs
+++ b/Src/CSharpier/SyntaxPrinter/UsingDirectives.cs
@@ -280,10 +280,18 @@ internal static class UsingDirectives
 
             if (x.Alias is not null && y.Alias is not null)
             {
-                return x.Alias.ToFullString().CompareTo(y.Alias.ToFullString());
+                return String.Compare(
+                    x.Alias.ToFullString(),
+                    y.Alias.ToFullString(),
+                    StringComparison.Ordinal
+                );
             }
 
-            return x.Name.ToFullString().CompareTo(y.Name.ToFullString());
+            return String.Compare(
+                x.Name.ToFullString(),
+                y.Name.ToFullString(),
+                StringComparison.Ordinal
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #1051.

I used `Ordinal` here just because it was what Rider suggested:

![image](https://github.com/belav/csharpier/assets/1174072/bfdadaac-fca3-4e62-a52a-e05469d15c28)