### PR TITLE
Do not overwrite `CSharpier_Check`, when already set.

### DIFF
--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.props
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.props
@@ -1,10 +1,7 @@
 <Project>
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(CSharpier_Check)' == '' ">
         <!-- Setting default value here, so it can be overwritten by caller -->
         <CSharpier_Check>false</CSharpier_Check>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <CSharpier_Check>true</CSharpier_Check>
+        <CSharpier_Check Condition=" '$(Configuration)' == 'Release' ">true</CSharpier_Check>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
At this point `CSharpier_Check` can be already set. For example: `Directory.Build.props` imported before `CSharpier.MsBuild.props`, and `CSharpier_Check` can be set here. Set default value only when current is empty.