### PR TITLE
Treat the path we get from the format request as a full path

### DIFF
--- a/Src/CSharpier.Cli/PipeMultipleFilesFormatter.cs
+++ b/Src/CSharpier.Cli/PipeMultipleFilesFormatter.cs
@@ -33,7 +33,6 @@ internal static class PipeMultipleFilesFormatter
                     return exitCode;
                 }
                 var character = Convert.ToChar(value);
-                DebugLogger.Log("Got " + character);
                 if (character == '\u0003')
                 {
                     DebugLogger.Log("Got EOF");
@@ -54,6 +53,10 @@ internal static class PipeMultipleFilesFormatter
                 {
                     DirectoryOrFilePaths =
                     [
+                        // we pass in c:/projects/test.cs
+                        // if you use combine on c:/projects and c:/projects/test.cs then you get c:/projects/test.cs
+                        // this combine should probably not exist, but I don't know if removing it would cause more problems
+                        // as long as the extensions don't change the working directory when they setup pipe-files, then I think this is okay
                         Path.Combine(Directory.GetCurrentDirectory(), fileName),
                     ],
                     OriginalDirectoryOrFilePaths =

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -16,6 +16,7 @@ internal class CSharpierServiceImplementation(string? configPath, ILogger logger
         try
         {
             logger.LogInformation("Received request to format " + formatFileParameter.fileName);
+            var fileName = this.fileSystem.Path.GetFullPath(formatFileParameter.fileName);
             if (formatFileParameter.fileContents.StartsWith("// csh-slow"))
             {
                 Thread.Sleep(TimeSpan.FromSeconds(5));
@@ -24,7 +25,7 @@ internal class CSharpierServiceImplementation(string? configPath, ILogger logger
             {
                 throw new Exception("Throwing because of // csh-throw comment");
             }
-            var directoryName = this.fileSystem.Path.GetDirectoryName(formatFileParameter.fileName);
+            var directoryName = this.fileSystem.Path.GetDirectoryName(fileName);
             DebugLogger.Log(directoryName ?? string.Empty);
             if (directoryName == null)
             {
@@ -42,14 +43,14 @@ internal class CSharpierServiceImplementation(string? configPath, ILogger logger
             );
 
             if (
-                GeneratedCodeUtilities.IsGeneratedCodeFile(formatFileParameter.fileName)
-                || optionsProvider.IsIgnored(formatFileParameter.fileName)
+                GeneratedCodeUtilities.IsGeneratedCodeFile(fileName)
+                || optionsProvider.IsIgnored(fileName)
             )
             {
                 return new FormatFileResult(Status.Ignored);
             }
 
-            var printerOptions = optionsProvider.GetPrinterOptionsFor(formatFileParameter.fileName);
+            var printerOptions = optionsProvider.GetPrinterOptionsFor(fileName);
             if (printerOptions == null)
             {
                 return new FormatFileResult(Status.UnsupportedFile);


### PR DESCRIPTION
This fixes the issue where we pass /temp/test.cs as the "warmup" file path, and then that path is treated differently later on in the code. Calling GetFullPath on it will convert it to c:/temp/test.cs on windows.

closes #1447