### PR TITLE
feat: add early return to `PrivatePrintLeadingTrivia`

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -224,6 +224,11 @@ internal static class Token
         bool skipLastHardline = false
     )
     {
+        if (leadingTrivia.Count == 0)
+        {
+            return Doc.Null;
+        }
+
         var docs = new List<Doc>();
 
         // we don't print any new lines until we run into a comment or directive


### PR DESCRIPTION
Use length check in PrintTrailingTrivia to return early, prevents List<Doc> allocation saving 1.9MB, 2%.


### Before
![image](https://github.com/user-attachments/assets/00955f73-7e76-4196-9ff0-47a9e2197abc)

### After
![image](https://github.com/user-attachments/assets/407e5c07-e4be-4ce2-9be4-d4e6fcd2e869)
