### PR TITLE
Finishing up some last TODOs around xml formatting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.0.0-alpha10",
+      "version": "1.0.0-alpha32",
       "commands": [
         "csharpier"
       ]

--- a/Src/CSharpier.Cli/HasMismatchedCliAndMsBuildVersions.cs
+++ b/Src/CSharpier.Cli/HasMismatchedCliAndMsBuildVersions.cs
@@ -28,7 +28,7 @@ internal static class HasMismatchedCliAndMsBuildVersions
                     XElement packagesXElement;
                     try
                     {
-                        packagesXElement = XElement.Load(fileSystem.File.OpenRead(filePath));
+                        packagesXElement = XElement.Parse(fileSystem.File.ReadAllText(filePath));
                     }
                     catch (Exception ex)
                     {
@@ -58,7 +58,7 @@ internal static class HasMismatchedCliAndMsBuildVersions
             XElement csProjXElement;
             try
             {
-                csProjXElement = XElement.Load(fileSystem.File.OpenRead(pathToCsProj));
+                csProjXElement = XElement.Parse(fileSystem.File.ReadAllText(pathToCsProj));
             }
             catch (Exception ex)
             {

--- a/Src/CSharpier.Cli/PhysicalFileInfoAndWriter.cs
+++ b/Src/CSharpier.Cli/PhysicalFileInfoAndWriter.cs
@@ -4,37 +4,15 @@ namespace CSharpier.Cli;
 
 internal class FileSystemFormattedFileWriter(IFileSystem fileSystem) : IFormattedFileWriter
 {
-    public IFileSystem FileSystem { get; } = fileSystem;
-
     public void WriteResult(CodeFormatterResult result, FileToFormatInfo fileToFormatInfo)
     {
         if (result.Code != fileToFormatInfo.FileContents)
         {
-            const int maxTries = 5;
-            var tries = 1;
-            // TODO #819 this started happening on the EFcore folder, is it related to the msbuild check somehow?
-            while (tries <= maxTries)
-            {
-                try
-                {
-                    this.FileSystem.File.WriteAllText(
-                        fileToFormatInfo.Path,
-                        result.Code,
-                        fileToFormatInfo.Encoding
-                    );
-                    return;
-                }
-                catch (IOException)
-                {
-                    if (tries == maxTries)
-                    {
-                        throw;
-                    }
-
-                    Thread.Sleep(TimeSpan.FromMilliseconds(50));
-                    tries++;
-                }
-            }
+            fileSystem.File.WriteAllText(
+                fileToFormatInfo.Path,
+                result.Code,
+                fileToFormatInfo.Encoding
+            );
         }
     }
 }

--- a/Src/CSharpier.Cli/PipeCommand.cs
+++ b/Src/CSharpier.Cli/PipeCommand.cs
@@ -22,7 +22,6 @@ internal static class PipeCommand
 
         pipeMultipleFilesCommand.SetHandler(async context =>
         {
-            // TODO #819 do these options even do anything??
             var logLevel = LogLevel.Information;
 
             var console = new SystemConsole();

--- a/Src/CSharpier.Cli/PipeCommand.cs
+++ b/Src/CSharpier.Cli/PipeCommand.cs
@@ -22,7 +22,7 @@ internal static class PipeCommand
 
         pipeMultipleFilesCommand.SetHandler(async context =>
         {
-            // TODO do these options even do anything??
+            // TODO #819 do these options even do anything??
             var logLevel = LogLevel.Information;
 
             var console = new SystemConsole();

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -62,6 +62,14 @@ internal class CSharpierServiceImplementation(ILogger logger)
                 cancellationToken
             );
 
+            if (result.CompilationErrors.Any())
+            {
+                return new FormatFileResult(Status.Failed)
+                {
+                    errorMessage = "File had compilation errors and could not be formatted"
+                };
+            }
+
             return new FormatFileResult(Status.Formatted) { formattedFile = result.Code };
         }
         catch (Exception ex)

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -55,7 +55,7 @@ internal class CSharpierServiceImplementation(ILogger logger)
                 return new FormatFileResult(Status.UnsupportedFile);
             }
 
-            // TODO if compilation errors we still return whatever was here
+            // TODO #819 if compilation errors we still return whatever was here
             var result = await CodeFormatter.FormatAsync(
                 formatFileParameter.fileContents,
                 printerOptions,

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -55,7 +55,7 @@ internal class CSharpierServiceImplementation(ILogger logger)
                 return new FormatFileResult(Status.UnsupportedFile);
             }
 
-            // TODO #819 if compilation errors we still return whatever was here
+            // TODO #819 if there are compilation errors we need to do something here
             var result = await CodeFormatter.FormatAsync(
                 formatFileParameter.fileContents,
                 printerOptions,

--- a/Src/CSharpier/Formatters/Xml/XmlFormatter.cs
+++ b/Src/CSharpier/Formatters/Xml/XmlFormatter.cs
@@ -32,14 +32,6 @@ internal static class XmlFormatter
         var mapping = new Dictionary<XNode, XmlNode>();
         CreateMapping(xDocument, xmlDocument, mapping);
 
-        /* TODO #819 it screws with the contents of these, is this valid?
-         
-    <PropertyGroup>
-      <_runtimeHostConfigurationOptionsString>@(_switchesAsItems->'&lt;RuntimeHostConfigurationOption Include=&quot;%(Identity)&quot; Value=&quot;%(Value)&quot; Trim=&quot;true&quot; /&gt;', '%0a    ')</_runtimeHostConfigurationOptionsString>
-      <_additionalPropertiesString>@(_propertiesAsItems->'&lt;%(Identity)&gt;%(Value)&lt;/%(Identity)&gt;', '%0a    ')</_additionalPropertiesString>
-    </PropertyGroup>
-         */
-
         var lineEnding = PrinterOptions.GetLineEnding(xml, printerOptions);
         var printingContext = new XmlPrintingContext
         {

--- a/Src/CSharpier/Formatters/Xml/XmlFormatter.cs
+++ b/Src/CSharpier/Formatters/Xml/XmlFormatter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Xml;
 using System.Xml.Linq;
 using CSharpier.SyntaxPrinter;
@@ -31,20 +32,13 @@ internal static class XmlFormatter
         var mapping = new Dictionary<XNode, XmlNode>();
         CreateMapping(xDocument, xmlDocument, mapping);
 
-        /* TODO #819 Error
-         efcore?
+        /* TODO #819 it screws with the contents of these, is this valid?
          
+    <PropertyGroup>
+      <_runtimeHostConfigurationOptionsString>@(_switchesAsItems->'&lt;RuntimeHostConfigurationOption Include=&quot;%(Identity)&quot; Value=&quot;%(Value)&quot; Trim=&quot;true&quot; /&gt;', '%0a    ')</_runtimeHostConfigurationOptionsString>
+      <_additionalPropertiesString>@(_propertiesAsItems->'&lt;%(Identity)&gt;%(Value)&lt;/%(Identity)&gt;', '%0a    ')</_additionalPropertiesString>
+    </PropertyGroup>
          */
-        /* TODO #819 Review
-         aspnetcore - https://github.com/belav/csharpier-repos/pull/121/files
-         runtime - https://github.com/belav/csharpier-repos/pull/122
-         efcore - https://github.com/belav/csharpier-repos/pull/123
-         - https://github.com/belav/csharpier-repos/pull/123/files#diff-9193fb0473a296510e5dfcecc173d53be487a9ea112a8b80514046ad0a9b2594
-         - this does some weird stuff with encoding inside of XText
-         roslyn - https://github.com/belav/csharpier-repos/pull/124/files
-         - probably good
-         */
-
 
         var lineEnding = PrinterOptions.GetLineEnding(xml, printerOptions);
         var printingContext = new XmlPrintingContext
@@ -64,7 +58,12 @@ internal static class XmlFormatter
         {
             Code = formattedXml,
             DocTree = printerOptions.IncludeDocTree ? DocSerializer.Serialize(doc) : string.Empty,
-            AST = string.Empty, // TODO #819 printerOptions.IncludeAST ? JsonSerializer.Serialize(xDocument) : string.Empty,
+            AST = printerOptions.IncludeAST
+                ? JsonSerializer.Serialize(
+                    xDocument,
+                    new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve }
+                )
+                : string.Empty,
         };
     }
 


### PR DESCRIPTION
Notable fixes

Fixing an issue with the msbuild version checker keeping a file open too long.
Treating a file with compilation errors as a failure when formatting with csharpier server.