### PR TITLE
Make long parenthesized expressions not always break.

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ParenthesizedExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ParenthesizedExpressions.test
@@ -1,16 +1,34 @@
-class ClassName
-{
-    void MethodName()
-    {
-        var x =
-            query
-            && (
-                currentChar == '='
-                || currentChar == '<'
-                || currentChar == '!'
-                || currentChar == '>'
-                || currentChar == '|'
-                || currentChar == '&'
-            );
-    }
-}
+var x =
+    query
+    && (
+        currentChar == '='
+        || currentChar == '<'
+        || currentChar == '!'
+        || currentChar == '>'
+        || currentChar == '|'
+        || currentChar == '&'
+    );
+
+// some comment won't break the next line
+(someObject as SomeType).CallMethod();
+
+(someObject as Exactly100____________________________________________________________).CallMethod();
+(someObject as SomeLongType___________________________________________________________)
+    .CallMethod();
+(someObject as SomeLongType________________________________________________________________________)
+    .CallMethod();
+
+(
+    someObject
+    as UnlikelyButThisIsWhatItWouldLookLike_________________________________________________
+)
+    .CallMethod();
+
+(
+    someObject
+    as UnlikelyButThisIsWhatItWouldLookLike_________________________________________________
+)
+    .CallMethod______________()
+    .CallMethod______________()
+    .CallMethod______________();
+

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -34,6 +34,7 @@ internal static class InvocationExpression
 
         var forceOneLine =
             groups.Count <= cutoff
+            && groups[0].First().Node is not ParenthesizedExpressionSyntax
             && (
                 groups
                     .Skip(shouldMergeFirstTwoGroups ? 1 : 0)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ParenthesizedExpression.cs
@@ -4,11 +4,14 @@ internal static class ParenthesizedExpression
 {
     public static Doc Print(ParenthesizedExpressionSyntax node, FormattingContext context)
     {
-        return Doc.Group(
-            Token.Print(node.OpenParenToken, context),
-            Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context)),
-            Doc.SoftLine,
-            Token.Print(node.CloseParenToken, context)
+        return Doc.Concat(
+            Token.PrintLeadingTrivia(node.OpenParenToken, context),
+            Doc.Group(
+                Token.PrintWithoutLeadingTrivia(node.OpenParenToken, context),
+                Doc.Indent(Doc.SoftLine, Node.Print(node.Expression, context)),
+                Doc.SoftLine,
+                Token.Print(node.CloseParenToken, context)
+            )
         );
     }
 }


### PR DESCRIPTION
closes #921

The goal of this ticket was to prefer breaking trailing members on a parenthesized expression before breaking the expression.
For example.
```c#
// input
(someObject as SomeLongType__________________________________________).CallMethod();

// expected
(someObject as SomeLongType__________________________________________)
    .CallMethod();

// actual
(
    someObject as SomeLongType__________________________________________
).CallMethod();
```

The way it is currently implemented though results in the following
```c#
var asyncMethodsWithToken = (
    from method in asyncMethods
    where method.GetParameters().Any(pi => pi.ParameterType == typeof(CancellationToken))
    select method
)
    .ToList();

// previously
var asyncMethodsWithToken = (
    from method in asyncMethods
    where method.GetParameters().Any(pi => pi.ParameterType == typeof(CancellationToken))
    select method
).ToList();
```

This does mean things are more consistent with longer chains
```c#
var asyncMethodsWithToken = (
    from method in asyncMethods
    where method.GetParameters().Any(pi => pi.ParameterType == typeof(CancellationToken))
    select method
)
    .ToList________________________()
    .ToList________________________()
    .ToList________________________();
```

Another example where I think the old version was probably better
```c#
Assert.Equal(
    CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
    (
        await Assert.ThrowsAsync<ArgumentException>(
            () =>
                Finder
                    .FindAsync<IntKey>(cancellationType, context, new object[] { "77" })
                    .AsTask()
        )
    )
        .Message
);

// previously
Assert.Equal(
    CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
    (
        await Assert.ThrowsAsync<ArgumentException>(
            () =>
                Finder
                    .FindAsync<IntKey>(cancellationType, context, new object[] { "77" })
                    .AsTask()
        )
    ).Message
);
```

I'm not sure how much work it would be to keep the tailing call next to the `)` if the contents of the parenthsized expression break.

FWIW prettier does not have any logic around this.