### PR TITLE
feat: add `Stack.ElementAt` overload, prevents Enumerator allocation

### DIFF
--- a/Src/CSharpier/Utilities/StackExtensions.cs
+++ b/Src/CSharpier/Utilities/StackExtensions.cs
@@ -19,4 +19,20 @@ internal static class StackExtensions
         }
     }
 #endif
+
+    // Overload for IEnumerable.ElementAt, prevents allocating Stack<T>.Enumerator
+    public static T ElementAt<T>(this Stack<T> collection, int index)
+    {
+        foreach (var item in collection)
+        {
+            if (index == 0)
+            {
+                return item;
+            }
+
+            index--;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(index));
+    }
 }


### PR DESCRIPTION
Overload for `ElementAt` to prevent boxing `Stack<T>.Enumerator`. Saves 0.9MB

### Before
| Method                | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 234.0 ms | 4.50 ms | 5.85 ms | 11000.0000 | 4000.0000 | 1000.0000 |  95.82 MB |

### After
| Method                | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 233.0 ms | 4.63 ms | 7.35 ms | 11000.0000 | 4000.0000 | 1000.0000 |  94.96 MB |
