### PR TITLE
Better support for dotnet commands.

### DIFF
--- a/Src/CSharpier.Rider/CHANGELOG.md
+++ b/Src/CSharpier.Rider/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # csharpier-rider Changelog
 
+## [1.6.0]
+- Better support for dotnet commands.
+  - Uses the Rider setting for '.NET CLI executable path' for running dotnet commands
+  - If unable to run dotnet commands, show an error message
+
 ## [1.5.3]
 - Add experimental support for CSharpier server
 

--- a/Src/CSharpier.Rider/README.md
+++ b/Src/CSharpier.Rider/README.md
@@ -5,6 +5,9 @@ This plugin makes use of the dotnet tool [CSharpier](https://github.com/belav/cs
 It uses Roslyn to parse your code and re-prints it using its own rules. 
 The printing process was ported from [prettier](https://prettier.io/) but has evolved over time.
 
+## CSharpier Version
+The plugin determines which version of csharpier is needed to format a give file by looking for a dotnet manifest file. If one is not found it looks for a globally installed version of CSharpier.
+
 ### To format files:
 - Install csharpier
   - as a local tool versioned to your project with `dotnet tool install csharpier`

--- a/Src/CSharpier.Rider/gradle.properties
+++ b/Src/CSharpier.Rider/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.intellij.csharpier
 pluginName = csharpier
-pluginVersion = 1.5.3
+pluginVersion = 1.6.0-beta
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/Src/CSharpier.Rider/gradle.properties
+++ b/Src/CSharpier.Rider/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.intellij.csharpier
 pluginName = csharpier
-pluginVersion = 1.6.0-beta
+pluginVersion = 1.6.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessPipeMultipleFiles.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessPipeMultipleFiles.java
@@ -2,6 +2,7 @@ package com.intellij.csharpier;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -9,6 +10,7 @@ import java.nio.charset.Charset;
 public class CSharpierProcessPipeMultipleFiles implements ICSharpierProcess, Disposable {
     private final boolean useUtf8;
     private final String csharpierPath;
+    private final DotNetProvider dotNetProvider;
     private Logger logger = CSharpierLogger.getInstance();
 
     private Process process = null;
@@ -16,9 +18,10 @@ public class CSharpierProcessPipeMultipleFiles implements ICSharpierProcess, Dis
     private BufferedReader stdOut;
     public boolean processFailedToStart;
 
-    public CSharpierProcessPipeMultipleFiles(String csharpierPath, boolean useUtf8) {
+    public CSharpierProcessPipeMultipleFiles(String csharpierPath, boolean useUtf8, Project project) {
         this.csharpierPath = csharpierPath;
         this.useUtf8 = useUtf8;
+        this.dotNetProvider = DotNetProvider.getInstance(project);
         this.startProcess();
 
         this.logger.debug("Warm CSharpier with initial format");
@@ -30,8 +33,8 @@ public class CSharpierProcessPipeMultipleFiles implements ICSharpierProcess, Dis
     private void startProcess() {
         try {
             var processBuilder = new ProcessBuilder(this.csharpierPath, "--pipe-multiple-files");
-            // TODO DOTNET_ROOT
             processBuilder.environment().put("DOTNET_NOLOGO", "1");
+            processBuilder.environment().put("DOTNET_ROOT", this.dotNetProvider.getDotNetROot());
             this.process = processBuilder.start();
 
             var charset = this.useUtf8 ? "utf-8" : Charset.defaultCharset().toString();

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessPipeMultipleFiles.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessPipeMultipleFiles.java
@@ -30,6 +30,7 @@ public class CSharpierProcessPipeMultipleFiles implements ICSharpierProcess, Dis
     private void startProcess() {
         try {
             var processBuilder = new ProcessBuilder(this.csharpierPath, "--pipe-multiple-files");
+            // TODO DOTNET_ROOT
             processBuilder.environment().put("DOTNET_NOLOGO", "1");
             this.process = processBuilder.start();
 

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
@@ -38,7 +38,7 @@ public class CSharpierProcessProvider implements DocumentListener, Disposable, I
 
     public CSharpierProcessProvider(@NotNull Project project) {
         this.project = project;
-        this.customPathInstaller = new CustomPathInstaller(CSharpierSettings.getInstance(project));
+        this.customPathInstaller = new CustomPathInstaller(project);
 
         for (var fileEditor : FileEditorManager.getInstance(project).getAllEditors()) {
             var path = fileEditor.getFile().getPath();
@@ -157,11 +157,8 @@ public class CSharpierProcessProvider implements DocumentListener, Disposable, I
                 "Unable to find dotnet-tools.json, falling back to running dotnet csharpier --version"
         );
 
-        Map<String, String> env = new HashMap<>();
-        env.put("DOTNET_NOLOGO", "1");
-
         var command = new String[]{"dotnet", "csharpier", "--version"};
-        var version = ProcessHelper.ExecuteCommand(command, env, new File(directoryThatContainsFile));
+        var version = DotNetProvider.getInstance(this.project).execDotNet(command, new File(directoryThatContainsFile));
 
         if (version == null) {
             version = "";

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessServer.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessServer.java
@@ -34,6 +34,7 @@ public class CSharpierProcessServer implements ICSharpierProcess, Disposable {
         try {
             var processBuilder = new ProcessBuilder(this.csharpierPath, "--server");
             processBuilder.redirectErrorStream(true);
+            // TODO DOTNET_ROOT
             processBuilder.environment().put("DOTNET_NOLOGO", "1");
             this.process = processBuilder.start();
 

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessSingleFile.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessSingleFile.java
@@ -18,6 +18,7 @@ public class CSharpierProcessSingleFile implements ICSharpierProcess {
         try {
             this.logger.debug("Running " + this.csharpierPath + " --write-stdout");
             var processBuilder = new ProcessBuilder(this.csharpierPath, "--write-stdout");
+            // TODO DOTNET_ROOT
             processBuilder.environment().put("DOTNET_NOLOGO", "1");
             processBuilder.redirectErrorStream(true);
             var process = processBuilder.start();

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettingsComponent.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettingsComponent.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
 
 
 public class CSharpierSettingsComponent implements SearchableConfigurable {
@@ -36,17 +38,42 @@ public class CSharpierSettingsComponent implements SearchableConfigurable {
         return "CSharpier";
     }
 
+    private JComponent createSectionHeader(String label) {
+        var panel = new JPanel(new GridBagLayout());
+        var gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.anchor = GridBagConstraints.WEST;
+
+        panel.add(new JBLabel(label), gbc);
+
+        gbc = new GridBagConstraints();
+        gbc.gridy = 0;
+        gbc.gridx = 1;
+        gbc.weightx = 1.0;
+        gbc.insets = new Insets(1, 6, 0, 0);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        var separator = new JSeparator(SwingConstants.HORIZONTAL);
+        panel.add(separator, gbc);
+
+        return panel;
+    }
+
     @Override
     public @Nullable JComponent createComponent() {
         var leftIndent = 20;
         var topInset = 10;
 
+
+
+
         return FormBuilder.createFormBuilder()
-                .addLabeledComponent(new JBLabel("General Settings"), new JSeparator())
+                .addComponent(createSectionHeader("General Settings"))
                 .setFormLeftIndent(leftIndent)
                 .addComponent(this.runOnSaveCheckBox, topInset)
                 .setFormLeftIndent(0)
-                .addLabeledComponent(new JBLabel("Developer Settings"), new JSeparator(), 20)
+                .addComponent(createSectionHeader("Developer Settings"), 20)
                 .setFormLeftIndent(leftIndent)
                 .addLabeledComponent(new JBLabel("Directory of custom dotnet-csharpier:"), this.customPathTextField, topInset, false)
                 .addComponent(this.useServerCheckBox, topInset)

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierStartup.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierStartup.java
@@ -4,9 +4,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.jetbrains.rider.NetCoreRuntime;
-import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost;
-import com.jetbrains.rider.RiderEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 public class CSharpierStartup implements StartupActivity, DumbAware {

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierStartup.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierStartup.java
@@ -4,11 +4,15 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import com.jetbrains.rider.NetCoreRuntime;
+import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost;
+import com.jetbrains.rider.RiderEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 public class CSharpierStartup implements StartupActivity, DumbAware {
     @Override
     public void runActivity(@NotNull Project project) {
+        DotNetProvider.getInstance(project);
         CSharpierProcessProvider.getInstance(project);
         ApplicationManager.getApplication().getService(ReformatWithCSharpierOnSave.class);
     }

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/DotNetProvider.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/DotNetProvider.java
@@ -1,0 +1,70 @@
+package com.intellij.csharpier;
+
+import com.intellij.execution.util.ExecUtil;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost;
+import com.jetbrains.rider.runtime.dotNetCore.DotNetCoreRuntime;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.List;
+
+// TODO https://github.com/belav/csharpier/pull/1183/files
+public class DotNetProvider {
+    private final Logger logger = CSharpierLogger.getInstance();
+    private final Project project;
+    private String dotNetRoot;
+    private String cliExePath;
+    private DotNetCoreRuntime dotNetCoreRuntime;
+
+    public DotNetProvider(@NotNull Project project) {
+        this.project = project;
+
+        // TODO how do we prevent other things from happening?
+        this.findDotNet();
+    }
+
+    static DotNetProvider getInstance(@NotNull Project project) {
+        return project.getService(DotNetProvider.class);
+    }
+
+    private boolean findDotNet() {
+        try {
+            this.dotNetCoreRuntime =  RiderDotNetActiveRuntimeHost.Companion.getInstance(project).getDotNetCoreRuntime().getValue();
+
+            if (dotNetCoreRuntime.getCliExePath() != null) {
+                logger.debug("Using dotnet found from RiderDotNetActiveRuntimeHost at " + dotNetCoreRuntime.getCliExePath());
+            }
+            else {
+                return false;
+            }
+
+            dotNetRoot = Paths.get(this.cliExePath).getParent().toString();
+
+            return true;
+        } catch (Exception ex) {
+            logger.error(ex);
+
+            return false;
+        }
+    }
+
+    public String execDotNet(List<String> command, File workingDirectory) {
+        var commands = List.copyOf(command);
+        commands.add(0, this.dotNetCoreRuntime.getCliExePath());
+
+        var env = Map.of(
+                "DOTNET_NOLOGO", "1",
+                "DOTNET_CLI_TELEMETRY_OPTOUT", "1",
+                "DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
+
+        return ProcessHelper.executeCommand(commands, env, workingDirectory);
+    }
+
+    public String getDotNetROot() {
+        return this.dotNetRoot;
+    }
+}

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/InstallGlobalAction.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/InstallGlobalAction.java
@@ -3,26 +3,32 @@ package com.intellij.csharpier;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 public class InstallGlobalAction extends NotificationAction {
 
     private final IProcessKiller processKiller;
+    private final DotNetProvider dotNetProvider;
 
     public InstallGlobalAction(
         @Nullable @NlsContexts.NotificationContent String text,
-        IProcessKiller processKiller
+        IProcessKiller processKiller,
+        Project project
     ) {
         super(text);
         this.processKiller = processKiller;
+        this.dotNetProvider = DotNetProvider.getInstance(project);
     }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
-        var command2 = new String[]{"dotnet", "tool", "install", "-g", "csharpier"};
-        ProcessHelper.ExecuteCommand(command2, null, null);
+        var command = List.of("tool", "install", "-g", "csharpier");
+        this.dotNetProvider.execDotNet(command, null);
         this.processKiller.killRunningProcesses();
 
         notification.expire();

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/InstallerService.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/InstallerService.java
@@ -38,10 +38,10 @@ public class InstallerService {
         var notification = NotificationGroupManager.getInstance().getNotificationGroup("CSharpier")
                 .createNotification(message, NotificationType.WARNING);
 
-        notification.addAction(new InstallGlobalAction("Install CSharpier Globally", processKiller));
+        notification.addAction(new InstallGlobalAction("Install CSharpier Globally", processKiller, this.project));
         if (!isOnlyGlobal) {
             notification.addAction(
-                new InstallLocalAction("Install CSharpier Locally", project.getBasePath(), processKiller)
+                new InstallLocalAction("Install CSharpier Locally", processKiller, project)
             );
         }
 

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
@@ -3,17 +3,18 @@ package com.intellij.csharpier;
 import org.apache.commons.lang.SystemUtils;
 import java.io.*;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ProcessHelper {
 
-    public static String ExecuteCommand(String[] command, Map<String, String> env, File workingDirectory) {
+    public static String executeCommand(List<String> command, Map<String, String> env, File workingDirectory) {
         var logger = CSharpierLogger.getInstance();
         try {
             var directoryToLog = workingDirectory == null ? "" : " in " + workingDirectory;
 
             logger.debug("Running " + String.join(" ", command) + directoryToLog);
-            var processBuilder = new ProcessBuilder(GetShellCommandIfNeeded(command));
+            var processBuilder = new ProcessBuilder(command);
 
             if (env == null) {
                 env = new HashMap<>();
@@ -71,14 +72,15 @@ public class ProcessHelper {
         return path;
     }
 
-    // For Mac, we'll have updated the PATH to include the .NET binary. However, setting
-    // the PATH doesn't affect the ProcessBuilder's command, but it will apply to
-    // spawned processes, so we'll run the desired command in the OS's default shell.
-    private static String[] GetShellCommandIfNeeded(String[] command) {
-        if (SystemUtils.IS_OS_MAC) {
-            return new String[] {"/bin/zsh", "-c", String.join(" ", command)};
-        }
-
-        return command;
-    }
+    // TODO see if I can get someone to verify this
+//    // For Mac, we'll have updated the PATH to include the .NET binary. However, setting
+//    // the PATH doesn't affect the ProcessBuilder's command, but it will apply to
+//    // spawned processes, so we'll run the desired command in the OS's default shell.
+//    private static String[] GetShellCommandIfNeeded(String[] command) {
+//        if (SystemUtils.IS_OS_MAC) {
+//            return new String[] {"/bin/zsh", "-c", String.join(" ", command)};
+//        }
+//
+//        return command;
+//    }
 }

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ProcessHelper.java
@@ -1,6 +1,5 @@
 package com.intellij.csharpier;
 
-import org.apache.commons.lang.SystemUtils;
 import java.io.*;
 import java.util.HashMap;
 import java.util.List;
@@ -19,9 +18,8 @@ public class ProcessHelper {
             if (env == null) {
                 env = new HashMap<>();
             }
-
-            if (!env.containsKey("PATH")) {
-                env.put("PATH", GetPathWithDotNetBinary());
+            else {
+                env = new HashMap<>(env);
             }
 
             processBuilder.environment().putAll(env);
@@ -51,36 +49,8 @@ public class ProcessHelper {
             }
             logger.debug(errorResult.toString());
         } catch (Exception e) {
-            logger.error(e.getMessage());
-            e.printStackTrace();
-
+            logger.error(e);
         }
         return null;
     }
-
-    private static String GetPathWithDotNetBinary() {
-        var path = System.getenv("PATH");
-
-        // For Mac, the .NET binary isn't available for ProcessBuilder, so we'll add the default
-        // installation location to the PATH. We'll prefer the ARM version and fallback to the x64.
-        if (SystemUtils.IS_OS_MAC) {
-            return path + ":/usr/local/share/dotnet:/usr/local/share/dotnet/x64/dotnet";
-        }
-
-        // For others, it seems the .NET binary is already available to ProcessBuilder by default.
-        // So we'll just return the PATH as is.
-        return path;
-    }
-
-    // TODO see if I can get someone to verify this
-//    // For Mac, we'll have updated the PATH to include the .NET binary. However, setting
-//    // the PATH doesn't affect the ProcessBuilder's command, but it will apply to
-//    // spawned processes, so we'll run the desired command in the OS's default shell.
-//    private static String[] GetShellCommandIfNeeded(String[] command) {
-//        if (SystemUtils.IS_OS_MAC) {
-//            return new String[] {"/bin/zsh", "-c", String.join(" ", command)};
-//        }
-//
-//        return command;
-//    }
 }

--- a/Src/CSharpier.Rider/src/main/resources/META-INF/plugin.xml
+++ b/Src/CSharpier.Rider/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.intellij.csharpier.CSharpierProcessProvider"/>
+        <projectService serviceImplementation="com.intellij.csharpier.DotNetProvider"/>
         <projectService serviceImplementation="com.intellij.csharpier.FormattingService"/>
         <projectService serviceImplementation="com.intellij.csharpier.CSharpierSettings"/>
         <projectService serviceImplementation="com.intellij.csharpier.InstallerService"/>


### PR DESCRIPTION
This makes use RiderDotNetActiveRuntimeHost to find the path to the dotnet exe, and sets DOTNET_ROOT where appropriate. This should remove any need for the PATH to be correct.

closes #893

