### PR TITLE
Update IntegratingWithLinters.md

### DIFF
--- a/docs/IntegratingWithLinters.md
+++ b/docs/IntegratingWithLinters.md
@@ -37,6 +37,7 @@ dotnet_diagnostic.SA1009.severity = none
 dotnet_diagnostic.SA1111.severity = none
 dotnet_diagnostic.SA1118.severity = none
 dotnet_diagnostic.SA1137.severity = none
+dotnet_diagnostic.SA1413.severity = none
 dotnet_diagnostic.SA1500.severity = none
 dotnet_diagnostic.SA1501.severity = none
 dotnet_diagnostic.SA1502.severity = none


### PR DESCRIPTION
SA1413: Use trailing comma in multiline initializer

This rule also conflicts with the csharpier formatting