### PR TITLE
feat: add `FirstOrDefault` overload

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
@@ -32,7 +32,7 @@ internal static class SeparatedSyntaxList
     // sometimes there are trailing commas with calls to Print (some patterns do that)
     // and if you pass null to PrintWithTrailingComma it won't add a trailing comma if there isn't one
     private static Doc Print<T>(
-        SeparatedSyntaxList<T> list,
+        in SeparatedSyntaxList<T> list,
         Func<T, PrintingContext, Doc> printFunc,
         Doc afterSeparator,
         PrintingContext context,

--- a/Src/CSharpier/Utilities/ListExtensions.cs
+++ b/Src/CSharpier/Utilities/ListExtensions.cs
@@ -33,4 +33,23 @@ internal static class ListExtensions
 
         return false;
     }
+
+    public static SyntaxTrivia FirstOrDefault(
+        this in SyntaxTriviaList source,
+        Func<SyntaxTrivia, bool> predicate
+    )
+    {
+        var first = new SyntaxTrivia();
+        // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var trivia in source)
+        {
+            if (predicate(trivia))
+            {
+                first = trivia;
+                break;
+            }
+        }
+
+        return first;
+    }
 }


### PR DESCRIPTION
Overload for `FirstOrDefault(this SyntaxTriviaList source`, stops `SyntaxTriviaList` being boxed saving 0.9MB


### Before
![image](https://github.com/user-attachments/assets/3cf4f0c6-de1a-465d-844a-6f371d405bf7)

### After
![image](https://github.com/user-attachments/assets/d030e41d-22ab-4cab-a213-d3f00604057d)
