### PR TITLE
feat: add `sealed` to `Doc` objects

### DIFF
--- a/Src/CSharpier/DocTypes/Align.cs
+++ b/Src/CSharpier/DocTypes/Align.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class Align : Doc, IHasContents
+internal sealed class Align : Doc, IHasContents
 {
     public int Width { get; }
     public Doc Contents { get; }

--- a/Src/CSharpier/DocTypes/AlwaysFits.cs
+++ b/Src/CSharpier/DocTypes/AlwaysFits.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class AlwaysFits(Doc printedTrivia) : Doc
+internal sealed class AlwaysFits(Doc printedTrivia) : Doc
 {
     public readonly Doc Contents = printedTrivia;
 }

--- a/Src/CSharpier/DocTypes/BreakParent.cs
+++ b/Src/CSharpier/DocTypes/BreakParent.cs
@@ -1,5 +1,5 @@
 namespace CSharpier.DocTypes;
 
-internal class BreakParent : Doc, IBreakParent { }
+internal sealed class BreakParent : Doc, IBreakParent { }
 
 internal interface IBreakParent { }

--- a/Src/CSharpier/DocTypes/Concat.cs
+++ b/Src/CSharpier/DocTypes/Concat.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class Concat(IList<Doc> contents) : Doc
+internal sealed class Concat(IList<Doc> contents) : Doc
 {
     public IList<Doc> Contents { get; set; } = contents;
 }

--- a/Src/CSharpier/DocTypes/ConditionalGroup.cs
+++ b/Src/CSharpier/DocTypes/ConditionalGroup.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class ConditionalGroup : Group
+internal sealed class ConditionalGroup : Group
 {
     public ConditionalGroup(Doc[] options)
     {

--- a/Src/CSharpier/DocTypes/ForceFlat.cs
+++ b/Src/CSharpier/DocTypes/ForceFlat.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class ForceFlat : Doc, IHasContents
+internal sealed class ForceFlat : Doc, IHasContents
 {
     public Doc Contents { get; set; } = Null;
 }

--- a/Src/CSharpier/DocTypes/HardLineNoTrim.cs
+++ b/Src/CSharpier/DocTypes/HardLineNoTrim.cs
@@ -1,3 +1,3 @@
 namespace CSharpier.DocTypes;
 
-internal class HardLineNoTrim : HardLine { }
+internal sealed class HardLineNoTrim : HardLine { }

--- a/Src/CSharpier/DocTypes/IfBreak.cs
+++ b/Src/CSharpier/DocTypes/IfBreak.cs
@@ -7,7 +7,7 @@ internal class IfBreak : Doc
     public string? GroupId { get; set; }
 }
 
-internal class IndentIfBreak : IfBreak
+internal sealed class IndentIfBreak : IfBreak
 {
     public IndentIfBreak(Doc contents, string groupId)
     {

--- a/Src/CSharpier/DocTypes/IndentDoc.cs
+++ b/Src/CSharpier/DocTypes/IndentDoc.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class IndentDoc : Doc, IHasContents
+internal sealed class IndentDoc : Doc, IHasContents
 {
     public Doc Contents { get; set; } = Null;
 }

--- a/Src/CSharpier/DocTypes/LeadingComment.cs
+++ b/Src/CSharpier/DocTypes/LeadingComment.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class LeadingComment : Doc
+internal sealed class LeadingComment : Doc
 {
     public CommentType Type { get; init; }
     public string Comment { get; init; } = string.Empty;

--- a/Src/CSharpier/DocTypes/LiteralLine.cs
+++ b/Src/CSharpier/DocTypes/LiteralLine.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class LiteralLine : LineDoc, IBreakParent
+internal sealed class LiteralLine : LineDoc, IBreakParent
 {
     public LiteralLine()
     {

--- a/Src/CSharpier/DocTypes/NullDoc.cs
+++ b/Src/CSharpier/DocTypes/NullDoc.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class NullDoc : Doc
+internal sealed class NullDoc : Doc
 {
     public static NullDoc Instance { get; } = new();
 

--- a/Src/CSharpier/DocTypes/Region.cs
+++ b/Src/CSharpier/DocTypes/Region.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class Region(string text) : Doc
+internal sealed class Region(string text) : Doc
 {
     public string Text { get; } = text;
     public bool IsEnd { get; init; }

--- a/Src/CSharpier/DocTypes/StringDoc.cs
+++ b/Src/CSharpier/DocTypes/StringDoc.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class StringDoc(string value, bool isDirective = false) : Doc
+internal sealed class StringDoc(string value, bool isDirective = false) : Doc
 {
     public string Value { get; } = value;
     public bool IsDirective { get; } = isDirective;

--- a/Src/CSharpier/DocTypes/TrailingComment.cs
+++ b/Src/CSharpier/DocTypes/TrailingComment.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal class TrailingComment : Doc
+internal sealed class TrailingComment : Doc
 {
     public CommentType Type { get; set; }
     public string Comment { get; set; } = string.Empty;

--- a/Src/CSharpier/DocTypes/Trim.cs
+++ b/Src/CSharpier/DocTypes/Trim.cs
@@ -1,3 +1,3 @@
 namespace CSharpier.DocTypes;
 
-internal class Trim : Doc { }
+internal sealed class Trim : Doc { }


### PR DESCRIPTION
Csharpier spends 7% of the time calling `IsInstanceOfClass` (IIRC think this is what `is` is lowered into). By sealing `Doc` types csharp should be able to do faster type comparison.