### PR TITLE
perf: use `Stopwatch.GetTimestamp` and `Task.WhenAll`

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -20,7 +20,7 @@ internal static class CommandLineFormatter
     {
         try
         {
-            var stopwatch = Stopwatch.StartNew();
+            var timestamp = Stopwatch.GetTimestamp();
             var commandLineFormatterResult = new CommandLineFormatterResult();
 
             if (commandLineOptions.StandardInFileContents != null)
@@ -98,7 +98,8 @@ internal static class CommandLineFormatter
                 }
             }
 
-            commandLineFormatterResult.ElapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+            commandLineFormatterResult.ElapsedMilliseconds = (long)
+                Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds;
             if (!commandLineOptions.WriteStdout)
             {
                 logger.LogInformation(
@@ -271,7 +272,7 @@ internal static class CommandLineFormatter
                     .ToArray();
                 try
                 {
-                    Task.WaitAll(tasks, cancellationToken);
+                    await Task.WhenAll(tasks).WaitAsync(cancellationToken);
                 }
                 catch (OperationCanceledException ex)
                 {


### PR DESCRIPTION
- Use `Stopwatch.GetTimestamp` instead of `Stopwatch`
- Replace `Task.WaitAll` with the `async` `Task.WhenAll` - this should be a straight upgrade right? It has been a while since I read up on the difference
  - Could Csharpier potentially use `Paralllel.ForeachAsync` here?  