### PR TITLE
feat: reuse collection types for `DocFitter`

### DIFF
--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -9,19 +9,22 @@ internal static class DocFitter
         Stack<PrintCommand> remainingCommands,
         int remainingWidth,
         Dictionary<string, PrintMode> groupModeMap,
-        Indenter indenter
+        Indenter indenter,
+        Stack<PrintCommand> newCommands,
+        StringBuilder output
     )
     {
+        // Reset reusable collections before usage
+        newCommands.Clear();
+        output.Clear();
+
         var returnFalseIfMoreStringsFound = false;
-        var newCommands = new Stack<PrintCommand>();
         newCommands.Push(nextCommand);
 
         void Push(Doc doc, PrintMode printMode, Indent indent)
         {
             newCommands.Push(new PrintCommand(indent, printMode, doc));
         }
-
-        var output = new StringBuilder();
 
         for (var x = 0; x < remainingCommands.Count || newCommands.Count > 0; )
         {

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -16,6 +16,10 @@ internal class DocPrinter
     protected readonly Indenter Indenter;
     protected readonly Stack<Indent> RegionIndents = new();
 
+    // Reusable collection types for use in DocFitter
+    protected readonly Stack<PrintCommand> DocFitterNewCommands = new();
+    protected readonly StringBuilder DocFitterOutput = new();
+
     protected DocPrinter(Doc doc, PrinterOptions printerOptions, string endOfLine)
     {
         this.EndOfLine = endOfLine;
@@ -389,7 +393,9 @@ internal class DocPrinter
             this.RemainingCommands,
             this.PrinterOptions.Width - this.CurrentWidth,
             this.GroupModeMap,
-            this.Indenter
+            this.Indenter,
+            this.DocFitterNewCommands,
+            this.DocFitterOutput
         );
     }
 


### PR DESCRIPTION
Instead of creating a new instance of `StringBuilder` and `Stack<PrintCommand>` every time `DocFitter.Fit` is called we instead create a single instance of each in `DocPrinter` and pass it into `DocFitter.Fit`.

This could be replaced by using `ValueStringBuilder` and `ValueListBuilder`, the latter would be beneficial as unlike `Stack<T>` we can access items by index instead of the `O(n)` lookup time with `ElementAt`.

### Before
| Method                | Mean     | Error   | StdDev  | Median   | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|--------:|---------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 231.5 ms | 4.62 ms | 8.78 ms | 228.0 ms | 11000.0000 | 4000.0000 | 1000.0000 |  95.82 MB |

### After
| Method                | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 227.0 ms | 4.51 ms | 6.33 ms | 10000.0000 | 4000.0000 | 1000.0000 |  90.03 MB |