### PR TITLE
Fixing issue with unsupported file error being shown for all files that csharpier can't format in a given directory.

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -64,7 +64,7 @@ internal static class CommandLineFormatter
                     );
 
                     var printerOptions = optionsProvider.GetPrinterOptionsFor(filePath);
-                    if (printerOptions is not null)
+                    if (printerOptions is { Formatter: not Formatter.Unknown })
                     {
                         printerOptions.IncludeGenerated = commandLineOptions.IncludeGenerated;
 
@@ -213,7 +213,7 @@ internal static class CommandLineFormatter
 
                 var printerOptions = optionsProvider.GetPrinterOptionsFor(actualFilePath);
 
-                if (printerOptions is not null)
+                if (printerOptions is { Formatter: not Formatter.Unknown })
                 {
                     printerOptions.IncludeGenerated = commandLineOptions.IncludeGenerated;
                     await FormatPhysicalFile(

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -106,7 +106,6 @@ internal class OptionsProvider
 
         if (resolvedEditorConfig is not null)
         {
-            DebugLogger.Log("has editorconfig");
             return resolvedEditorConfig.ConvertToPrinterOptions(filePath);
         }
 

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -42,7 +42,7 @@ internal class CSharpierServiceImplementation(string? configPath, ILogger logger
             }
 
             var printerOptions = optionsProvider.GetPrinterOptionsFor(formatFileParameter.fileName);
-            if (printerOptions == null)
+            if (printerOptions == null || printerOptions.Formatter is Formatter.Unknown)
             {
                 return new FormatFileResult(Status.UnsupportedFile);
             }

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -109,6 +109,20 @@ public class CommandLineFormatterTests
     }
 
     [Test]
+    public void Format_Does_Not_Write_Unsupported_With_EditorConfig()
+    {
+        var context = new TestContext();
+        context.WhenAFileExists(".editorconfig", "");
+        context.WhenAFileExists("Unsupported.js", "asdfasfasdf");
+
+        var result = this.Format(context);
+
+        result
+            .ErrorOutputLines.Should()
+            .NotContain("Error ./Unsupported.js - Is an unsupported file type.");
+    }
+
+    [Test]
     public void Format_Does_Not_Write_Unsupported_When_Formatting_Directory()
     {
         var context = new TestContext();

--- a/Src/CSharpier/DebugLogger.cs
+++ b/Src/CSharpier/DebugLogger.cs
@@ -4,7 +4,7 @@ namespace CSharpier;
 
 internal class DebugLogger
 {
-    private static object lockObject = new();
+    private static readonly object lockObject = new();
 
     [Conditional("DEBUG")]
     public static void Log(object message)
@@ -20,5 +20,16 @@ internal class DebugLogger
                 // we don't care if this fails
             }
         }
+    }
+
+    [Conditional("DEBUG")]
+    public static void LogIf(bool condition, object message)
+    {
+        if (!condition)
+        {
+            return;
+        }
+
+        Log(message);
     }
 }


### PR DESCRIPTION
We only want that error/warning if someone directly requests to format a file that csharpier does not support. Formatting a directory assumes that you only want to format files that are supported and/or have a defined formatter in the config.