### PR TITLE
feat: convert `Node.Print` to use `switch (node.Kind())`

### DIFF
--- a/Src/CSharpier.Generators/NodePrinterGenerator.cs
+++ b/Src/CSharpier.Generators/NodePrinterGenerator.cs
@@ -1,7 +1,7 @@
-﻿using System.IO;
-using System.Linq;
-using Generators;
+﻿using Generators;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpier.Generators;
 
@@ -9,6 +9,197 @@ namespace CSharpier.Generators;
 public class NodePrinterGenerator : TemplatedGenerator
 {
     protected override string SourceName => "Node";
+
+    private static Dictionary<string, string[]> SpecialCase = new()
+    {
+        {
+            nameof(AssignmentExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.SimpleAssignmentExpression),
+                nameof(SyntaxKind.AddAssignmentExpression),
+                nameof(SyntaxKind.SubtractAssignmentExpression),
+                nameof(SyntaxKind.MultiplyAssignmentExpression),
+                nameof(SyntaxKind.DivideAssignmentExpression),
+                nameof(SyntaxKind.ModuloAssignmentExpression),
+                nameof(SyntaxKind.AndAssignmentExpression),
+                nameof(SyntaxKind.ExclusiveOrAssignmentExpression),
+                nameof(SyntaxKind.OrAssignmentExpression),
+                nameof(SyntaxKind.LeftShiftAssignmentExpression),
+                nameof(SyntaxKind.RightShiftAssignmentExpression),
+                nameof(SyntaxKind.UnsignedRightShiftAssignmentExpression),
+                nameof(SyntaxKind.CoalesceAssignmentExpression),
+            }
+        },
+        {
+            nameof(BaseExpressionColonSyntax),
+            new[] { nameof(SyntaxKind.ExpressionColon), nameof(SyntaxKind.NameColon) }
+        },
+        {
+            nameof(BaseFieldDeclarationSyntax),
+            new[] { nameof(SyntaxKind.FieldDeclaration), nameof(SyntaxKind.EventFieldDeclaration) }
+        },
+        {
+            nameof(BaseMethodDeclarationSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.MethodDeclaration),
+                nameof(SyntaxKind.OperatorDeclaration),
+                nameof(SyntaxKind.ConversionOperatorDeclaration),
+                nameof(SyntaxKind.ConstructorDeclaration),
+                nameof(SyntaxKind.DestructorDeclaration),
+            }
+        },
+        {
+            nameof(BasePropertyDeclarationSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.PropertyDeclaration),
+                nameof(SyntaxKind.EventDeclaration),
+                nameof(SyntaxKind.IndexerDeclaration),
+            }
+        },
+        {
+            nameof(BaseTypeDeclarationSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.ClassDeclaration),
+                nameof(SyntaxKind.StructDeclaration),
+                nameof(SyntaxKind.InterfaceDeclaration),
+                nameof(SyntaxKind.RecordDeclaration),
+                nameof(SyntaxKind.RecordStructDeclaration),
+                nameof(SyntaxKind.EnumDeclaration),
+            }
+        },
+        {
+            nameof(BinaryExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.AddExpression),
+                nameof(SyntaxKind.SubtractExpression),
+                nameof(SyntaxKind.MultiplyExpression),
+                nameof(SyntaxKind.DivideExpression),
+                nameof(SyntaxKind.ModuloExpression),
+                nameof(SyntaxKind.LeftShiftExpression),
+                nameof(SyntaxKind.RightShiftExpression),
+                nameof(SyntaxKind.UnsignedRightShiftExpression),
+                nameof(SyntaxKind.LogicalOrExpression),
+                nameof(SyntaxKind.LogicalAndExpression),
+                nameof(SyntaxKind.BitwiseOrExpression),
+                nameof(SyntaxKind.BitwiseAndExpression),
+                nameof(SyntaxKind.ExclusiveOrExpression),
+                nameof(SyntaxKind.EqualsExpression),
+                nameof(SyntaxKind.NotEqualsExpression),
+                nameof(SyntaxKind.LessThanExpression),
+                nameof(SyntaxKind.LessThanOrEqualExpression),
+                nameof(SyntaxKind.GreaterThanExpression),
+                nameof(SyntaxKind.GreaterThanOrEqualExpression),
+                nameof(SyntaxKind.IsExpression),
+                nameof(SyntaxKind.AsExpression),
+                nameof(SyntaxKind.CoalesceExpression),
+            }
+        },
+        {
+            nameof(BinaryPatternSyntax),
+            new[] { nameof(SyntaxKind.OrPattern), nameof(SyntaxKind.AndPattern) }
+        },
+        {
+            nameof(CheckedExpressionSyntax),
+            new[] { nameof(SyntaxKind.CheckedExpression), nameof(SyntaxKind.UncheckedExpression) }
+        },
+        {
+            nameof(CheckedStatementSyntax),
+            new[] { nameof(SyntaxKind.CheckedStatement), nameof(SyntaxKind.UncheckedStatement) }
+        },
+        {
+            nameof(ClassOrStructConstraintSyntax),
+            new[] { nameof(SyntaxKind.ClassConstraint), nameof(SyntaxKind.StructConstraint) }
+        },
+        {
+            nameof(CommonForEachStatementSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.ForEachStatement),
+                nameof(SyntaxKind.ForEachVariableStatement),
+            }
+        },
+        {
+            nameof(GotoStatementSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.GotoStatement),
+                nameof(SyntaxKind.GotoCaseStatement),
+                nameof(SyntaxKind.GotoDefaultStatement),
+            }
+        },
+        {
+            nameof(InitializerExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.ObjectInitializerExpression),
+                nameof(SyntaxKind.CollectionInitializerExpression),
+                nameof(SyntaxKind.ArrayInitializerExpression),
+                nameof(SyntaxKind.ComplexElementInitializerExpression),
+                nameof(SyntaxKind.WithInitializerExpression),
+            }
+        },
+        {
+            nameof(LiteralExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.ArgListExpression),
+                nameof(SyntaxKind.NumericLiteralExpression),
+                nameof(SyntaxKind.StringLiteralExpression),
+                nameof(SyntaxKind.Utf8StringLiteralExpression),
+                nameof(SyntaxKind.CharacterLiteralExpression),
+                nameof(SyntaxKind.TrueLiteralExpression),
+                nameof(SyntaxKind.FalseLiteralExpression),
+                nameof(SyntaxKind.NullLiteralExpression),
+                nameof(SyntaxKind.DefaultLiteralExpression),
+            }
+        },
+        {
+            nameof(MemberAccessExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.SimpleMemberAccessExpression),
+                nameof(SyntaxKind.PointerMemberAccessExpression),
+            }
+        },
+        {
+            nameof(PostfixUnaryExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.PostIncrementExpression),
+                nameof(SyntaxKind.PostDecrementExpression),
+                nameof(SyntaxKind.SuppressNullableWarningExpression),
+            }
+        },
+        {
+            nameof(PrefixUnaryExpressionSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.UnaryPlusExpression),
+                nameof(SyntaxKind.UnaryMinusExpression),
+                nameof(SyntaxKind.BitwiseNotExpression),
+                nameof(SyntaxKind.LogicalNotExpression),
+                nameof(SyntaxKind.PreIncrementExpression),
+                nameof(SyntaxKind.PreDecrementExpression),
+                nameof(SyntaxKind.AddressOfExpression),
+                nameof(SyntaxKind.PointerIndirectionExpression),
+                nameof(SyntaxKind.IndexExpression),
+            }
+        },
+        { nameof(UnaryPatternSyntax), new[] { nameof(SyntaxKind.NotPattern) } },
+        {
+            nameof(YieldStatementSyntax),
+            new[]
+            {
+                nameof(SyntaxKind.YieldReturnStatement),
+                nameof(SyntaxKind.YieldBreakStatement),
+            }
+        },
+    };
 
     protected override object GetModel(GeneratorExecutionContext context)
     {
@@ -18,12 +209,16 @@ public class NodePrinterGenerator : TemplatedGenerator
             .Select(fileName => new
             {
                 PrinterName = fileName,
-                SyntaxNodeName = fileName + "Syntax",
-                VariableName = char.ToLower(fileName[0]) + fileName[1..],
+                SyntaxNodeName = $"{fileName}Syntax",
+                SyntaxKinds = SpecialCase.TryGetValue($"{fileName}Syntax", out var kinds)
+                    ? string.Join(" or ", kinds.Select(x => $"SyntaxKind.{x}"))
+                    : $"SyntaxKind.{fileName}",
             })
             .OrderBy(o => o.SyntaxNodeName)
             .ToArray();
 
-        return new { NodeTypes = nodeTypes };
+        var syntaxNodeTypes = string.Join(" or ", nodeTypes.Select(x => x.SyntaxNodeName));
+
+        return new { NodeTypes = nodeTypes, SyntaxNodeTypes = syntaxNodeTypes };
     }
 }

