### PR TITLE
Sync exposed CodeFormatterOptions with currently supported cli options

### DIFF
--- a/Src/CSharpier.Tests/CodeFormatterTests.cs
+++ b/Src/CSharpier.Tests/CodeFormatterTests.cs
@@ -61,30 +61,39 @@ internal class CodeFormatterTests
 
         result.Code.Should().Be("var someVariable =\n    someValue;\n");
     }
-    
+
     [Test]
     public void Format_Should_Use_IndentStyle()
     {
         var code = "void someMethod() { var someVariable = someValue; }";
-        var result = CodeFormatter.Format(code, new CodeFormatterOptions { IndentStyle = IndentStyle.Tabs, IndentSize = 1});
+        var result = CodeFormatter.Format(
+            code,
+            new CodeFormatterOptions { IndentStyle = IndentStyle.Tabs, IndentSize = 1 }
+        );
 
         result.Code.Should().Be("void someMethod()\n{\n\tvar someVariable = someValue;\n}\n");
     }
-    
+
     [Test]
     public void Format_Should_Use_IndentWidth()
     {
         var code = "void someMethod() { var someVariable = someValue; }";
-        var result = CodeFormatter.Format(code, new CodeFormatterOptions { IndentStyle = IndentStyle.Spaces, IndentSize = 1});
+        var result = CodeFormatter.Format(
+            code,
+            new CodeFormatterOptions { IndentStyle = IndentStyle.Spaces, IndentSize = 1 }
+        );
 
         result.Code.Should().Be("void someMethod()\n{\n var someVariable = someValue;\n}\n");
     }
-    
+
     [Test]
     public void Format_Should_Use_EndOfLine()
     {
         var code = "var someVariable = someValue;";
-        var result = CodeFormatter.Format(code, new CodeFormatterOptions { EndOfLine = EndOfLine.CRLF });
+        var result = CodeFormatter.Format(
+            code,
+            new CodeFormatterOptions { EndOfLine = EndOfLine.CRLF }
+        );
 
         result.Code.Should().Be("var someVariable = someValue;\r\n");
     }

--- a/Src/CSharpier.Tests/CodeFormatterTests.cs
+++ b/Src/CSharpier.Tests/CodeFormatterTests.cs
@@ -61,6 +61,33 @@ internal class CodeFormatterTests
 
         result.Code.Should().Be("var someVariable =\n    someValue;\n");
     }
+    
+    [Test]
+    public void Format_Should_Use_IndentStyle()
+    {
+        var code = "void someMethod() { var someVariable = someValue; }";
+        var result = CodeFormatter.Format(code, new CodeFormatterOptions { IndentStyle = IndentStyle.Tabs, IndentSize = 1});
+
+        result.Code.Should().Be("void someMethod()\n{\n\tvar someVariable = someValue;\n}\n");
+    }
+    
+    [Test]
+    public void Format_Should_Use_IndentWidth()
+    {
+        var code = "void someMethod() { var someVariable = someValue; }";
+        var result = CodeFormatter.Format(code, new CodeFormatterOptions { IndentStyle = IndentStyle.Spaces, IndentSize = 1});
+
+        result.Code.Should().Be("void someMethod()\n{\n var someVariable = someValue;\n}\n");
+    }
+    
+    [Test]
+    public void Format_Should_Use_EndOfLine()
+    {
+        var code = "var someVariable = someValue;";
+        var result = CodeFormatter.Format(code, new CodeFormatterOptions { EndOfLine = EndOfLine.CRLF });
+
+        result.Code.Should().Be("var someVariable = someValue;\r\n");
+    }
 
     [TestCase("\n")]
     [TestCase("\r\n")]

--- a/Src/CSharpier/CodeFormatter.cs
+++ b/Src/CSharpier/CodeFormatter.cs
@@ -21,7 +21,13 @@ public static class CodeFormatter
 
         return CSharpFormatter.FormatAsync(
             code,
-            new PrinterOptions { Width = options.Width },
+            new PrinterOptions
+            {
+                Width = options.Width,
+                UseTabs = options.IndentStyle == IndentStyle.Tabs,
+                TabWidth = options.IndentSize,
+                EndOfLine = options.EndOfLine
+            },
             cancellationToken
         );
     }
@@ -44,7 +50,13 @@ public static class CodeFormatter
 
         return CSharpFormatter.FormatAsync(
             syntaxTree,
-            new PrinterOptions { Width = options.Width },
+            new PrinterOptions
+            {
+                Width = options.Width,
+                UseTabs = options.IndentStyle == IndentStyle.Tabs,
+                TabWidth = options.IndentSize,
+                EndOfLine = options.EndOfLine
+            },
             SourceCodeKind.Regular,
             cancellationToken
         );

--- a/Src/CSharpier/CodeFormatterOptions.cs
+++ b/Src/CSharpier/CodeFormatterOptions.cs
@@ -3,4 +3,13 @@ namespace CSharpier;
 public class CodeFormatterOptions
 {
     public int Width { get; init; } = 100;
+    public IndentStyle IndentStyle { get; init; } = IndentStyle.Spaces;
+    public int IndentSize { get; init; } = 4;
+    public EndOfLine EndOfLine { get; init; } = EndOfLine.Auto;
+}
+
+public enum IndentStyle
+{
+    Spaces,
+    Tabs
 }

--- a/Src/CSharpier/EndOfLine.cs
+++ b/Src/CSharpier/EndOfLine.cs
@@ -1,0 +1,8 @@
+namespace CSharpier;
+
+public enum EndOfLine
+{
+    Auto,
+    CRLF,
+    LF
+}

--- a/Src/CSharpier/PrinterOptions.cs
+++ b/Src/CSharpier/PrinterOptions.cs
@@ -33,10 +33,3 @@ internal class PrinterOptions
         return "\n";
     }
 }
-
-internal enum EndOfLine
-{
-    Auto,
-    CRLF,
-    LF
-}

--- a/Src/CSharpier/PublicAPI.Unshipped.txt
+++ b/Src/CSharpier/PublicAPI.Unshipped.txt
@@ -1,1 +1,13 @@
-﻿
+﻿CSharpier.CodeFormatterOptions.EndOfLine.get -> CSharpier.EndOfLine
+CSharpier.CodeFormatterOptions.EndOfLine.init -> void
+CSharpier.CodeFormatterOptions.IndentSize.get -> int
+CSharpier.CodeFormatterOptions.IndentSize.init -> void
+CSharpier.CodeFormatterOptions.IndentStyle.get -> CSharpier.IndentStyle
+CSharpier.CodeFormatterOptions.IndentStyle.init -> void
+CSharpier.EndOfLine
+CSharpier.EndOfLine.Auto = 0 -> CSharpier.EndOfLine
+CSharpier.EndOfLine.CRLF = 1 -> CSharpier.EndOfLine
+CSharpier.EndOfLine.LF = 2 -> CSharpier.EndOfLine
+CSharpier.IndentStyle
+CSharpier.IndentStyle.Spaces = 0 -> CSharpier.IndentStyle
+CSharpier.IndentStyle.Tabs = 1 -> CSharpier.IndentStyle


### PR DESCRIPTION
Tried to incorporate your feedback. Personally think it's just fine to have an enum with just two values, so I went along with it. Had to make EndOfLine public as well, hence I also moved it out of PrinterOptions.cs, but wasn't sure where to place it.

Not familiar with how that PublicAPI.Unshipped.txt stuff works, but I let my IDE update it. Let me know if it's all wrong :)