### PR TITLE
perf: inline hot path and remove `IsInstanceOf` usage

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/CSharpierIgnore.cs
+++ b/Src/CSharpier/SyntaxPrinter/CSharpierIgnore.cs
@@ -26,11 +26,16 @@ internal static class CSharpierIgnore
             return false;
         }
 
-        return syntaxNode.Parent
-                is BaseTypeDeclarationSyntax
-                    or BlockSyntax
-                    or CompilationUnitSyntax
-                    or NamespaceDeclarationSyntax
+        return syntaxNode.Parent?.Kind()
+                is SyntaxKind.ClassDeclaration
+                    or SyntaxKind.StructDeclaration
+                    or SyntaxKind.InterfaceDeclaration
+                    or SyntaxKind.RecordDeclaration
+                    or SyntaxKind.RecordStructDeclaration
+                    or SyntaxKind.EnumDeclaration
+                    or SyntaxKind.Block
+                    or SyntaxKind.CompilationUnit
+                    or SyntaxKind.NamespaceDeclaration
             && HasIgnoreComment(syntaxNode);
     }
 

--- a/Src/CSharpier/Utilities/CharacterSizeCalculator.cs
+++ b/Src/CSharpier/Utilities/CharacterSizeCalculator.cs
@@ -3,10 +3,13 @@
  * From https://github.com/PowerShell/PowerShell/tree/master
  */
 
+using System.Runtime.CompilerServices;
+
 namespace CSharpier.Utilities;
 
 internal static class CharacterSizeCalculator
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // csharpier-ignore
     public static int CalculateWidth(char c)
     {
@@ -23,7 +26,6 @@ internal static class CharacterSizeCalculator
              ((uint)(c - 0xfe30) <= (0xfe6f - 0xfe30)) || /* CJK Compatibility Forms */
              ((uint)(c - 0xff00) <= (0xff60 - 0xff00)) || /* Fullwidth Forms */
              ((uint)(c - 0xffe0) <= (0xffe6 - 0xffe0)));
-
         // We can ignore these ranges because .Net strings use surrogate pairs
         // for this range and we do not handle surrogate pairs.
         // (c >= 0x20000 && c <= 0x2fffd) ||


### PR DESCRIPTION
- Add `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to `CalculateWidth`, I assumed the JIT would do this but perhaps not
- Use `SyntaxKind` in `IsNodeIgnored`

### Benchmarks
Benchmarks appear to show a suprising speedup, although I don't know if this is accurate.
#### Before

| Method                | Mean    | Error    | StdDev   | Median  | Gen0       | Gen1       | Gen2       | Allocated |
|---------------------- |--------:|---------:|---------:|--------:|-----------:|-----------:|-----------:|----------:|
| Default_CodeFormatter | 1.637 s | 0.0329 s | 0.0969 s | 1.598 s | 52000.0000 | 31000.0000 | 10000.0000 | 420.54 MB |
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| Default_CodeFormatter | 1.571 s | 0.0308 s | 0.0822 s | 50000.0000 | 29000.0000 | 9000.0000 | 419.39 MB |
`


#### After

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2       | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|-----------:|----------:|
| Default_CodeFormatter | 1.399 s | 0.0183 s | 0.0171 s | 52000.0000 | 31000.0000 | 10000.0000 | 420.36 MB |
| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2       | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|-----------:|----------:|
| Default_CodeFormatter | 1.406 s | 0.0066 s | 0.0059 s | 52000.0000 | 31000.0000 | 10000.0000 | 420.52 MB |
| Method                | Mean    | Error    | StdDev   | Median  | Gen0       | Gen1       | Gen2       | Allocated |
|---------------------- |--------:|---------:|---------:|--------:|-----------:|-----------:|-----------:|----------:|
| Default_CodeFormatter | 1.457 s | 0.0285 s | 0.0740 s | 1.425 s | 52000.0000 | 31000.0000 | 10000.0000 | 420.38 MB |