### PR TITLE
feat: add early return to `PrintTrailingTrivia`

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -374,8 +374,13 @@ internal static class Token
         return PrintTrailingTrivia(node.TrailingTrivia);
     }
 
-    private static Doc PrintTrailingTrivia(SyntaxTriviaList trailingTrivia)
+    private static Doc PrintTrailingTrivia(in SyntaxTriviaList trailingTrivia)
     {
+        if (trailingTrivia.Count == 0)
+        {
+            return Doc.Null;
+        }
+
         var docs = new List<Doc>();
         foreach (var trivia in trailingTrivia)
         {


### PR DESCRIPTION
- Use length check in `PrintTrailingTrivia` to return early, prevents `List<Doc>` allocation saving 1MB
- Pass `SyntaxTriviaList` by `in` because its a pretty large struct


### Before
![image](https://github.com/user-attachments/assets/90b9d855-4575-490a-a9f1-75c9e3aaad5c)


### After
![image](https://github.com/user-attachments/assets/1ff74e1d-2f40-47f3-adf7-d8d727085186)
