### PR TITLE
Msbuild unformatted files are no longer treated as error on linux

### DIFF
--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,1 +1,3 @@
 Uploads/
+
+Tests/MsBuild/TestCases/

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -27,11 +27,15 @@ jobs:
           dotnet tool restore
           dotnet csharpier . --check
   test_msbuild:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     name: Test CSharpier.MSBuild
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v3
-      - run: |
+      - env:
+          GithubOS: ${{matrix.os}}
+        run: |
           pwsh ./Tests/MsBuild/Run.ps1
-

--- a/Src/CSharpier.MsBuild/README.md
+++ b/Src/CSharpier.MsBuild/README.md
@@ -5,15 +5,12 @@ One way to test the changes in the build/* files
 - Ensure you revert those files and make the same changes to the files here.
 
 Some automated tests exist
-- the validate PR GH action runs these, mostly around framework versions
+- the validate PR GH action runs these
 - cd ./Tests/MsBuild
-- ./Run.ps1
+- ./Run.ps1 - some of these don't seem to work well locally
 
 Other things that would be really really nice to automate
-- exits properly in release when no files formatted  
-  https://github.com/belav/csharpier/issues/1357
-- same as above if thing set
 - formats files in debug
 - formats files if told to in release
-- a few scenarios in here I think, compilation errors etc  
-  https://github.com/belav/csharpier/issues/1131 
+- checks files if told to in debug
+- log levels

--- a/Src/CSharpier.MsBuild/README.md
+++ b/Src/CSharpier.MsBuild/README.md
@@ -4,7 +4,16 @@ One way to test the changes in the build/* files
 - Edit those files at `C:\Users\[Username]\.nuget\packages\csharpier.msbuild\[VersionNumber]\build`
 - Ensure you revert those files and make the same changes to the files here.
 
-Another way
-- the validate PR GH action does this, currently only uses the net8 sdk
-- dotnet pack Src/CSharpier.MsBuild/CSharpier.MsBuild.csproj -o nupkg /p:Version=0.0.1
-- docker build -f ./Tests/CSharpier.MsBuild.Test/Dockerfile .
+Some automated tests exist
+- the validate PR GH action runs these, mostly around framework versions
+- cd ./Tests/MsBuild
+- ./Run.ps1
+
+Other things that would be really really nice to automate
+- exits properly in release when no files formatted  
+  https://github.com/belav/csharpier/issues/1357
+- same as above if thing set
+- formats files in debug
+- formats files if told to in release
+- a few scenarios in here I think, compilation errors etc  
+  https://github.com/belav/csharpier/issues/1131 

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -11,12 +11,10 @@
     <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
     <FirstTargetFramework Condition=" '$(FirstTargetFrameworks)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
     <NullOutput>NUL</NullOutput>
-    <IgnoreExitCode>true</IgnoreExitCode>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <NullOutput>/dev/null</NullOutput>
-    <IgnoreExitCode>false</IgnoreExitCode>
   </PropertyGroup>
 
   <!-- https://github.com/belav/csharpier/issues/1131 -->
@@ -31,7 +29,7 @@
       IgnoreExitCode="true"
       IgnoreStandardErrorWarningFormat="true"
       CustomErrorRegularExpression="^Error "
-      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
+      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
   </Target>
 
   <!-- getting this to run a single time for projects that target multiple frameworks requires all of this

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -29,7 +29,7 @@
       IgnoreExitCode="true"
       IgnoreStandardErrorWarningFormat="true"
       CustomErrorRegularExpression="^Error "
-      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
+      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
   </Target>
 
   <!-- getting this to run a single time for projects that target multiple frameworks requires all of this

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -17,8 +17,6 @@
     <NullOutput>/dev/null</NullOutput>
   </PropertyGroup>
 
-  <!-- https://github.com/belav/csharpier/issues/1131 -->
-  
   <Target Name="CSharpierFormatInner" Condition="'$(CSharpier_Bypass)' != 'true'">
     <!-- IgnoreExitCode cleans up the output when files aren't formatted and fail the check -->
     <!-- &gt; NullOutput suppresses the output from this so that compilation errors will show up a single time -->

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -11,12 +11,16 @@
     <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
     <FirstTargetFramework Condition=" '$(FirstTargetFrameworks)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
     <NullOutput>NUL</NullOutput>
+    <IgnoreExitCode>true</IgnoreExitCode>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <NullOutput>/dev/null</NullOutput>
+    <IgnoreExitCode>false</IgnoreExitCode>
   </PropertyGroup>
 
+  <!-- https://github.com/belav/csharpier/issues/1131 -->
+  
   <Target Name="CSharpierFormatInner" Condition="'$(CSharpier_Bypass)' != 'true'">
     <!-- IgnoreExitCode cleans up the output when files aren't formatted and fail the check -->
     <!-- &gt; NullOutput suppresses the output from this so that compilation errors will show up a single time -->

--- a/Tests/MsBuild/Directory.Build.props
+++ b/Tests/MsBuild/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/Tests/MsBuild/Run.ps1
+++ b/Tests/MsBuild/Run.ps1
@@ -75,23 +75,38 @@ RUN dotnet build -c Release
 
 
 Write-Host "::group::UnformattedFileCausesError"
-
-$output = (& dotnet build -c Release ./TestCases/UnformattedFileCausesError/Project.csproj) | Out-String
-Write-Host $output
-if ($LASTEXITCODE -ne 1) {
-    $failureMessage += "::error::The TestCase UnformattedFileCausesError did not return an exit code of 1`n"
-}
-# test output to see what is in it
-
+$output = [TestHelper]::RunTestCase("UnformattedFileCausesError", $true)
+# TODO do we need to test output?
 Write-Host "::endgroup::"
 
+Write-Host "::group::FileThatCantCompileCausesOneError"
+$output = [TestHelper]::RunTestCase("FileThatCantCompileCausesOneError", $true)
+# TODO what do we need to look for in the output?
+Write-Host "::endgroup::"
 
-# OneError
-# any other scenarior to test?
+# TODO any other scenarior to test?
 
 
 if ($failureMessage -ne "") {
     Write-Host $failureMessage
     exit 1
+}
+
+class TestHelper {
+    static [string] RunTestCase([string] $testCase, [bool] $expectErrorCode) {
+        $output = (& dotnet build -c Release ./TestCases/$($testCase)/Project.csproj) | Out-String
+        Write-Host $output
+        
+        $expectedExitCode = 0
+        if ($expectErrorCode -eq $true) {
+            $expectedExitCode = 1
+        }
+
+        if ($LASTEXITCODE -ne $expectedExitCode) {
+            $failureMessage += "::error::The TestCase $testCase did not return an exit code of $expectedExitCode`n"
+        }
+        
+        return $output
+    }
 }
 

--- a/Tests/MsBuild/Run.ps1
+++ b/Tests/MsBuild/Run.ps1
@@ -19,7 +19,7 @@ New-Item $basePath -ItemType Directory | Out-Null
 $failureMessages = @()
 
 foreach ($scenario in $scenarios) {
-    # these fail on windows in GH and because they use dockerfiles for the scenarios we don't need to run them twice anyway
+    # these fail on windows in GH and because they use docker for the scenarios we don't need to run them twice anyway
     if ($env:GithubOS -eq "windows-latest") {
         continue
     }

--- a/Tests/MsBuild/Scenarios.json
+++ b/Tests/MsBuild/Scenarios.json
@@ -1,21 +1,21 @@
 [
   {
-    "name": "sdk:8.0_netstandard2.0",
+    "name": "sdk-8.0_netstandard2.0",
     "sdk": "mcr.microsoft.com/dotnet/sdk:8.0",
     "targetFrameworks": "netstandard2.0"
   },
   {
-    "name": "sdk:8.0_net8.0-windows",
+    "name": "sdk-8.0_net8.0-windows",
     "sdk": "mcr.microsoft.com/dotnet/sdk:8.0",
     "targetFrameworks": "net8.0-windows"
   },
   {
-    "name": "sdk:8.0_net6.0;net7.07",
+    "name": "sdk-8.0_net6.0;net7.07",
     "sdk": "mcr.microsoft.com/dotnet/sdk:8.0",
     "targetFrameworks": "net6.0;net7.0"
   },
   {
-    "name": "sdk:8.0_csharpier-net8.0",
+    "name": "sdk-8.0_csharpier-net8.0",
     "sdk": "mcr.microsoft.com/dotnet/sdk:8.0",
     "targetFrameworks": "netstandard2.0",
     "csharpier_frameworkVersion": "net8.0"

--- a/Tests/MsBuild/TestCases/FileThatCantCompileCausesOneError/FileWithCompileError.cs
+++ b/Tests/MsBuild/TestCases/FileThatCantCompileCausesOneError/FileWithCompileError.cs
@@ -1,0 +1,4 @@
+﻿namespace Net8;
+
+public class Class1 
+{

--- a/Tests/MsBuild/TestCases/FileThatCantCompileCausesOneError/Project.csproj
+++ b/Tests/MsBuild/TestCases/FileThatCantCompileCausesOneError/Project.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CSharpier.MsBuild" Version="0.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Tests/MsBuild/TestCases/UnformattedFileCausesError/Project.csproj
+++ b/Tests/MsBuild/TestCases/UnformattedFileCausesError/Project.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CSharpier.MsBuild" Version="0.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Tests/MsBuild/TestCases/UnformattedFileCausesError/UnformattedFile.cs
+++ b/Tests/MsBuild/TestCases/UnformattedFileCausesError/UnformattedFile.cs
@@ -1,0 +1,7 @@
+﻿namespace Net8;
+
+public class Class1 
+{
+
+
+}

--- a/Tests/MsBuild/nuget.config
+++ b/Tests/MsBuild/nuget.config
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
   <packageSources>
     <add key="Local" value="nupkg" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="Local">
+      <package pattern="CSharpier.MsBuild" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
The changes for https://github.com/belav/csharpier/pull/1311 seem to work in windows, but cause problems in linux. Files that aren't formatted are no longer treated as errors.

closes #1357