### PR TITLE
Remove prettier style method chaining

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MemberChain_PropertiesConsistent.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MemberChain_PropertiesConsistent.test
@@ -1,18 +1,18 @@
-var someVariable =
-    someObject____________.Property_______________.CallMethod______________________();
+var someVariable = someObject____________
+    .Property_______________
+    .CallMethod______________________();
 
-var someVariable = someObject.Property.CallMethod(someValue =>
-    someValue.SomeProperty == someOtherValue___________________________
-);
+var someVariable = someObject
+    .Property
+    .CallMethod(someValue => someValue.SomeProperty == someOtherValue___________________________);
 
 var someVariable = someObject
     .Property()
     .CallMethod(someValue => someValue.SomeProperty == someOtherValue___________________________);
 
 var someVariable = someObject
-    .Property.CallMethod(someValue =>
-        someValue.SomeProperty == someOtherValue___________________________
-    )
+    .Property
+    .CallMethod(someValue => someValue.SomeProperty == someOtherValue___________________________)
     .CallMethod();
 
 var someVariable = someObject
@@ -31,10 +31,8 @@ var someVariable = this.CallMethod()
 var someVariable = this.Array[1]
     .CallMethod(someValue => someValue.SomeProperty == someOtherValue___________________________);
 
-var someVariable = this
-    .Property.CallMethod(someValue =>
-        someValue.SomeProperty == someOtherValue___________________________
-    )
+var someVariable = this.Property
+    .CallMethod(someValue => someValue.SomeProperty == someOtherValue___________________________)
     .CallMethod();
 
 var someVariable = this.CallMethod()

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MemberChains.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MemberChains.test
@@ -48,11 +48,13 @@ var someValue = someOtherValue!
     .Where(o => someLongCondition__________________________);
 
 var someValue = someOtherValue!
-    .Thing!.Where(o => someLongCondition__________________________)
+    .Thing!
+    .Where(o => someLongCondition__________________________)
     .Where(o => someLongCondition__________________________);
 
 var someValue = someOtherValue
-    .Thing.Where(o => someLongCondition__________________________)
+    .Thing
+    .Where(o => someLongCondition__________________________)
     .Where(o => someLongCondition__________________________);
 
 var someValue = someOtherValue
@@ -77,7 +79,8 @@ roleNames
     );
 
 roleNames
-    .Value.Where(o => o.SomeProperty____________________________________)
+    .Value
+    .Where(o => o.SomeProperty____________________________________)
     .Select(o => o.SomethingElse);
 
 return someCondition
@@ -105,9 +108,11 @@ CallSomeMethod(
     someParameter____________________________________
 )!;
 
-var someVariable = someObject.Property.CallMethod(someValue =>
-    someValue.SomeProperty == someOtherValue___________________________________
-);
+var someVariable = someObject
+    .Property
+    .CallMethod(someValue =>
+        someValue.SomeProperty == someOtherValue___________________________________
+    );
 
 CallMethod(
         firstParameter________________________________,
@@ -227,41 +232,48 @@ var someValue = CallMethod______________________(
     .CallMethod__________________();
 
 someThing_______________________
-    .Property.CallMethod__________________()
+    .Property
+    .CallMethod__________________()
     .CallMethod__________________();
 
 someThing_______________________
-    ?.Property.CallMethod__________________()
+    ?.Property
+    .CallMethod__________________()
     .CallMethod__________________();
 
 someThing_______________________
-    .Property!.CallMethod__________________()
+    .Property!
+    .CallMethod__________________()
     .CallMethod__________________();
 
 IEnumerable<ValueProviderFactory> valueProviderFactories =
     new ModelBinderAttribute_______().GetValueProviderFactories(config);
 
-var something________________________________________ = x
-    .SomeProperty.CallMethod(longParameter_____________, longParameter_____________)
+var something________________________________________ = x.SomeProperty
+    .CallMethod(longParameter_____________, longParameter_____________)
     .CallMethod();
 
 CallMethod(o =>
-    o.Property.CallMethod_____________________________________________________()
+    o.Property
+        .CallMethod_____________________________________________________()
         .CallMethod_____________________________________________________()
 );
 
 CallMethod(
     o,
-    o.Property.CallMethod_____________________________________________________()
+    o.Property
+        .CallMethod_____________________________________________________()
         .CallMethod_____________________________________________________()
 );
 
 var someValue =
     someValue
-    && o.Property.CallMethod_____________________________________________________()
+    && o.Property
+        .CallMethod_____________________________________________________()
         .CallMethod_____________________________________________________();
 
-o.Property.CallMethod(
+o.Property
+    .CallMethod(
         someParameter_____________________________,
         someParameter_____________________________
     )

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SpreadElements.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SpreadElements.test
@@ -11,7 +11,8 @@ int[] someOtherArray =
 List<KeyValuePair<string, string>> list =
 [
     .. attribute
-        .Targets.Select(target =>
+        .Targets
+        .Select(target =>
             KeyValuePair.Create(
                 target,
                 context.EntityDefinitions.TryGetValue(target, out var type) ? type.ClassName : null


### PR DESCRIPTION
I was experimenting with method chaining, and noticed that by removing `GroupPrintedNodesPrettierStyle` and only using `GroupPrintedNodesOnLines` formatting improved in my opinion.

Specifically this fixes #1298 and didn't seem to have any significant negative effects.

This seems a bit too easy, I'm sure there's a reason for the existing setup.
But I thought I'd bring it up at least.