### PR TITLE
Fixing regression from 0.27.1 with invocations

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -367,7 +367,11 @@ internal static class InvocationExpression
         // https://github.com/belav/csharpier-repos/pull/100/files
         if (
             groups[1].Count == 1
-            || parent is SimpleLambdaExpressionSyntax or ArgumentSyntax or BinaryExpressionSyntax
+            || parent
+                is SimpleLambdaExpressionSyntax
+                    or ArgumentSyntax
+                    or BinaryExpressionSyntax
+                    or ExpressionStatementSyntax
             || groups[1].Skip(1).First().Node
                 is InvocationExpressionSyntax
                     or ElementAccessExpressionSyntax


### PR DESCRIPTION
closes #1153

I did add a test case, but accidentally went to main with it when I was dedenting [MemberChains.test](https://github.com/belav/csharpier/blob/main/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MemberChains.test)

```c#
// 0.27.1
o
    .Property.CallMethod(
        someParameter_____________________________,
        someParameter_____________________________
    )
    .CallMethod()
    .CallMethod();

// 0.27.2
o.Property.CallMethod(
    someParameter_____________________________,
    someParameter_____________________________
)
    .CallMethod()
    .CallMethod();