### PR TITLE
Use current `dotnet` host instead of global

### DIFF
--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -4,6 +4,8 @@
     <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '8.0'))">net8.0</CSharpier_FrameworkVersion>
     <CSharpier_FrameworkVersion Condition="'$(CSharpier_FrameworkVersion)' == ''" Label="Fallback">net8.0</CSharpier_FrameworkVersion>
     <CSharpierDllPath>$(MSBuildThisFileDirectory)../tools/csharpier/$(CSharpier_FrameworkVersion)/dotnet-csharpier.dll</CSharpierDllPath>
+    <CSharpier_dotnet_Path Condition="'$(CSharpier_dotnet_Path)' == ''">$(DOTNET_HOST_PATH)</CSharpier_dotnet_Path>
+    <CSharpier_dotnet_Path Condition="'$(CSharpier_dotnet_Path)' == ''">dotnet</CSharpier_dotnet_Path>
     <CSharpierArgs Condition="'$(CSharpier_Check)' == 'true'">$(CSharpierArgs) --check</CSharpierArgs>
     <CSharpierArgs Condition="'$(CSharpier_LogLevel)' != ''">$(CSharpierArgs) --loglevel $(CSharpier_LogLevel)</CSharpierArgs>
     <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
@@ -23,7 +25,7 @@
       StdOutEncoding="utf-8"
       StdErrEncoding="utf-8"
       IgnoreExitCode="true"
-      Command="dotnet &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
+      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
   </Target>
 
   <!-- getting this to run a single time for projects that target multiple frameworks requires all of this


### PR DESCRIPTION
Use current `dotnet` binary from `DOTNET_HOST_PATH` instead of just `dotnet`.
Reasons:
1. Global (in `PATH`) may not exist (when used _Binaries_, but not _Installers_).
2. Global can have different runtime version.
3. Consistent with outer tools (`csc` for example).
https://github.com/dotnet/roslyn/blob/324fd25331c969cd742ba68eee09ffd4b6fd29e3/src/Compilers/Shared/RuntimeHostInfo.cs#L61-L64
4. It is documented to be used for that purpose.
https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_host_path