### PR TITLE
Remove extra newline for collection expression property initializers

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/CollectionExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/CollectionExpressions.test
@@ -97,4 +97,15 @@ class MyClass
             HttpMethod.None,
             HttpMethod.Connect,
         ];
+
+    public List<DayOfWeek> DaysOfWeek { get; } =
+        [
+            DayOfWeek.Sunday,
+            DayOfWeek.Monday,
+            DayOfWeek.Tuesday,
+            DayOfWeek.Wednesday,
+            DayOfWeek.Thursday,
+            DayOfWeek.Friday,
+            DayOfWeek.Saturday
+        ];
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CollectionExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CollectionExpression.cs
@@ -16,10 +16,7 @@ internal static class CollectionExpression
                         or ExpressionStatementSyntax
                     )
                 }
-                or EqualsValueClauseSyntax
-                {
-                    Parent: not (PropertyDeclarationSyntax or VariableDeclaratorSyntax)
-                }
+                or EqualsValueClauseSyntax { Parent: not VariableDeclaratorSyntax }
             ? Doc.Null
             : Doc.IfBreak(Doc.Line, Doc.Null);
 


### PR DESCRIPTION
Closes #1063 

Avoids adding a newline before a `CollectionExpressionSyntax` when its parent is an `EqualsValueClause` whose own parent is a `PropertyDeclarationSyntax`.