### PR TITLE
Sort usings with OrdinalIgnoreCase

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UsingDirectives_SortIgnoreCasing.expected.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UsingDirectives_SortIgnoreCasing.expected.test
@@ -1,0 +1,4 @@
+using Aaword;
+using AWord;
+using Bbword;
+using BWord;

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UsingDirectives_SortIgnoreCasing.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UsingDirectives_SortIgnoreCasing.test
@@ -1,0 +1,4 @@
+using AWord;
+using BWord;
+using Bbword;
+using Aaword;

--- a/Src/CSharpier/SyntaxPrinter/UsingDirectives.cs
+++ b/Src/CSharpier/SyntaxPrinter/UsingDirectives.cs
@@ -283,14 +283,14 @@ internal static class UsingDirectives
                 return String.Compare(
                     x.Alias.ToFullString(),
                     y.Alias.ToFullString(),
-                    StringComparison.Ordinal
+                    StringComparison.OrdinalIgnoreCase
                 );
             }
 
             return String.Compare(
                 x.Name.ToFullString(),
                 y.Name.ToFullString(),
-                StringComparison.Ordinal
+                StringComparison.OrdinalIgnoreCase
             );
         }
     }


### PR DESCRIPTION
Fixes #1061

`Newtonsoft.Json` should be sorted before `NSubstitute`

