### PR TITLE
feat: enable jumping to "not formatted" files from VisualStudio error list

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -60,7 +60,8 @@ internal static class CommandLineFormatter
                 {
                     var fileIssueLogger = new FileIssueLogger(
                         commandLineOptions.OriginalDirectoryOrFilePaths[0],
-                        logger
+                        logger,
+                        commandLineOptions.MsBuildFormat
                     );
 
                     var printerOptions = optionsProvider.GetPrinterOptionsFor(filePath);
@@ -231,7 +232,11 @@ internal static class CommandLineFormatter
                 }
                 else if (warnForUnsupported)
                 {
-                    var fileIssueLogger = new FileIssueLogger(originalFilePath, logger);
+                    var fileIssueLogger = new FileIssueLogger(
+                        originalFilePath,
+                        logger,
+                        isMsBuildFormat: false
+                    );
                     fileIssueLogger.WriteWarning("Is an unsupported file type.");
                 }
             }
@@ -307,7 +312,11 @@ internal static class CommandLineFormatter
             cancellationToken
         );
 
-        var fileIssueLogger = new FileIssueLogger(originalFilePath, logger);
+        var fileIssueLogger = new FileIssueLogger(
+            originalFilePath,
+            logger,
+            commandLineOptions.MsBuildFormat
+        );
 
         logger.LogDebug(
             commandLineOptions.Check

--- a/Src/CSharpier.Cli/CommandLineOptions.cs
+++ b/Src/CSharpier.Cli/CommandLineOptions.cs
@@ -7,6 +7,7 @@ internal class CommandLineOptions
 {
     public string[] DirectoryOrFilePaths { get; init; } = [];
     public bool Check { get; init; }
+    public bool MsBuildFormat { get; init; }
     public bool Fast { get; init; }
     public bool SkipWrite { get; init; }
     public bool WriteStdout { get; init; }
@@ -21,6 +22,7 @@ internal class CommandLineOptions
     internal delegate Task<int> Handler(
         string[] directoryOrFile,
         bool check,
+        bool msBuildFormat,
         bool fast,
         bool skipWrite,
         bool writeStdout,
@@ -51,6 +53,10 @@ internal class CommandLineOptions
                 ["--loglevel"],
                 () => LogLevel.Information.ToString(),
                 "Specify the log level - Debug, Information (default), Warning, Error, None"
+            ),
+            new Option(
+                ["--msbuild-format"],
+                "Formats messages in standard error/warning format for MSBuild."
             ),
             new Option(
                 ["--no-cache"],

--- a/Src/CSharpier.Cli/ConsoleLogger.cs
+++ b/Src/CSharpier.Cli/ConsoleLogger.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CSharpier.Cli;
 
-internal class ConsoleLogger(IConsole console, LogLevel loggingLevel) : ILogger
+internal class ConsoleLogger(IConsole console, LogLevel loggingLevel, bool isMsBuildFormat) : ILogger
 {
     private static readonly object ConsoleLock = new();
 
@@ -52,7 +52,7 @@ internal class ConsoleLogger(IConsole console, LogLevel loggingLevel) : ILogger
         {
             var message = formatter(state, exception!);
 
-            if (logLevel >= LogLevel.Warning)
+            if (!isMsBuildFormat && logLevel >= LogLevel.Warning)
             {
                 console.ForegroundColor = GetColorLevel(logLevel);
                 Write($"{logLevel} ");

--- a/Src/CSharpier.Cli/FileIssueLogger.cs
+++ b/Src/CSharpier.Cli/FileIssueLogger.cs
@@ -2,11 +2,29 @@ using Microsoft.Extensions.Logging;
 
 namespace CSharpier.Cli;
 
-internal class FileIssueLogger(string filePath, ILogger logger)
+internal class FileIssueLogger(string filePath, ILogger logger, bool isMsBuildFormat)
 {
+    static string FormatMsBuildError(LogState logState, Exception? exception) =>
+        $"{logState.Path}: error: {logState.Message}";
+
+    record class LogState
+    {
+        public required string Path;
+        public required string Message;
+    }
+
     public void WriteError(string value, Exception? exception = null)
     {
-        logger.LogError(exception, $"{this.GetPath()} - {value}");
+        if (isMsBuildFormat)
+        {
+            var logState = new LogState() { Path = this.GetPath(), Message = value };
+
+            logger.Log(LogLevel.Error, 0, logState, exception, FormatMsBuildError);
+        }
+        else
+        {
+            logger.LogError(exception, $"{this.GetPath()} - {value}");
+        }
     }
 
     public void WriteWarning(string value)

--- a/Src/CSharpier.Cli/Program.cs
+++ b/Src/CSharpier.Cli/Program.cs
@@ -23,6 +23,7 @@ internal class Program
     public static async Task<int> Run(
         string[]? directoryOrFile,
         bool check,
+        bool msBuildFormat,
         bool fast,
         bool skipWrite,
         bool writeStdout,
@@ -42,7 +43,7 @@ internal class Program
         var actualConfigPath = string.IsNullOrEmpty(configPath) ? null : configPath;
 
         var console = new SystemConsole();
-        var logger = new ConsoleLogger(console, logLevel);
+        var logger = new ConsoleLogger(console, logLevel, msBuildFormat);
 
         if (pipeMultipleFiles)
         {
@@ -89,6 +90,7 @@ internal class Program
             OriginalDirectoryOrFilePaths = originalDirectoryOrFile!,
             StandardInFileContents = standardInFileContents,
             Check = check,
+            MsBuildFormat = msBuildFormat,
             NoCache = noCache,
             NoMSBuildCheck = noMSBuildCheck,
             Fast = fast,

--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -43,9 +43,7 @@
       StdOutEncoding="utf-8"
       StdErrEncoding="utf-8"
       IgnoreExitCode="true"
-      IgnoreStandardErrorWarningFormat="true"
-      CustomErrorRegularExpression="^Error "
-      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) "
+      Command="&quot;$(CSharpier_dotnet_Path)&quot; exec &quot;$(CSharpierDllPath)&quot; $(CSharpierArgs) --msbuild-format --no-msbuild-check --compilation-errors-as-warnings &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput) "
     />
   </Target>
   <!-- getting this to run a single time for projects that target multiple frameworks requires all of this


### PR DESCRIPTION
- adds `--msbuild-format` parameter to format error message according to [standard error/warning format of MSBuild](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022)

Enables to double click on "was not formatted" message in error list of Visual Studio to jump to the file affected.