### PR TITLE
refactor: Use switches instead of if-else in DocFitter

### DIFF
--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -30,18 +30,11 @@ internal static class DocFitter
                 return false;
             }
 
-            PrintCommand command;
-            if (newCommands.Count > 0)
+            var (currentIndent, currentMode, currentDoc) = newCommands switch
             {
-                command = newCommands.Pop();
-            }
-            else
-            {
-                command = remainingCommands.ElementAt(x);
-                x++;
-            }
-
-            var (currentIndent, currentMode, currentDoc) = command;
+                { Count: > 0 } => newCommands.Pop(),
+                _ => remainingCommands.ElementAt(x++)
+            };
 
             switch (currentDoc)
             {

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -41,7 +41,6 @@ internal static class DocFitter
                 case NullDoc:
                     break;
                 case StringDoc stringDoc:
-                {
                     // directives should not be considered when calculating if something fits
                     if (stringDoc.Value == null || stringDoc.IsDirective)
                         continue;
@@ -52,28 +51,18 @@ internal static class DocFitter
                     output.Append(stringDoc.Value);
                     remainingWidth -= stringDoc.Value.GetPrintedWidth();
                     break;
-                }
                 case LeadingComment
                 or TrailingComment:
-                {
                     if (output.Length > 0 && currentMode is not PrintMode.ForceFlat)
-                    {
                         returnFalseIfMoreStringsFound = true;
-                    }
 
                     break;
-                }
                 case Region:
                     return false;
                 case Concat concat:
-                {
                     for (var i = concat.Contents.Count - 1; i >= 0; i--)
-                    {
                         Push(concat.Contents[i], currentMode, currentIndent);
-                    }
-
                     break;
-                }
                 case IndentDoc indent:
                     Push(indent.Contents, currentMode, indenter.IncreaseIndent(currentIndent));
                     break;
@@ -114,7 +103,6 @@ internal static class DocFitter
                     break;
                 }
                 case LineDoc line:
-                {
                     if (currentMode is PrintMode.Flat or PrintMode.ForceFlat)
                     {
                         if (currentDoc is HardLine { SkipBreakIfFirstInGroup: true })
@@ -137,7 +125,6 @@ internal static class DocFitter
                     }
 
                     return true;
-                }
                 case ForceFlat flat:
                     Push(flat.Contents, PrintMode.ForceFlat, currentIndent);
                     break;

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -43,51 +43,51 @@ internal static class DocFitter
 
             var (currentIndent, currentMode, currentDoc) = command;
 
-            if (currentDoc is StringDoc stringDoc)
+            switch (currentDoc)
             {
-                // directives should not be considered when calculating if something fits
-                if (stringDoc.Value == null || stringDoc.IsDirective)
+                case NullDoc:
+                    break;
+                case StringDoc stringDoc:
                 {
-                    continue;
-                }
+                    // directives should not be considered when calculating if something fits
+                    if (stringDoc.Value == null || stringDoc.IsDirective)
+                        continue;
 
-                if (returnFalseIfMoreStringsFound)
-                {
-                    return false;
-                }
+                    if (returnFalseIfMoreStringsFound)
+                        return false;
 
-                output.Append(stringDoc.Value);
-                remainingWidth -= stringDoc.Value.GetPrintedWidth();
-            }
-            else if (currentDoc != Doc.Null)
-            {
-                if (currentDoc is LeadingComment or TrailingComment)
+                    output.Append(stringDoc.Value);
+                    remainingWidth -= stringDoc.Value.GetPrintedWidth();
+                    break;
+                }
+                case LeadingComment
+                or TrailingComment:
                 {
                     if (output.Length > 0 && currentMode is not PrintMode.ForceFlat)
                     {
                         returnFalseIfMoreStringsFound = true;
                     }
+
+                    break;
                 }
-                else if (currentDoc is Region)
-                {
+                case Region:
                     return false;
-                }
-                else if (currentDoc is Concat concat)
+                case Concat concat:
                 {
                     for (var i = concat.Contents.Count - 1; i >= 0; i--)
                     {
                         Push(concat.Contents[i], currentMode, currentIndent);
                     }
+
+                    break;
                 }
-                else if (currentDoc is IndentDoc indent)
-                {
+                case IndentDoc indent:
                     Push(indent.Contents, currentMode, indenter.IncreaseIndent(currentIndent));
-                }
-                else if (currentDoc is Trim)
-                {
+                    break;
+                case Trim:
                     remainingWidth += output.TrimTrailingWhitespace();
-                }
-                else if (currentDoc is Group group)
+                    break;
+                case Group group:
                 {
                     var groupMode = group.Break ? PrintMode.Break : currentMode;
 
@@ -102,8 +102,10 @@ internal static class DocFitter
                     {
                         groupModeMap![group.GroupId] = groupMode;
                     }
+
+                    break;
                 }
-                else if (currentDoc is IfBreak ifBreak)
+                case IfBreak ifBreak:
                 {
                     var ifBreakMode =
                         ifBreak.GroupId != null && groupModeMap!.ContainsKey(ifBreak.GroupId)
@@ -116,8 +118,9 @@ internal static class DocFitter
                             : ifBreak.FlatContents;
 
                     Push(contents, currentMode, currentIndent);
+                    break;
                 }
-                else if (currentDoc is LineDoc line)
+                case LineDoc line:
                 {
                     if (currentMode is PrintMode.Flat or PrintMode.ForceFlat)
                     {
@@ -136,30 +139,28 @@ internal static class DocFitter
 
                             remainingWidth -= 1;
                         }
+
+                        break;
                     }
-                    else
-                    {
-                        return true;
-                    }
+
+                    return true;
                 }
-                else if (currentDoc is ForceFlat flat)
-                {
+                case ForceFlat flat:
                     Push(flat.Contents, PrintMode.ForceFlat, currentIndent);
-                }
-                else if (currentDoc is BreakParent) { }
-                else if (currentDoc is Align align)
-                {
+                    break;
+                case BreakParent:
+                    break;
+                case Align align:
                     Push(
                         align.Contents,
                         currentMode,
                         indenter.AddAlign(currentIndent, align.Width)
                     );
-                }
-                else if (currentDoc is AlwaysFits) { }
-                else
-                {
+                    break;
+                case AlwaysFits:
+                    break;
+                default:
                     throw new Exception("Can't handle " + currentDoc.GetType());
-                }
             }
         }
 


### PR DESCRIPTION
While I was working on the fixes for #1077, I needed to debug `DocFitter`. There is the long chained if-else and when you press the `Step over` button in RIder the debugger stops on a condition of each branch, but in a switch statement the debugger jumps right to the executed branch and it speed up debugging.

I don't mind if the PR will be rejected. It contains only syntax changes and doesn't modify the logic of `DocFitter`


