### PR TITLE
feat: create an overload for `Any( SyntaxTriviaList` to prevent allocations

### DIFF
--- a/Src/CSharpier/Utilities/ListExtensions.cs
+++ b/Src/CSharpier/Utilities/ListExtensions.cs
@@ -18,4 +18,19 @@ internal static class ListExtensions
             value.Add(doc);
         }
     }
+
+    // Overload for Any to prevent unnecessary allocations of EnumeratorImpl
+    public static bool Any(this in SyntaxTriviaList triviaList, Func<SyntaxTrivia, bool> predicate)
+    {
+        // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var trivia in triviaList)
+        {
+            if (predicate(trivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Creates an extension method that overloads `Any(this SyntaxTriviaList)` this uses the struct `SyntaxTriviaList.Enumerator` to iterate, instead of allocating the class `SyntaxTriviaList.EnumeratorImpl : IEnumerator<SyntaxTrivia>` and boxing `SyntaxTrviaList`.

Saves around 11% of memory aka 11MB on the benchmark.

## Benchmarks
### Before
| Method                                  | Mean          | Error        | StdDev       | Median        | Gen0       | Gen1      | Gen2      | Allocated   |
|---------------------------------------- |--------------:|-------------:|-------------:|--------------:|-----------:|----------:|----------:|------------:|
| Default_CodeFormatter                   | 187,771.22 us | 3,718.757 us | 6,705.686 us | 187,214.50 us | 11000.0000 | 4000.0000 | 1000.0000 | 98124.57 KB |
| Default_SyntaxNodeComparer              |   1,920.62 us |    77.064 us |   227.225 us |   1,840.56 us |    66.4063 |   15.6250 |         - |   643.28 KB |
| IsCodeBasicallyEqual_SyntaxNodeComparer |      97.11 us |     3.195 us |     9.421 us |      96.33 us |    10.7422 |    1.3428 |         - |    99.02 KB |


### After
| Method                                  | Mean          | Error        | StdDev       | Gen0       | Gen1      | Gen2      | Allocated   |
|---------------------------------------- |--------------:|-------------:|-------------:|-----------:|----------:|----------:|------------:|
| Default_CodeFormatter                   | 180,664.34 us | 3,555.331 us | 6,037.222 us | 10000.0000 | 4000.0000 | 1000.0000 | 87296.88 KB |
| Default_SyntaxNodeComparer              |   2,315.61 us |   105.286 us |   310.439 us |    66.4063 |   15.6250 |         - |   643.28 KB |
| IsCodeBasicallyEqual_SyntaxNodeComparer |      84.32 us |     1.638 us |     2.297 us |    10.7422 |    1.3428 |         - |    99.02 KB |
