### PR TITLE
test: add test for unchecked statements/expressions

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UncheckedStatements.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/UncheckedStatements.test
@@ -1,0 +1,21 @@
+class ClassName
+{
+    void MethodName()
+    {
+        unchecked
+        {
+            unchecked(++i);
+
+            unchecked(printsLikeInvocations + whenItsFlat);
+
+            unchecked(
+                printsLikeInvocations + whenItBreaks______________________________________________
+            );
+
+            unchecked(
+                printsLikeInvocations
+                + whenItLongBreaks_______________________________________________
+            );
+        }
+    }
+}


### PR DESCRIPTION
Noticed that tests weren't failing for #1509 when I forgot to account for `SyntaxKind.UncheckedStatement`. This will hopefully catch it