### PR TITLE
feat: added `ValueStringBuilder`

### DIFF
--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -21,130 +21,138 @@ internal static class DocFitter
             newCommands.Push(new PrintCommand(indent, printMode, doc));
         }
 
-        var output = new StringBuilder();
+        var output = new ValueStringBuilder(stackalloc char[256]);
 
-        for (var x = 0; x < remainingCommands.Count || newCommands.Count > 0; )
+        try
         {
-            if (remainingWidth < 0)
+            for (var x = 0; x < remainingCommands.Count || newCommands.Count > 0; )
             {
-                return false;
-            }
-
-            var (currentIndent, currentMode, currentDoc) = newCommands switch
-            {
-                { Count: > 0 } => newCommands.Pop(),
-                _ => remainingCommands.ElementAt(x++),
-            };
-
-            switch (currentDoc)
-            {
-                case NullDoc:
-                    break;
-                case StringDoc stringDoc:
-                    // directives should not be considered when calculating if something fits
-                    if (stringDoc.Value == null || stringDoc.IsDirective)
-                        continue;
-
-                    if (returnFalseIfMoreStringsFound)
-                        return false;
-
-                    output.Append(stringDoc.Value);
-                    remainingWidth -= stringDoc.Value.GetPrintedWidth();
-                    break;
-                case LeadingComment
-                or TrailingComment:
-                    if (output.Length > 0 && currentMode is not PrintMode.ForceFlat)
-                        returnFalseIfMoreStringsFound = true;
-
-                    break;
-                case Region:
+                if (remainingWidth < 0)
+                {
                     return false;
-                case Concat concat:
-                    for (var i = concat.Contents.Count - 1; i >= 0; i--)
-                        Push(concat.Contents[i], currentMode, currentIndent);
-                    break;
-                case IndentDoc indent:
-                    Push(indent.Contents, currentMode, indenter.IncreaseIndent(currentIndent));
-                    break;
-                case Trim:
-                    remainingWidth += output.TrimTrailingWhitespace();
-                    break;
-                case Group group:
-                {
-                    var groupMode = group.Break ? PrintMode.Break : currentMode;
-
-                    // when determining if something fits, use the last option from a conditionalGroup, which should be the most expanded one
-                    var groupContents =
-                        groupMode == PrintMode.Break && group is ConditionalGroup conditionalGroup
-                            ? conditionalGroup.Options.Last()
-                            : group.Contents;
-                    Push(groupContents, groupMode, currentIndent);
-
-                    if (group.GroupId != null)
-                    {
-                        groupModeMap![group.GroupId] = groupMode;
-                    }
-
-                    break;
                 }
-                case IfBreak ifBreak:
+
+                var (currentIndent, currentMode, currentDoc) = newCommands switch
                 {
-                    var ifBreakMode =
-                        ifBreak.GroupId != null
-                        && groupModeMap.TryGetValue(ifBreak.GroupId, out var groupMode)
-                            ? groupMode
-                            : currentMode;
+                    { Count: > 0 } => newCommands.Pop(),
+                    _ => remainingCommands.ElementAt(x++),
+                };
 
-                    var contents =
-                        ifBreakMode == PrintMode.Break
-                            ? ifBreak.BreakContents
-                            : ifBreak.FlatContents;
+                switch (currentDoc)
+                {
+                    case NullDoc:
+                        break;
+                    case StringDoc stringDoc:
+                        // directives should not be considered when calculating if something fits
+                        if (stringDoc.Value == null || stringDoc.IsDirective)
+                            continue;
 
-                    Push(contents, currentMode, currentIndent);
-                    break;
-                }
-                case LineDoc line:
-                    if (currentMode is PrintMode.Flat or PrintMode.ForceFlat)
+                        if (returnFalseIfMoreStringsFound)
+                            return false;
+
+                        output.Append(stringDoc.Value);
+                        remainingWidth -= stringDoc.Value.GetPrintedWidth();
+                        break;
+                    case LeadingComment
+                    or TrailingComment:
+                        if (output.Length > 0 && currentMode is not PrintMode.ForceFlat)
+                            returnFalseIfMoreStringsFound = true;
+
+                        break;
+                    case Region:
+                        return false;
+                    case Concat concat:
+                        for (var i = concat.Contents.Count - 1; i >= 0; i--)
+                            Push(concat.Contents[i], currentMode, currentIndent);
+                        break;
+                    case IndentDoc indent:
+                        Push(indent.Contents, currentMode, indenter.IncreaseIndent(currentIndent));
+                        break;
+                    case Trim:
+                        remainingWidth += output.TrimTrailingWhitespace();
+                        break;
+                    case Group group:
                     {
-                        if (currentDoc is HardLine { SkipBreakIfFirstInGroup: true })
-                        {
-                            returnFalseIfMoreStringsFound = false;
-                        }
-                        else if (line.Type == LineDoc.LineType.Hard)
-                        {
-                            return true;
-                        }
+                        var groupMode = group.Break ? PrintMode.Break : currentMode;
 
-                        if (line.Type != LineDoc.LineType.Soft)
-                        {
-                            output.Append(' ');
+                        // when determining if something fits, use the last option from a conditionalGroup, which should be the most expanded one
+                        var groupContents =
+                            groupMode == PrintMode.Break
+                            && group is ConditionalGroup conditionalGroup
+                                ? conditionalGroup.Options.Last()
+                                : group.Contents;
+                        Push(groupContents, groupMode, currentIndent);
 
-                            remainingWidth -= 1;
+                        if (group.GroupId != null)
+                        {
+                            groupModeMap![group.GroupId] = groupMode;
                         }
 
                         break;
                     }
+                    case IfBreak ifBreak:
+                    {
+                        var ifBreakMode =
+                            ifBreak.GroupId != null
+                            && groupModeMap.TryGetValue(ifBreak.GroupId, out var groupMode)
+                                ? groupMode
+                                : currentMode;
 
-                    return true;
-                case ForceFlat flat:
-                    Push(flat.Contents, PrintMode.ForceFlat, currentIndent);
-                    break;
-                case BreakParent:
-                    break;
-                case Align align:
-                    Push(
-                        align.Contents,
-                        currentMode,
-                        indenter.AddAlign(currentIndent, align.Width)
-                    );
-                    break;
-                case AlwaysFits:
-                    break;
-                default:
-                    throw new Exception("Can't handle " + currentDoc.GetType());
+                        var contents =
+                            ifBreakMode == PrintMode.Break
+                                ? ifBreak.BreakContents
+                                : ifBreak.FlatContents;
+
+                        Push(contents, currentMode, currentIndent);
+                        break;
+                    }
+                    case LineDoc line:
+                        if (currentMode is PrintMode.Flat or PrintMode.ForceFlat)
+                        {
+                            if (currentDoc is HardLine { SkipBreakIfFirstInGroup: true })
+                            {
+                                returnFalseIfMoreStringsFound = false;
+                            }
+                            else if (line.Type == LineDoc.LineType.Hard)
+                            {
+                                return true;
+                            }
+
+                            if (line.Type != LineDoc.LineType.Soft)
+                            {
+                                output.Append(' ');
+
+                                remainingWidth -= 1;
+                            }
+
+                            break;
+                        }
+
+                        return true;
+                    case ForceFlat flat:
+                        Push(flat.Contents, PrintMode.ForceFlat, currentIndent);
+                        break;
+                    case BreakParent:
+                        break;
+                    case Align align:
+                        Push(
+                            align.Contents,
+                            currentMode,
+                            indenter.AddAlign(currentIndent, align.Width)
+                        );
+                        break;
+                    case AlwaysFits:
+                        break;
+                    default:
+                        throw new Exception("Can't handle " + currentDoc.GetType());
+                }
             }
-        }
 
-        return remainingWidth > 0;
+            return remainingWidth > 0;
+        }
+        finally
+        {
+            output.Dispose();
+        }
     }
 }

