### PR TITLE
To avoid windows firewall warnings when running csharpier as a server…

### DIFF
--- a/Src/CSharpier.Cli/ServerFormatter.cs
+++ b/Src/CSharpier.Cli/ServerFormatter.cs
@@ -22,9 +22,10 @@ public static class ServerFormatter
         builder.WebHost.ConfigureKestrel(
             (_, serverOptions) =>
             {
-                serverOptions.Listen(IPAddress.Any, thePort);
+                serverOptions.Listen(IPAddress.Loopback, thePort);
             }
         );
+
         var app = builder.Build();
         var service = new CSharpierServiceImplementation(actualConfigPath, logger);
         app.MapPost(


### PR DESCRIPTION
…, bind it to the loopback address