### PR TITLE
feat: convert `PrintCommand` to value type

### DIFF
--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -405,7 +405,7 @@ internal class DocPrinter
     }
 }
 
-internal record PrintCommand(Indent Indent, PrintMode Mode, Doc Doc);
+internal record struct PrintCommand(Indent Indent, PrintMode Mode, Doc Doc);
 
 internal enum PrintMode
 {


### PR DESCRIPTION
Converts `PrintCommand` to a struct, this is a massive memory and performance improvement 😄 
Converting types to a struct sometimes causes regressions from copying so I had held of on this one.

#### Before
| Method                | Mean     | Error   | StdDev   | Gen0      | Gen1      | Gen2      | Allocated |
|---------------------- |---------:|--------:|---------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter | 206.3 ms | 4.11 ms | 10.00 ms | 7000.0000 | 3000.0000 | 1000.0000 |  66.17 MB |

#### After
| Method                | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|---------------------- |---------:|--------:|--------:|----------:|----------:|----------:|
| Default_CodeFormatter | 176.3 ms | 3.46 ms | 5.17 ms | 4000.0000 | 2000.0000 |  46.53 MB |


### Using `readonly struct`
I did experiment with making this a `readonly struct` and passing via `in` see #1506. I'm not convinced this makes an impact although the difference is likely too small to accurately benchmark.

I opted to benchmark each with the below code. The results appear to show that a basic struct is faster although this could just be random noise. Looking at the IL code or profiling with dotTrace might give us the right answer, for now, I'm happy to settle with the current solution.
```C#
for (int i = 0; i < 10; i++)
{
    CSharpFormatter
        .FormatAsync(this.largeCode, new PrinterOptions())
        .GetAwaiter()
        .GetResult();
}
``` 


#### 10X Struct
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.962 s | 0.0307 s | 0.0257 s | 53000.0000 | 29000.0000 | 7000.0000 | 464.31 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.980 s | 0.0211 s | 0.0176 s | 53000.0000 | 28000.0000 | 7000.0000 | 464.14 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.965 s | 0.0160 s | 0.0142 s | 53000.0000 | 28000.0000 | 7000.0000 | 464.14 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.957 s | 0.0164 s | 0.0128 s | 53000.0000 | 28000.0000 | 7000.0000 | 464.14 MB |

#### 10X Readonly Struct
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.979 s | 0.0249 s | 0.0220 s | 53000.0000 | 28000.0000 | 7000.0000 | 464.14 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.971 s | 0.0137 s | 0.0114 s | 53000.0000 | 29000.0000 | 7000.0000 |  464.3 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.980 s | 0.0276 s | 0.0245 s | 53000.0000 | 29000.0000 | 7000.0000 | 464.31 MB |

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.953 s | 0.0139 s | 0.0108 s | 53000.0000 | 28000.0000 | 7000.0000 | 464.14 MB |