--- a/Src/CSharpier/Utilities/StringBuilderExtensions.cs
+++ b/Src/CSharpier/Utilities/StringBuilderExtensions.cs
@@ -62,4 +62,24 @@ internal static class StringBuilderExtensions
         stringBuilder.Length -= trimmed;
         return trimmed;
     }
+
+    public static int TrimTrailingWhitespace(this ref ValueStringBuilder stringBuilder)
+    {
+        if (stringBuilder.Length == 0)
+        {
+            return 0;
+        }
+
+        var trimmed = 0;
+        for (; trimmed < stringBuilder.Length; trimmed++)
+        {
+            if (stringBuilder[^(trimmed + 1)] is not ' ' and not '\t')
+            {
+                break;
+            }
+        }
+
+        stringBuilder.Length -= trimmed;
+        return trimmed;
+    }
 }

--- a/Src/CSharpier/Utilities/ValueStringBuilder.cs
+++ b/Src/CSharpier/Utilities/ValueStringBuilder.cs
@@ -1,0 +1,318 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace CSharpier.Utilities;
+
+internal ref struct ValueStringBuilder
+{
+    private char[]? arrayToReturnToPool;
+    private Span<char> chars;
+    private int pos;
+
+    public ValueStringBuilder(Span<char> initialBuffer)
+    {
+        arrayToReturnToPool = null;
+        chars = initialBuffer;
+        pos = 0;
+    }
+
+    public ValueStringBuilder(int initialCapacity)
+    {
+        arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+        chars = arrayToReturnToPool;
+        pos = 0;
+    }
+
+    public int Length
+    {
+        get => pos;
+        set
+        {
+            Debug.Assert(value >= 0);
+            Debug.Assert(value <= chars.Length);
+            pos = value;
+        }
+    }
+
+    public int Capacity => chars.Length;
+
+    public void EnsureCapacity(int capacity)
+    {
+        // This is not expected to be called this with negative capacity
+        Debug.Assert(capacity >= 0);
+
+        // If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+        if ((uint)capacity > (uint)chars.Length)
+            Grow(capacity - pos);
+    }
+
+    /// <summary>
+    /// Get a pinnable reference to the builder.
+    /// Does not ensure there is a null char after <see cref="Length"/>
+    /// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+    /// the explicit method call, and write eg "fixed (char* c = builder)"
+    /// </summary>
+    public ref char GetPinnableReference()
+    {
+        return ref MemoryMarshal.GetReference(chars);
+    }
+
+    /// <summary>
+    /// Get a pinnable reference to the builder.
+    /// </summary>
+    /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+    public ref char GetPinnableReference(bool terminate)
+    {
+        if (terminate)
+        {
+            EnsureCapacity(Length + 1);
+            chars[Length] = '\0';
+        }
+        return ref MemoryMarshal.GetReference(chars);
+    }
+
+    public ref char this[int index]
+    {
+        get
+        {
+            Debug.Assert(index < pos);
+            return ref chars[index];
+        }
+    }
+
+    public override string ToString()
+    {
+        string s = chars.Slice(0, pos).ToString();
+        Dispose();
+        return s;
+    }
+
+    /// <summary>Returns the underlying storage of the builder.</summary>
+    public Span<char> RawChars => chars;
+
+    /// <summary>
+    /// Returns a span around the contents of the builder.
+    /// </summary>
+    /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+    public ReadOnlySpan<char> AsSpan(bool terminate)
+    {
+        if (terminate)
+        {
+            EnsureCapacity(Length + 1);
+            chars[Length] = '\0';
+        }
+        return chars.Slice(0, pos);
+    }
+
+    public ReadOnlySpan<char> AsSpan() => chars.Slice(0, pos);
+
+    public ReadOnlySpan<char> AsSpan(int start) => chars.Slice(start, pos - start);
+
+    public ReadOnlySpan<char> AsSpan(int start, int length) => chars.Slice(start, length);
+
+    public bool TryCopyTo(Span<char> destination, out int charsWritten)
+    {
+        if (chars.Slice(0, pos).TryCopyTo(destination))
+        {
+            charsWritten = pos;
+            Dispose();
+            return true;
+        }
+        else
+        {
+            charsWritten = 0;
+            Dispose();
+            return false;
+        }
+    }
+
+    public void Insert(int index, char value, int count)
+    {
+        if (pos > chars.Length - count)
+        {
+            Grow(count);
+        }
+
+        int remaining = pos - index;
+        chars.Slice(index, remaining).CopyTo(chars.Slice(index + count));
+        chars.Slice(index, count).Fill(value);
+        pos += count;
+    }
+
+    public void Insert(int index, string? s)
+    {
+        if (s == null)
+        {
+            return;
+        }
+
+        int count = s.Length;
+
+        if (pos > (chars.Length - count))
+        {
+            Grow(count);
+        }
+
+        int remaining = pos - index;
+        chars.Slice(index, remaining).CopyTo(chars.Slice(index + count));
+        s
+#if !NET
+        .AsSpan()
+#endif
+        .CopyTo(chars.Slice(index));
+        pos += count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(char c)
+    {
+        int pos = this.pos;
+        Span<char> chars = this.chars;
+        if ((uint)pos < (uint)chars.Length)
+        {
+            chars[pos] = c;
+            this.pos = pos + 1;
+        }
+        else
+        {
+            GrowAndAppend(c);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(string? s)
+    {
+        if (s == null)
+        {
+            return;
+        }
+
+        int pos = this.pos;
+        if (s.Length == 1 && (uint)pos < (uint)chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+        {
+            chars[pos] = s[0];
+            this.pos = pos + 1;
+        }
+        else
+        {
+            AppendSlow(s);
+        }
+    }
+
+    private void AppendSlow(string s)
+    {
+        int pos = this.pos;
+        if (pos > chars.Length - s.Length)
+        {
+            Grow(s.Length);
+        }
+
+        s
+#if !NET
+        .AsSpan()
+#endif
+        .CopyTo(chars.Slice(pos));
+        this.pos += s.Length;
+    }
+
+    public void Append(char c, int count)
+    {
+        if (pos > chars.Length - count)
+        {
+            Grow(count);
+        }
+
+        Span<char> dst = chars.Slice(pos, count);
+        for (int i = 0; i < dst.Length; i++)
+        {
+            dst[i] = c;
+        }
+        pos += count;
+    }
+
+    public void Append(scoped ReadOnlySpan<char> value)
+    {
+        int pos = this.pos;
+        if (pos > chars.Length - value.Length)
+        {
+            Grow(value.Length);
+        }
+
+        value.CopyTo(chars.Slice(this.pos));
+        this.pos += value.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<char> AppendSpan(int length)
+    {
+        int origPos = pos;
+        if (origPos > chars.Length - length)
+        {
+            Grow(length);
+        }
+
+        pos = origPos + length;
+        return chars.Slice(origPos, length);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void GrowAndAppend(char c)
+    {
+        Grow(1);
+        Append(c);
+    }
+
+    /// <summary>
+    /// Resize the internal buffer either by doubling current buffer size or
+    /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+    /// <see cref="pos"/> whichever is greater.
+    /// </summary>
+    /// <param name="additionalCapacityBeyondPos">
+    /// Number of chars requested beyond current position.
+    /// </param>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Grow(int additionalCapacityBeyondPos)
+    {
+        Debug.Assert(additionalCapacityBeyondPos > 0);
+        Debug.Assert(
+            pos > chars.Length - additionalCapacityBeyondPos,
+            "Grow called incorrectly, no resize is needed."
+        );
+
+        const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+        // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+        // to double the size if possible, bounding the doubling to not go beyond the max array length.
+        int newCapacity = (int)
+            Math.Max(
+                (uint)(pos + additionalCapacityBeyondPos),
+                Math.Min((uint)chars.Length * 2, ArrayMaxLength)
+            );
+
+        // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+        // This could also go negative if the actual required length wraps around.
+        char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+        chars.Slice(0, pos).CopyTo(poolArray);
+
+        char[]? toReturn = arrayToReturnToPool;
+        chars = arrayToReturnToPool = poolArray;
+        if (toReturn != null)
+        {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        char[]? toReturn = arrayToReturnToPool;
+        this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+        if (toReturn != null)
+        {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+    }
+}


### PR DESCRIPTION
Add `ValueStringBuilder` to replace `StringBuilder`, used for `DocFitter.Fits` saving around 3.5 MB.




### Before
![image](https://github.com/user-attachments/assets/d6d9ee7c-567a-418f-a4e6-080169c70914)


### After
![image](https://github.com/user-attachments/assets/5dbaedad-a40d-4aba-9647-cdc6ec6bbdb9)
