### PR TITLE
feat: check for " " values and return a static instance

### DIFF
--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -14,8 +14,10 @@ internal abstract class Doc
 
     public static implicit operator Doc(string value)
     {
-        return new StringDoc(value);
+        return value is " " ? SpaceString : new StringDoc(value);
     }
+
+    private static readonly StringDoc SpaceString = new(" ");
 
     public static NullDoc Null => NullDoc.Instance;
 


### PR DESCRIPTION
Add a check to `Doc`'s implicit operator for " " returning a static instance if found. Saves 0.5 MB in tests aka around 0.5%

### Benchmarks
#### Before
| Method                | Mean     | Error   | StdDev   | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|---------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 238.8 ms | 4.75 ms | 11.92 ms | 11000.0000 | 4000.0000 | 1000.0000 |  95.82 MB |


#### After
| Method                | Mean     | Error   | StdDev   | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|---------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 236.6 ms | 4.72 ms | 11.32 ms | 11000.0000 | 4000.0000 | 1000.0000 |  95.27 MB |
