### PR TITLE
feat: manual `Where` loop to prevent boxing and enumerator allocation

### DIFF
--- a/Src/CSharpier/Formatters/CSharp/PreprocessorSymbols.cs
+++ b/Src/CSharpier/Formatters/CSharp/PreprocessorSymbols.cs
@@ -36,17 +36,19 @@ internal class PreprocessorSymbols : CSharpSyntaxWalker
             return;
         }
 
-        foreach (
-            var syntaxTrivia in token.LeadingTrivia.Where(syntaxTrivia =>
-                syntaxTrivia.RawSyntaxKind()
-                    is SyntaxKind.IfDirectiveTrivia
-                        or SyntaxKind.ElifDirectiveTrivia
-                        or SyntaxKind.ElseDirectiveTrivia
-                        or SyntaxKind.EndIfDirectiveTrivia
-            )
-        )
+        // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var syntaxTrivia in token.LeadingTrivia)
         {
-            this.Visit((CSharpSyntaxNode)syntaxTrivia.GetStructure()!);
+            if (
+                syntaxTrivia.RawSyntaxKind()
+                is SyntaxKind.IfDirectiveTrivia
+                    or SyntaxKind.ElifDirectiveTrivia
+                    or SyntaxKind.ElseDirectiveTrivia
+                    or SyntaxKind.EndIfDirectiveTrivia
+            )
+            {
+                this.Visit((CSharpSyntaxNode)syntaxTrivia.GetStructure()!);
+            }
         }
     }
 


### PR DESCRIPTION
Similar to #1485, use a manual `foreach` where loop to prevent boxing of `SyntaxTriviaList`, `SyntaxTriviaList.EnumeratorImpl` and `WhereIterator`.

### Before
![image](https://github.com/user-attachments/assets/5da8a77a-e7fe-4852-b6b8-6849ebb6c469)

### After
![image](https://github.com/user-attachments/assets/bcbedb56-e444-45e3-89d0-19d868840c34)
