### PR TITLE
TargetFramework netstandard2.0 for SourceGenerators

### DIFF
--- a/Src/CSharpier.Generators/CSharpier.Generators.csproj
+++ b/Src/CSharpier.Generators/CSharpier.Generators.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <PackageScribanIncludeSource>true</PackageScribanIncludeSource>

--- a/Src/CSharpier.Tests.Generators/CSharpier.Tests.Generators.csproj
+++ b/Src/CSharpier.Tests.Generators/CSharpier.Tests.Generators.csproj
@@ -7,6 +7,7 @@
     <NoWarn>SYSLIB0013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="Scriban" IncludeAssets="Build" />
   </ItemGroup>

--- a/Src/CSharpier.Tests.Generators/CSharpier.Tests.Generators.csproj
+++ b/Src/CSharpier.Tests.Generators/CSharpier.Tests.Generators.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>


### PR DESCRIPTION
* Changed the TFM to netstandard2.0 because the Generator could not be loaded in Rider
* Reading the docs it says, that it needs to target netstandard2.0 https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview#get-started-with-source-generators