### PR TITLE
VS Extension now hot reloads its config

### DIFF
--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="83d6b6a0-9e25-4034-80f3-38445d8a8837" Version="1.8.0" Language="en-US" Publisher="CSharpier" />
+        <Identity Id="83d6b6a0-9e25-4034-80f3-38445d8a8837" Version="1.9.0" Language="en-US" Publisher="CSharpier" />
         <DisplayName>CSharpier</DisplayName>
         <Description xml:space="preserve">CSharpier is an opinionated code formatter for c#. It uses Roslyn to parse your code and re-prints it using its own rules.</Description>
         <MoreInfo>https://github.com/belav/csharpier</MoreInfo>

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudio2019/source.extension.vsixmanifest
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudio2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="edd8b38c-baa1-46c6-b82e-1da7a0ba597b" Version="1.8.0" Language="en-US" Publisher="CSharpier" />
+        <Identity Id="edd8b38c-baa1-46c6-b82e-1da7a0ba597b" Version="1.9.0" Language="en-US" Publisher="CSharpier" />
         <DisplayName>CSharpier 2019</DisplayName>
         <Description xml:space="preserve">CSharpier is an opinionated code formatter for c#. It uses Roslyn to parse your code and re-prints it using its own rules.</Description>
         <MoreInfo>https://github.com/belav/csharpier</MoreInfo>

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierOptions.cs
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierOptions.cs
@@ -226,7 +226,8 @@
             static void OnFileChanged(object sender, FileSystemEventArgs e)
             {
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
-                ThreadHelper.JoinableTaskFactory.Run(async () => {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     await Instance.LoadAsync();
                 });
@@ -236,7 +237,7 @@
             _hotReloadWatcher.Changed += OnFileChanged;
             _hotReloadWatcher.Created += OnFileChanged;
             _hotReloadWatcher.Renamed += OnFileChanged;
-            
+
             _hotReloadWatcher.EnableRaisingEvents = true;
         }
 

--- a/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierOptions.cs
+++ b/Src/CSharpier.VisualStudio/CSharpier.VisualStudioShared/CSharpierOptions.cs
@@ -58,6 +58,8 @@
         private static readonly AsyncLazy<CSharpierOptions> liveModel =
             new(CreateAsync, ThreadHelper.JoinableTaskFactory);
 
+        private static FileSystemWatcher _hotReloadWatcher;
+
         public static CSharpierOptions Instance
         {
             get
@@ -73,6 +75,7 @@
         {
             var instance = new CSharpierOptions();
             await instance.LoadAsync();
+            await InitializeHotReloadWatcherAsync();
             return instance;
         }
 
@@ -112,7 +115,7 @@
             }
 
             await LoadOptionsFromFile(
-                this.GetSolutionOptionsFileNameAsync,
+                GetSolutionOptionsFileNameAsync,
                 o =>
                 {
                     newInstance.SolutionRunOnSave = o.RunOnSave;
@@ -170,7 +173,7 @@
             }
 
             await SaveOptions(
-                this.GetSolutionOptionsFileNameAsync,
+                GetSolutionOptionsFileNameAsync,
                 new OptionsDto { RunOnSave = this.SolutionRunOnSave }
             );
 
@@ -197,7 +200,7 @@
             );
         }
 
-        private async Task<string?> GetSolutionOptionsFileNameAsync()
+        private static async Task<string?> GetSolutionOptionsFileNameAsync()
         {
 #pragma warning disable VSSDK006
             var solution =
@@ -209,6 +212,32 @@
             return userOptsFile != null
                 ? Path.Combine(Path.GetDirectoryName(userOptsFile), "csharpier.json")
                 : null;
+        }
+
+        private static async Task InitializeHotReloadWatcherAsync()
+        {
+            string filePath = await GetSolutionOptionsFileNameAsync();
+
+            _hotReloadWatcher = new FileSystemWatcher(
+                Path.GetDirectoryName(filePath),
+                Path.GetFileName(filePath)
+            );
+
+            static void OnFileChanged(object sender, FileSystemEventArgs e)
+            {
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+                ThreadHelper.JoinableTaskFactory.Run(async () => {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await Instance.LoadAsync();
+                });
+#pragma warning restore
+            }
+
+            _hotReloadWatcher.Changed += OnFileChanged;
+            _hotReloadWatcher.Created += OnFileChanged;
+            _hotReloadWatcher.Renamed += OnFileChanged;
+            
+            _hotReloadWatcher.EnableRaisingEvents = true;
         }
 
         private class OptionsDto

--- a/Src/CSharpier.VisualStudio/ChangeLog.md
+++ b/Src/CSharpier.VisualStudio/ChangeLog.md
@@ -1,4 +1,7 @@
-﻿## [1.8.0]
+﻿## [1.9.0]
+- Configuration will hot reload: changes to `.vs/$(SolutionName)/v17/csharpier.json` will trigger a reload of the configuration in an opened Visual Studio instance.
+
+## [1.8.0]
 - Use dotnet tool list to find both local and global installs of csharpier.
 
 ## [1.7.4]


### PR DESCRIPTION
This fixes #1367. 

The `.vs/$(SolutionName)/v17/csharpier.json` file is now watched for changes and will reload the configuration when the file is changed.