### PR TITLE
Allow to work with semantic versioning

### DIFF
--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
@@ -1,17 +1,11 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Security.Policy;
-using System.Windows.Forms;
+using System.Text.RegularExpressions;
 using System.Xml;
-using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Newtonsoft.Json;
 
 namespace CSharpier.VisualStudio
 {
@@ -214,8 +208,7 @@ namespace CSharpier.VisualStudio
                 var customPath = this.customPathInstaller.GetPathForVersion(version);
 
                 this.logger.Debug("Adding new version " + version + " process for " + directory);
-
-                var installedVersion = new Version(version);
+                var installedVersion = GetInstalledVersion(version);
                 var pipeFilesVersion = new Version("0.12.0");
                 var serverVersion = new Version("0.28.0");
                 ICSharpierProcess cSharpierProcess;
@@ -276,6 +269,24 @@ namespace CSharpier.VisualStudio
             }
 
             return NullCSharpierProcess.Instance;
+        }
+
+        private Version GetInstalledVersion(string version)
+        {
+            if (Version.TryParse(version, out var installedVersion) && installedVersion != null)
+            {
+                return installedVersion;
+            }
+
+            // handle semver versions
+            // regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+            var regex = Regex.Match("0.27.3-dg.13", @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$");
+            if (regex.Success && regex.Groups.Count > 3)
+            {
+                return new Version($"{regex.Groups[1]}.{regex.Groups[2]}.{regex.Groups[3]}");
+            }
+
+            throw new ArgumentException($"Unable to parse version '{version}'", nameof(version));
         }
 
         private void DisplayFailureMessage()

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
@@ -280,7 +280,10 @@ namespace CSharpier.VisualStudio
 
             // handle semver versions
             // regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-            var regex = Regex.Match("0.27.3-dg.13", @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$");
+            var regex = Regex.Match(
+                "0.27.3-dg.13",
+                @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+            );
             if (regex.Success && regex.Groups.Count > 3)
             {
                 return new Version($"{regex.Groups[1]}.{regex.Groups[2]}.{regex.Groups[3]}");

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierProcessProvider.cs
@@ -1,11 +1,17 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Net;
+using System.Security.Policy;
+using System.Windows.Forms;
 using System.Xml;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Newtonsoft.Json;
 
 namespace CSharpier.VisualStudio
 {


### PR DESCRIPTION
The VS extension is not able to work with preview versions. If you have a version like 0.27.3-beta, then the extension does not work. This code is fixing this issue. It allows to work with preview versions.