### PR TITLE
feat: use foreach loop in `GetPrintedWidth` to prevent `CharEnumerator` allocations

### DIFF
--- a/Src/CSharpier/Utilities/StringExtensions.cs
+++ b/Src/CSharpier/Utilities/StringExtensions.cs
@@ -40,7 +40,14 @@ internal static class StringExtensions
     // some unicode characters should be considered size of 2 when calculating how big this string will be when printed
     public static int GetPrintedWidth(this string value)
     {
-        return value.Sum(CharacterSizeCalculator.CalculateWidth);
+        var sum = 0;
+        // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var character in value)
+        {
+            sum += CharacterSizeCalculator.CalculateWidth(character);
+        }
+
+        return sum;
     }
 
     public static int CalculateCurrentLeadingIndentation(this string line, int indentSize)


### PR DESCRIPTION
`value.Sum(` allocates a `CharEnumerator` instance, manually looping prevents the allocation. Saves around 5 MB on the benchmark iirc 5% of total allocations.

This could be further improved by using a SIMD implementation of `CharacterSizeCalculator.CalculateWidth`, this is extremely micro benchmarky tho 😅 

### Before
![image](https://github.com/user-attachments/assets/1444e6c2-42fc-4129-b036-4c9c296771c8)


### After
![image](https://github.com/user-attachments/assets/c8a1d6ea-ba60-48d2-969d-3522aa4b4ab2)


## Benchmarks

### Before
| Method                                  | Mean          | Error        | StdDev       | Gen0       | Gen1      | Gen2      | Allocated    |
|---------------------------------------- |--------------:|-------------:|-------------:|-----------:|----------:|----------:|-------------:|
| Default_CodeFormatter                   | 170,091.68 us | 3,367.421 us | 5,437.757 us | 11000.0000 | 4000.0000 | 1000.0000 | 103844.49 KB |
| Default_SyntaxNodeComparer              |   1,732.65 us |    33.380 us |    34.279 us |    66.4063 |   15.6250 |         - |    643.33 KB |
| IsCodeBasicallyEqual_SyntaxNodeComparer |      96.81 us |     2.075 us |     6.119 us |    10.7422 |    1.3428 |         - |     99.02 KB |

###
After
 | Method                                  | Mean         | Error       | StdDev      | Median        | Gen0       | Gen1      | Gen2      | Allocated   |
|---------------------------------------- |-------------:|------------:|------------:|--------------:|-----------:|----------:|----------:|------------:|
| Default_CodeFormatter                   | 171,512.8 us | 3,308.99 us | 8,362.24 us | 171,873.50 us | 11000.0000 | 4000.0000 | 1000.0000 | 98120.95 KB |
| Default_SyntaxNodeComparer              |   1,919.8 us |    43.59 us |   126.46 us |   1,884.53 us |    66.4063 |   15.6250 |         - |   644.28 KB |
| IsCodeBasicallyEqual_SyntaxNodeComparer |     100.4 us |     2.30 us |     6.77 us |      98.88 us |    10.7422 |    1.3428 |         - |    99.02 KB |


