### PR TITLE
perf: remove unnecessary `ToList` call and convert linq to code

### DIFF
--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -56,28 +56,23 @@ internal abstract class Doc
 
     public static Doc Concat(params Doc[] contents) => new Concat(contents);
 
-    public static Doc Join(Doc separator, IEnumerable<Doc> array)
+    public static Doc Join(Doc separator, IEnumerable<Doc> enumerable)
     {
         var docs = new List<Doc>();
 
-        var list = array.ToList();
-
-        if (list.Count == 1)
-        {
-            return list[0];
-        }
-
-        for (var x = 0; x < list.Count; x++)
+        var x = 0;
+        foreach (var doc in enumerable)
         {
             if (x != 0)
             {
                 docs.Add(separator);
             }
 
-            docs.Add(list[x]);
+            docs.Add(doc);
+            x++;
         }
 
-        return Concat(docs);
+        return docs.Count == 1 ? docs[0] : Concat(docs);
     }
 
     public static ForceFlat ForceFlat(List<Doc> contents) =>

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace CSharpier.SyntaxPrinter.SyntaxNodePrinters;
 
 internal record PrintedNode(CSharpSyntaxNode Node, Doc Doc);
@@ -27,7 +29,7 @@ internal static class InvocationExpression
             ? GroupPrintedNodesPrettierStyle(printedNodes)
             : GroupPrintedNodesOnLines(printedNodes);
 
-        var oneLine = groups.SelectMany(o => o).Select(o => o.Doc).ToArray();
+        var oneLine = SelectManyDocsToArray(groups);
 
         var shouldMergeFirstTwoGroups = ShouldMergeFirstTwoGroups(groups, parent);
 
@@ -334,6 +336,30 @@ internal static class InvocationExpression
         }
 
         return groups;
+    }
+
+    [SuppressMessage("ReSharper", "ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator")]
+    private static Doc[] SelectManyDocsToArray(List<List<PrintedNode>> groups)
+    {
+        var arrayLength = 0;
+        foreach (var group in groups)
+        {
+            arrayLength += group.Count;
+        }
+
+        var outputArray = new Doc[arrayLength];
+
+        var pos = 0;
+        foreach (var group in groups)
+        {
+            foreach (var node in group)
+            {
+                outputArray[pos] = node.Doc;
+                pos++;
+            }
+        }
+
+        return outputArray;
     }
 
     private static Doc PrintIndentedGroup(List<List<PrintedNode>> groups)


### PR DESCRIPTION
- Remove unnecessary `ToList` call - 0.15 MB
- Extract a linq call and convert it to code - 0.8 MB


### Benchmarks (timing is inaccurate)
#### Before
| Method                | Mean     | Error   | StdDev   | Gen0      | Gen1      | Allocated |
|---------------------- |---------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter | 191.4 ms | 4.05 ms | 11.81 ms | 4000.0000 | 2000.0000 |  42.24 MB |

#### After
| Method                | Mean     | Error    | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|---------------------- |---------:|---------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter | 157.3 ms | 11.59 ms | 34.18 ms | 138.8 ms | 4000.0000 | 2000.0000 |  41.29 MB |


