### PR TITLE
Fixing bug where if the last line of a raw string was a non-content l…

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/RawStringLiterals_DoesNotIndentFinalEmptyLine.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/RawStringLiterals_DoesNotIndentFinalEmptyLine.test
@@ -1,4 +1,4 @@
-Console.WriteLine(
+MakeSureBothNonContentLinesHereStayTrimmed(
     $"""
 
 

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/RawStringLiterals_DoesNotIndentFinalEmptyLine.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/RawStringLiterals_DoesNotIndentFinalEmptyLine.test
@@ -1,0 +1,6 @@
+Console.WriteLine(
+    $"""
+
+
+    """
+);

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
@@ -89,7 +89,13 @@ internal static class InterpolatedStringExpression
             }
         }
 
-        contents.Add(lastLineIsIndented ? Doc.HardLineNoTrim : Doc.LiteralLine);
+        contents.Add(
+            lastLineIsIndented
+                ? contents[^1] is StringDoc { Value: "" }
+                    ? Doc.HardLine
+                    : Doc.HardLineNoTrim
+                : Doc.LiteralLine
+        );
         contents.Add(Token.Print(node.StringEndToken, context));
 
         return Doc.IndentIf(!node.HasParent(typeof(ArgumentSyntax)), Doc.Concat(contents));

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InterpolatedStringExpression.cs
@@ -43,7 +43,7 @@ internal static class InterpolatedStringExpression
 
     private static Doc RawString(InterpolatedStringExpressionSyntax node, PrintingContext context)
     {
-        var lastLineIsIndented =
+        var endDelimiterIsIndented =
             node.StringEndToken.Text.Replace("\r", string.Empty).Replace("\n", string.Empty)[0]
                 is '\t'
                     or ' ';
@@ -51,7 +51,7 @@ internal static class InterpolatedStringExpression
         var contents = new List<Doc>
         {
             Token.Print(node.StringStartToken, context),
-            lastLineIsIndented ? Doc.HardLineNoTrim : Doc.LiteralLine,
+            endDelimiterIsIndented ? Doc.HardLineNoTrim : Doc.LiteralLine,
         };
         foreach (var content in node.Contents)
         {
@@ -79,7 +79,7 @@ internal static class InterpolatedStringExpression
                         continue;
                     }
                     contents.Add(
-                        lastLineIsIndented
+                        endDelimiterIsIndented
                             ? string.IsNullOrEmpty(line)
                                 ? Doc.HardLine
                                 : Doc.HardLineNoTrim
@@ -90,7 +90,7 @@ internal static class InterpolatedStringExpression
         }
 
         contents.Add(
-            lastLineIsIndented
+            endDelimiterIsIndented
                 ? contents[^1] is StringDoc { Value: "" }
                     ? Doc.HardLine
                     : Doc.HardLineNoTrim


### PR DESCRIPTION
…ine then it would end up indented to the same level as the end delimiter

closes #1455