### PR TITLE
Modifying CSharpier to support reading gitignore files to determine what files are ignored.

### DIFF
--- a/Src/CSharpier.Cli.Tests/CliTests.cs
+++ b/Src/CSharpier.Cli.Tests/CliTests.cs
@@ -27,6 +27,12 @@ public class CliTests
             File.Delete(FormattingCacheFactory.CacheFilePath);
         }
 
+        Directory.CreateDirectory(testFileDirectory);
+    }
+
+    [TearDown]
+    public void AfterEachTest()
+    {
         void DeleteDirectory()
         {
             if (Directory.Exists(testFileDirectory))
@@ -44,8 +50,6 @@ public class CliTests
             Thread.Sleep(TimeSpan.FromMilliseconds(100));
             DeleteDirectory();
         }
-
-        Directory.CreateDirectory(testFileDirectory);
     }
 
     [TestCase("\n")]
@@ -172,7 +176,10 @@ public class CliTests
             .ExecuteAsync();
 
         result.ExitCode.Should().Be(1);
-        result.ErrorOutput.Should().StartWith("Error ./TooWide.cs - Was not formatted.");
+        result
+            .ErrorOutput.Replace('\\', '/')
+            .Should()
+            .StartWith("Error ./TooWide.cs - Was not formatted.");
     }
 
     [Test]
@@ -347,7 +354,7 @@ max_line_length = 10"
             .ExecuteAsync();
 
         result
-            .ErrorOutput.Replace("\\", "/")
+            .ErrorOutput.Replace('\\', '/')
             .Should()
             .StartWith("Error ./CheckUnformatted.cs - Was not formatted.");
         result.ExitCode.Should().Be(1);

--- a/Src/CSharpier.Cli.Tests/CliTests.cs
+++ b/Src/CSharpier.Cli.Tests/CliTests.cs
@@ -15,10 +15,9 @@ namespace CSharpier.Cli.Tests;
 // are written properly
 public class CliTests
 {
-    private static readonly string testFileDirectory = Path.Combine(
-        Directory.GetCurrentDirectory(),
-        "TestFiles"
-    );
+    private static readonly string testFileDirectory = Directory
+        .CreateTempSubdirectory("CsharpierTestFies")
+        .FullName;
 
     [SetUp]
     public void BeforeEachTest()

--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -151,7 +151,7 @@ internal static class CommandLineFormatter
 
         for (var x = 0; x < commandLineOptions.DirectoryOrFilePaths.Length; x++)
         {
-            var directoryOrFilePath = commandLineOptions.DirectoryOrFilePaths[x].Replace("\\", "/");
+            var directoryOrFilePath = commandLineOptions.DirectoryOrFilePaths[x];
             var isFile = fileSystem.File.Exists(directoryOrFilePath);
             var isDirectory = fileSystem.Directory.Exists(directoryOrFilePath);
 
@@ -178,9 +178,7 @@ internal static class CommandLineFormatter
                 cancellationToken
             );
 
-            var originalDirectoryOrFile = commandLineOptions
-                .OriginalDirectoryOrFilePaths[x]
-                .Replace("\\", "/");
+            var originalDirectoryOrFile = commandLineOptions.OriginalDirectoryOrFilePaths[x];
 
             var formattingCache = await FormattingCacheFactory.InitializeAsync(
                 commandLineOptions,
@@ -193,7 +191,8 @@ internal static class CommandLineFormatter
             {
                 if (!originalDirectoryOrFile.StartsWith('.'))
                 {
-                    originalDirectoryOrFile = "./" + originalDirectoryOrFile;
+                    originalDirectoryOrFile =
+                        "." + Path.DirectorySeparatorChar + originalDirectoryOrFile;
                 }
             }
 
@@ -266,13 +265,8 @@ internal static class CommandLineFormatter
                         SearchOption.AllDirectories
                     )
                     .Select(o =>
-                    {
-                        var normalizedPath = o.Replace("\\", "/");
-                        return FormatFile(
-                            normalizedPath,
-                            normalizedPath.Replace(directoryOrFilePath, originalDirectoryOrFile)
-                        );
-                    })
+                        FormatFile(o, o.Replace(directoryOrFilePath, originalDirectoryOrFile))
+                    )
                     .ToArray();
                 try
                 {

--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -54,7 +54,7 @@ internal static class CommandLineFormatter
                     (
                         commandLineOptions.IncludeGenerated
                         || !GeneratedCodeUtilities.IsGeneratedCodeFile(filePath)
-                    ) && !optionsProvider.IsIgnored(filePath)
+                    ) && !await optionsProvider.IsIgnoredAsync(filePath, cancellationToken)
                 )
                 {
                     var fileIssueLogger = new FileIssueLogger(
@@ -62,7 +62,10 @@ internal static class CommandLineFormatter
                         logger
                     );
 
-                    var printerOptions = optionsProvider.GetPrinterOptionsFor(filePath);
+                    var printerOptions = await optionsProvider.GetPrinterOptionsForAsync(
+                        filePath,
+                        cancellationToken
+                    );
                     if (printerOptions is { Formatter: not Formatter.Unknown })
                     {
                         printerOptions.IncludeGenerated = commandLineOptions.IncludeGenerated;
@@ -204,13 +207,16 @@ internal static class CommandLineFormatter
                     (
                         !commandLineOptions.IncludeGenerated
                         && GeneratedCodeUtilities.IsGeneratedCodeFile(actualFilePath)
-                    ) || optionsProvider.IsIgnored(actualFilePath)
+                    ) || await optionsProvider.IsIgnoredAsync(actualFilePath, cancellationToken)
                 )
                 {
                     return;
                 }
 
