### PR TITLE
feat: use interpolated string in `RightHandSide`

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/RightHandSide.cs
+++ b/Src/CSharpier/SyntaxPrinter/RightHandSide.cs
@@ -12,7 +12,7 @@ internal static class RightHandSide
     {
         var layout = DetermineLayout(leftNode, rightNode);
 
-        var groupId = layout == Layout.Fluid ? layout.ToString() + Guid.NewGuid() : String.Empty;
+        var groupId = layout == Layout.Fluid ? $"{Layout.Fluid}{Guid.NewGuid()}" : string.Empty;
 
         return layout switch
         {


### PR DESCRIPTION
Prevent unnecessary `Guid.ToString()` allocation using interpolated string. Saves 0.3MB

### Benchmarks (timing is inaccurate my laptops not plugged in)
### Before
| Default_CodeFormatter | 234.9 ms | 11.21 ms | 33.05 ms | 7000.0000 | 3000.0000 | 1000.0000 |  66.17 MB |

### After
| Default_CodeFormatter | 230.9 ms | 9.77 ms | 28.66 ms | 220.6 ms | 7000.0000 | 3000.0000 | 1000.0000 |  65.86 MB |