--- a/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
+++ b/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using CSharpier.DocTypes;
 using CSharpier.SyntaxPrinter;
 using CSharpier.SyntaxPrinter.SyntaxNodePrinters;
@@ -29,13 +30,14 @@ namespace CSharpier.SyntaxPrinter
             context.State.PrintingDepth++;
             try
             {
-                switch (syntaxNode)
+                switch ((SyntaxKind)syntaxNode.RawKind)
                 {
                     {{- for nodeType in NodeTypes }}
-                    case {{ nodeType.SyntaxNodeName }} {{ nodeType.VariableName }}:
-                        return {{ nodeType.PrinterName }}.Print({{ nodeType.VariableName }}, context);
+                    case {{ nodeType.SyntaxKinds }}:
+                        return {{ nodeType.PrinterName }}.Print(({{ nodeType.SyntaxNodeName }})syntaxNode, context);
                     {{- end }}
                     default:
+                        Debug.Assert(syntaxNode is not ({{- SyntaxNodeTypes -}}));
                         return UnhandledNode.Print(syntaxNode, context);
                 }
             }

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/LabeledStatements.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/LabeledStatements.test
@@ -3,6 +3,7 @@ class ClassName
     void MethodName()
     {
         label:
+
         goto label;
     }
 }

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SwitchStatements.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SwitchStatements.test
@@ -38,10 +38,14 @@ public class ClassName
         {
             case 1:
             {
+                CallMethod();
+
                 goto case 2;
             }
             case 2:
             {
+                CallMethod();
+
                 goto default;
             }
             default:


### PR DESCRIPTION
- Use `switch (syntaxNode.Kind())` instead of `is`. Should be slightly faster 🤞 
- Add `Debug.Assert` in the default branch to ensure that future changes to roslyn / mistakes with `SyntaxKind` are caught


### Benchmarks
Ran `FormatAsync` in a for loop 10 times to try and average performance. Seems to show a small 1.5% increase in performance at the cost of more complexity and the potential for errors. Do you think its worth merging this pr @belav ? TBH I'm a little dissapointed 😅 

I did wonder if using chained `or` might affect the generated code 🤷 the massive `SyntaxKind` switch statements in roslyn use several `case` tags instead. Perhaps this is lowered into better code? Looking at the IL I think it creates a jump table, although I'm not sure - I'm not fluent in IL 😄 .


#### Before
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 2.115 s | 0.0132 s | 0.0103 s | 77000.0000 | 35000.0000 | 9000.0000 | 661.69 MB |

#### After
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 2.085 s | 0.0168 s | 0.0149 s | 77000.0000 | 35000.0000 | 9000.0000 |  661.7 MB |