### PR TITLE
feat: convert Linq to code to prevent closure

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -404,11 +404,17 @@ internal static class Token
 
     public static bool HasLeadingCommentMatching(SyntaxNode node, Regex regex)
     {
-        return node.GetLeadingTrivia()
-            .Any(o =>
+        // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var o in node.GetLeadingTrivia())
+        {
+            if (
                 o.RawSyntaxKind() is SyntaxKind.SingleLineCommentTrivia
                 && regex.IsMatch(o.ToString())
-            );
+            )
+                return true;
+        }
+
+        return false;
     }
 
     public static bool HasLeadingCommentMatching(SyntaxToken token, Regex regex)


### PR DESCRIPTION
Convert linq to code to prevent closure allocation to capture the `Regex` value. This removes a 1 MB `DisplayClass` closure object and a 2.4MB `Func<SyntaxTrivia, bool>`, not sure why this removes both a display class and a func object 🤷 

No idea why dotMemory claims that the method isn't allocating all of objects, I guess its erroneously crediting the allocations to methods that call `HasLeadingCommentMatching` and have the method call inlined. It also thinks a vey small number of closure/func allocations are occuring after the changes???
### Before
![image](https://github.com/user-attachments/assets/93963aca-c8ac-473f-9aeb-48ba2e66e1e2)

### After
![image](https://github.com/user-attachments/assets/71c3a580-d0c6-4a00-a75a-c30bb9312d96)
