### PR TITLE
Adapt to current error format

### DIFF
--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -25,6 +25,8 @@
       StdOutEncoding="utf-8"
       StdErrEncoding="utf-8"
       IgnoreExitCode="true"
+      IgnoreStandardErrorWarningFormat="true"
+      CustomErrorRegularExpression="^Error "
       Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) " />
   </Target>
 


### PR DESCRIPTION
As CSharpier currently does not output error messages in MSBuild compatible format, adapt Exec options to current error format. Should fix #1357.