### PR TITLE
fix: Removed magic value from the MSBuild scenarios creation

### DIFF
--- a/Tests/MsBuild/Run.ps1
+++ b/Tests/MsBuild/Run.ps1
@@ -40,7 +40,7 @@ RUN dotnet build -c Release
     $csharpierFrameworkVersion = ""
     if ($null -ne $scenario.csharpier_frameworkVersion) {
         $csharpierFrameworkVersion = "
-    <CSharpier_FrameworkVersion>net8.0</CSharpier_FrameworkVersion>
+    <CSharpier_FrameworkVersion>$($scenario.csharpier_frameworkVersion)</CSharpier_FrameworkVersion>
 "
     }
 


### PR DESCRIPTION
This should ensure that we can add and try out further test scenarios without any restrictions. In perspective e.g. `net9.0`