-                var printerOptions = optionsProvider.GetPrinterOptionsFor(actualFilePath);
+                var printerOptions = await optionsProvider.GetPrinterOptionsForAsync(
+                    actualFilePath,
+                    cancellationToken
+                );
 
                 if (printerOptions is { Formatter: not Formatter.Unknown })
                 {

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -15,6 +15,7 @@ internal class IgnoreFile
 
     public bool IsIgnored(string filePath)
     {
+        filePath = filePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
         foreach (var ignore in this.ignores)
         {
             // when using one of the ignore files to determine if a given file is ignored or not

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Ignore;
 
@@ -63,20 +64,21 @@ internal class IgnoreFile
                 )
             )
             {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
                 try
                 {
-                    if (string.IsNullOrWhiteSpace(line))
-                    {
-                        continue;
-                    }
                     ignore.Add(line);
                 }
                 catch (Exception ex)
                 {
                     throw new InvalidIgnoreFileException(
-                        @$"The .csharpierignore file at {ignoreFilePath} could not be parsed due to the following line:
-{line}
-",
+                        $"""
+                        The .csharpierignore file at {ignoreFilePath} could not be parsed due to the following line:
+                        {line}
+                        """,
                         ex
                     );
                 }

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.IO.Abstractions;
 using Ignore;
 
@@ -30,7 +29,7 @@ internal class IgnoreFile
         return false;
     }
 
-    public static async Task<IgnoreFile> CreateAsync(
+    public static async Task<IgnoreFile?> CreateAsync(
         string baseDirectoryPath,
         IFileSystem fileSystem,
         CancellationToken cancellationToken

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,112 +1,179 @@
+using System.Diagnostics;
 using System.IO.Abstractions;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Ignore;
 
 namespace CSharpier.Cli;
 
+internal class IgnoreWithBasePath(string basePath)
+{
+    public string BasePath => basePath;
+    public readonly List<IgnoreRule> Rules = new();
+
+    public bool TryIsIgnored(string path, out bool isIgnored)
+    {
+        isIgnored = false;
+        var pathRelativeToIgnoreFile = path.Replace('\\', '/');
+        if (!pathRelativeToIgnoreFile.StartsWith(basePath, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        pathRelativeToIgnoreFile =
+            pathRelativeToIgnoreFile.Length > basePath.Length
+                ? pathRelativeToIgnoreFile[(basePath.Length + 1)..]
+                : string.Empty;
+
+        var hasMatchingRule = false;
+        foreach (var rule in this.Rules)
+        {
+            var isMatch = rule.IsMatch(pathRelativeToIgnoreFile);
+            if (isMatch)
+            {
+                hasMatchingRule = true;
+            }
+            if (rule.Negate)
+            {
+                if (isIgnored && isMatch)
+                {
+                    isIgnored = false;
+                }
+            }
+            else if (!isIgnored && isMatch)
+            {
+                isIgnored = true;
+            }
+        }
+        return hasMatchingRule;
+    }
+
+    public void Add(string rule)
+    {
+        this.Rules.Add(new IgnoreRule(rule));
+    }
+}
+
 internal class IgnoreFile
 {
-    protected Ignore.Ignore Ignore { get; }
-    protected string IgnoreBaseDirectoryPath { get; }
+    protected List<IgnoreWithBasePath> ignores { get; }
     private static readonly string[] alwaysIgnored = ["**/node_modules", "**/obj", "**/.git"];
 
-    protected IgnoreFile(Ignore.Ignore ignore, string ignoreBaseDirectoryPath)
+    protected IgnoreFile(List<IgnoreWithBasePath> ignores)
     {
-        this.Ignore = ignore;
-        this.IgnoreBaseDirectoryPath = ignoreBaseDirectoryPath.Replace('\\', '/');
+        this.ignores = ignores;
     }
 
     public bool IsIgnored(string filePath)
     {
-        var pathRelativeToIgnoreFile = filePath.Replace('\\', '/');
-        if (
-            !pathRelativeToIgnoreFile.StartsWith(
-                this.IgnoreBaseDirectoryPath,
-                StringComparison.Ordinal
-            )
-        )
+        foreach (var ignore in this.ignores)
         {
-            // TODO #631
-            // the ignore file was created for /test/subfolder
-            // and we are checking if /test/.editorconfig is ignored, which it CAN'T be
-            // in main, we did not check if parent folder editorconfigs were ignored, which is probably a bug
-            // we need to figure out a better way to deal with ignorefiles, which will come in the PR for 631
-
-            return false;
-            // throw new Exception(
-            //     $"The filePath of {filePath} does not start with the ignoreBaseDirectoryPath of {this.IgnoreBaseDirectoryPath}"
-            // );
+            if (ignore.TryIsIgnored(filePath, out var result))
+            {
+                DebugLogger.Log(ignore);
+                DebugLogger.Log($"{filePath} {result}");
+                return result;
+            }
         }
 
-        pathRelativeToIgnoreFile =
-            pathRelativeToIgnoreFile.Length > this.IgnoreBaseDirectoryPath.Length
-                ? pathRelativeToIgnoreFile[(this.IgnoreBaseDirectoryPath.Length + 1)..]
-                : string.Empty;
-
-        return this.Ignore.IsIgnored(pathRelativeToIgnoreFile);
+        return false;
     }
 
-    public static async Task<IgnoreFile> Create(
+    public static async Task<IgnoreFile> CreateAsync(
         string baseDirectoryPath,
         IFileSystem fileSystem,
         CancellationToken cancellationToken
     )
     {
-        var ignore = new Ignore.Ignore();
-
-        foreach (var name in alwaysIgnored)
+        var ignoreFilePaths = FindIgnorePath(baseDirectoryPath, fileSystem);
+        if (ignoreFilePaths.Count == 0)
         {
-            ignore.Add(name);
-        }
-
-        var ignoreFilePath = FindIgnorePath(baseDirectoryPath, fileSystem);
-        if (ignoreFilePath == null)
-        {
-            return new IgnoreFile(ignore, baseDirectoryPath);
-        }
-
-        foreach (
-            var line in await fileSystem.File.ReadAllLinesAsync(ignoreFilePath, cancellationToken)
-        )
-        {
-            try
+            var ignore = new IgnoreWithBasePath(baseDirectoryPath.Replace('\\', '/'));
+            foreach (var name in alwaysIgnored)
             {
-                ignore.Add(line);
+                ignore.Add(name);
             }
-            catch (Exception ex)
+            return new IgnoreFile([ignore]);
+        }
+
+        var ignores = new List<IgnoreWithBasePath>();
+        foreach (var ignoreFilePath in ignoreFilePaths)
+        {
+            var ignore = new IgnoreWithBasePath(
+                Path.GetDirectoryName(ignoreFilePath)!.Replace('\\', '/')
+            );
+            ignores.Insert(0, ignore);
+            foreach (var name in alwaysIgnored)
             {
-                throw new InvalidIgnoreFileException(
-                    @$"The .csharpierignore file at {ignoreFilePath} could not be parsed due to the following line:
+                ignore.Add(name);
+            }
+            foreach (
+                var line in await fileSystem.File.ReadAllLinesAsync(
+                    ignoreFilePath,
+                    cancellationToken
+                )
+            )
+            {
+                try
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+                    ignore.Add(line);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidIgnoreFileException(
+                        @$"The .csharpierignore file at {ignoreFilePath} could not be parsed due to the following line:
 {line}
 ",
-                    ex
-                );
+                        ex
+                    );
+                }
             }
         }
 
-        var directoryName = fileSystem.Path.GetDirectoryName(ignoreFilePath);
-
-        ArgumentNullException.ThrowIfNull(directoryName);
-
-        return new IgnoreFile(ignore, directoryName);
+        return new IgnoreFile(ignores);
     }
 
-    private static string? FindIgnorePath(string baseDirectoryPath, IFileSystem fileSystem)
+    // this will return the ignore paths with the priority path coming last, which means the rules from the last entry will take
+    // priority. .csharpierignore comes last, gitignore come before
+    private static List<string> FindIgnorePath(string baseDirectoryPath, IFileSystem fileSystem)
     {
+        var result = new List<string>();
+        string? foundCSharpierIgnoreFilePath = null;
         var directoryInfo = fileSystem.DirectoryInfo.New(baseDirectoryPath);
         while (directoryInfo != null)
         {
-            var ignoreFilePath = fileSystem.Path.Combine(
-                directoryInfo.FullName,
-                ".csharpierignore"
-            );
-            if (fileSystem.File.Exists(ignoreFilePath))
+            if (foundCSharpierIgnoreFilePath is null)
             {
-                return ignoreFilePath;
+                var csharpierIgnoreFilePath = fileSystem.Path.Combine(
+                    directoryInfo.FullName,
+                    ".csharpierignore"
+                );
+                if (fileSystem.File.Exists(csharpierIgnoreFilePath))
+                {
+                    foundCSharpierIgnoreFilePath = csharpierIgnoreFilePath;
+                }
+            }
+
+            var gitIgnoreFilePath = fileSystem.Path.Combine(directoryInfo.FullName, ".gitignore");
+            if (fileSystem.File.Exists(gitIgnoreFilePath))
+            {
+                result.Insert(0, gitIgnoreFilePath);
             }
 
             directoryInfo = directoryInfo.Parent;
         }
 
-        return null;
+        if (foundCSharpierIgnoreFilePath is not null)
+        {
+            result.Add(foundCSharpierIgnoreFilePath);
+        }
+
+        return result;
     }
 }
 

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -201,8 +201,8 @@ internal class OptionsProvider
     }
 
     /// <summary>
-    /// this is a type of lazy lookup. We preload a csharpierconfig for the initial directory of the format command
-    /// For a file in a given subdirectory if we've already found the appropriate cshapierconfig return it
+    /// this is a type of lazy lookup. We preload file type for the initial directory of the format command
+    /// When trying to format a file in a given subdirectory if we've already found the appropriate file type then return it
     /// otherwise track it down (parsing if we need to) and set the references for any parent directories
     /// </summary>
     private async Task<T?> FindFileAsync<T>(

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -41,6 +41,12 @@ internal class OptionsProvider
         CancellationToken cancellationToken
     )
     {
+        while (!System.Diagnostics.Debugger.IsAttached)
+        {
+            Thread.Sleep(100);
+        }
+
+        DebugLogger.Log("Create " + directoryName);
         var csharpierConfigPath = configPath;
         string? editorConfigPath = null;
 
@@ -71,6 +77,8 @@ internal class OptionsProvider
             logger
         );
 
+        optionsProvider.ignoreFilesByDirectory[directoryName] = ignoreFile;
+
         if (csharpierConfigPath is null)
         {
             optionsProvider.csharpierConfigsByDirectory[directoryName] =
@@ -83,12 +91,6 @@ internal class OptionsProvider
                 EditorConfigLocator.FindForDirectoryName(directoryName, fileSystem, ignoreFile);
         }
 
-        optionsProvider.ignoreFilesByDirectory[directoryName] = await IgnoreFile.CreateAsync(
-            directoryName,
-            fileSystem,
-            cancellationToken
-        );
-
         return optionsProvider;
     }
 
@@ -97,6 +99,7 @@ internal class OptionsProvider
         CancellationToken cancellationToken
     )
     {
+        DebugLogger.Log("GetPrinterOptionsForAsync " + filePath);
         if (this.specifiedConfigFile is not null)
         {
             return this.specifiedConfigFile.ConvertToPrinterOptions(filePath);
@@ -239,6 +242,7 @@ internal class OptionsProvider
         CancellationToken cancellationToken
     )
     {
+        DebugLogger.Log("FindIgnoreFileAsync " + directoryName);
         if (this.ignoreFilesByDirectory.TryGetValue(directoryName, out var ignoreFile))
         {
             return ignoreFile;

--- a/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
+++ b/Src/CSharpier.Cli/Server/CSharpierServiceImplementation.cs
@@ -51,13 +51,16 @@ internal class CSharpierServiceImplementation(ILogger logger)
 
             if (
                 GeneratedCodeUtilities.IsGeneratedCodeFile(fileName)
-                || optionsProvider.IsIgnored(fileName)
+                || await optionsProvider.IsIgnoredAsync(fileName, cancellationToken)
             )
             {
                 return new FormatFileResult(Status.Ignored);
             }
 
-            var printerOptions = optionsProvider.GetPrinterOptionsFor(formatFileParameter.fileName);
+            var printerOptions = await optionsProvider.GetPrinterOptionsForAsync(
+                formatFileParameter.fileName,
+                cancellationToken
+            );
             if (printerOptions == null || printerOptions.Formatter is Formatter.Unknown)
             {
                 return new FormatFileResult(Status.UnsupportedFile);

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -578,9 +578,10 @@ public class CommandLineFormatterTests
     public void Ignore_Should_Deal_With_Inconsistent_Slashes()
     {
         var context = new TestContext();
-        var unformattedFilePath1 = @"SubFolder\1\File1.cs";
+        var altSlash = Path.AltDirectorySeparatorChar;
+        var unformattedFilePath1 = $"Child{altSlash}GrandChild{altSlash}File1.cs";
         context.WhenAFileExists(unformattedFilePath1, UnformattedClassContent);
-        context.WhenAFileExists("SubFolder/1/.csharpierignore", "File1.cs");
+        context.WhenAFileExists("Child/GrandChild/.csharpierignore", "File1.cs");
 
         var result = Format(context, directoryOrFilePaths: unformattedFilePath1);
 

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -596,6 +596,75 @@ public class CommandLineFormatterTests
         result.ErrorOutputLines.Skip(1).First().Should().Contain(@"\Src\Uploads\*.cs");
     }
 
+    [TestCase("File.cs", "!File.cs", false)]
+    [TestCase("", "File.cs", true)]
+    [TestCase("!File.cs", "File.cs", true)]
+    [TestCase("File.cs", "", true)]
+    public void CSharpier_Ignore_And_Git_Ignore_Root_Level(
+        string gitIgnoreContents,
+        string csharpierIgnoreContents,
+        bool isIgnored
+    )
+    {
+        var context = new TestContext();
+        context.WhenAFileExists("File.cs", UnformattedClassContent);
+        context.WhenAFileExists(".csharpierignore", csharpierIgnoreContents);
+        context.WhenAFileExists(".gitignore", gitIgnoreContents);
+
+        var result = Format(context);
+
+        result
+            .OutputLines.FirstOrDefault()
+            .Should()
+            .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
+    }
+
+    [TestCase("File.cs", "!File.cs", false)]
+    [TestCase("", "File.cs", true)]
+    [TestCase("!File.cs", "File.cs", true)]
+    [TestCase("File.cs", "", true)]
+    public void CSharpier_Ignore_And_Git_Ignore_Sub_Level(
+        string gitIgnoreContents,
+        string csharpierIgnoreContents,
+        bool isIgnored
+    )
+    {
+        var context = new TestContext();
+        context.WhenAFileExists("Sub/File.cs", UnformattedClassContent);
+        context.WhenAFileExists(".csharpierignore", csharpierIgnoreContents);
+        context.WhenAFileExists("Sub/.gitignore", gitIgnoreContents);
+
+        var result = Format(context);
+
+        result
+            .OutputLines.FirstOrDefault()
+            .Should()
+            .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
+    }
+
+    [TestCase("File.cs", "!File.cs", false)]
+    [TestCase("", "File.cs", true)]
+    [TestCase("!File.cs", "File.cs", true)]
+    [TestCase("File.cs", "", true)]
+    public void Two_Git_Ignores(
+        string rootGitIgnoreContents,
+        string subGitIgnoreContents,
+        bool isIgnored
+    )
+    {
+        var context = new TestContext();
+        context.WhenAFileExists("Sub/File.cs", UnformattedClassContent);
+        context.WhenAFileExists(".gitignore", rootGitIgnoreContents);
+        context.WhenAFileExists("Sub/.gitignore", subGitIgnoreContents);
+
+        var result = Format(context);
+
+        result
+            .OutputLines.FirstOrDefault()
+            .Should()
+            .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
+    }
+
     [Test]
     public void Write_Stdout_Should_Only_Write_File()
     {

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -25,6 +25,7 @@ public class CommandLineFormatterTests
 
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Error ./Invalid.cs - Failed to compile so was not formatted.");
 
@@ -41,6 +42,7 @@ public class CommandLineFormatterTests
 
         result
             .OutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Warning ./Invalid.cs - Failed to compile so was not formatted.");
 
@@ -57,6 +59,7 @@ public class CommandLineFormatterTests
 
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Error ./Subdirectory/Invalid.cs - Failed to compile so was not formatted.");
     }
@@ -74,6 +77,7 @@ public class CommandLineFormatterTests
 
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be(
                 $"Error {GetRootPath().Replace('\\', '/')}/Subdirectory/Invalid.cs - Failed to compile so was not formatted."
@@ -90,6 +94,7 @@ public class CommandLineFormatterTests
 
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Error ./Directory/Invalid.cs - Failed to compile so was not formatted.");
     }
@@ -104,6 +109,7 @@ public class CommandLineFormatterTests
 
         result
             .OutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Warning ./Unsupported.js - Is an unsupported file type.");
     }
@@ -372,6 +378,7 @@ public class CommandLineFormatterTests
         context.GetFileContent(unformattedFilePath).Should().Be(UnformattedClassContent);
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .StartWith("Error ./Unformatted.cs - Was not formatted.");
     }
@@ -535,10 +542,14 @@ public class CommandLineFormatterTests
     public void Multiple_Files_Should_Use_Multiple_Ignores()
     {
         var context = new TestContext();
-        var unformattedFilePath1 = "SubFolder/1/File1.cs";
-        var unformattedFilePath2 = "SubFolder/2/File2.cs";
-        context.WhenAFileExists(unformattedFilePath1, UnformattedClassContent);
-        context.WhenAFileExists(unformattedFilePath2, UnformattedClassContent);
+        var unformattedFilePath1 = context.WhenAFileExists(
+            "SubFolder/1/File1.cs",
+            UnformattedClassContent
+        );
+        var unformattedFilePath2 = context.WhenAFileExists(
+            "SubFolder/2/File2.cs",
+            UnformattedClassContent
+        );
         context.WhenAFileExists("SubFolder/1/.csharpierignore", "File1.cs");
         context.WhenAFileExists("SubFolder/2/.csharpierignore", "File2.cs");
 
@@ -588,7 +599,6 @@ public class CommandLineFormatterTests
         result.ExitCode.Should().Be(1);
         result
             .ErrorOutputLines.First()
-            .Replace("\\", "/")
             .Should()
             .Contain(
                 $"Error The .csharpierignore file at {path} could not be parsed due to the following line:"
@@ -717,6 +727,7 @@ public class CommandLineFormatterTests
         context.GetFileContent("Invalid.cs").Should().Be(contents);
         result
             .ErrorOutputLines.First()
+            .Replace('\\', '/')
             .Should()
             .Be("Error ./Invalid.cs - Failed to compile so was not formatted.");
     }
@@ -794,7 +805,6 @@ class ClassName
 
         result
             .OutputLines.First()
-            .Replace("\\", "/")
             .Should()
             .Be($"Warning The configuration file at {configPath} was empty.");
     }
@@ -896,7 +906,9 @@ class ClassName
 
         public string WhenAFileExists(string path, string contents)
         {
-            path = this.FileSystem.Path.Combine(GetRootPath(), path).Replace('\\', '/');
+            path = this
+                .FileSystem.Path.Combine(GetRootPath(), path)
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             this.FileSystem.AddFile(path, new MockFileData(contents));
             return path;
         }

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -788,7 +788,10 @@ indent_size = 2
                 CancellationToken.None
             );
 
-            var printerOptions = provider.GetPrinterOptionsFor(filePath);
+            var printerOptions = await provider.GetPrinterOptionsForAsync(
+                filePath,
+                CancellationToken.None
+            );
 
             if (printerOptions is null)
             {

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -779,6 +779,15 @@ indent_size = 2
                 filePath = filePath.Replace("c:", string.Empty);
             }
 
+            directoryName = directoryName.Replace(
+                Path.AltDirectorySeparatorChar,
+                Path.DirectorySeparatorChar
+            );
+            filePath = filePath.Replace(
+                Path.AltDirectorySeparatorChar,
+                Path.DirectorySeparatorChar
+            );
+
             this.fileSystem.AddDirectory(directoryName);
             var provider = await OptionsProvider.Create(
                 directoryName,

--- a/docs/Ignore.md
+++ b/docs/Ignore.md
@@ -2,11 +2,11 @@
 title: Ignoring Code
 hide_table_of_contents: true
 ---
-Use `.csharpierignore` to bypass formatting specific files and folders.
+CSharpier supports
+- `.csharpierignore` and `.gitignore` to bypass formatting specific files and folders.
+- `csharpier-ignore` comments to bypass formatting specific parts of files.
 
-Use `csharpier-ignore` comments to bypass formatting specific parts of files.
-
-## Ignoring Files `.csharpierignore`
+## Ignoring Files
 
 Add a `.csharpierignore` file to ignore additional files and folders. The file uses [gitignore syntax](https://git-scm.com/docs/gitignore#_pattern_format)
 
@@ -14,6 +14,23 @@ Example
 ```ignore
 Uploads/
 **/App_Data/*.cs
+```
+
+### .gitignore
+CSharpier will read the contents of `.gitignore` files and use them in addition to a `.csharpierignore` file to determine if a file should be ignored.
+
+If a directory tree contains a `.csharpierignore` file then patterns in that file will always take priority over any `.gitignore` file in the same tree.
+
+To enable formatting of a file that is ignored via a `.gitignore` add a negated pattern.
+
+```.gitignore
+# .gitignore
+**/generated
+```
+
+```.gitignore
+# .csharpierignore
+!**/generated
 ```
 
 ### Files Ignored by Default


### PR DESCRIPTION
Closes #631 

CSharpier now works as follows.

- .gitignore files are considered when determining if a file will be ignored. A .gitignore file at the same level as a given file will take priority over a .gitignore file above it in the directory tree.
- If a .csharpierignore file is present at the same level or anywhere above the given file in the tree and it contains a pattern for a given file, that will take priority.
- The patterns within .csharpierignore work the same as a .gitignore, with patterns lower in the file taking priority over patterns above
- CSharpier does not currently look further up the directory tree for additional .csharpierignore files if it finds one. But it does look for .gitignore files. If there is demand this could be added later.

