### PR TITLE
perf: add new `Concat` types for children lengths

### DIFF
--- a/Src/CSharpier.Tests/CSharpier.Tests.csproj
+++ b/Src/CSharpier.Tests/CSharpier.Tests.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>True</SignAssembly>
     <!-- DiffEngine references older packages and vulnerabilities on tests isn't a big deal -->
     <NuGetAuditMode>direct</NuGetAuditMode>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DiffEngine" />

--- a/Src/CSharpier/CSharpier.csproj
+++ b/Src/CSharpier/CSharpier.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>../../Nuget/csharpier.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010049d266ea1aeae09c0abfce28b8728314d4e4807126ee8bc56155a7ddc765997ed3522908b469ae133fc49ef0bfa957df36082c1c2e0ec8cdc05a4ca4dbd4e1bea6c17fc1008555e15af13a8fc871a04ffc38f5e60e6203bfaf01d16a2a283b90572ade79135801c1675bf38b7a5a60ec8353069796eb53a26ffdddc9ee1273be</PublicKey>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />

--- a/Src/CSharpier/DocPrinter/DocFitter.cs
+++ b/Src/CSharpier/DocPrinter/DocFitter.cs
@@ -63,8 +63,8 @@ internal static class DocFitter
                 case Region:
                     return false;
                 case Concat concat:
-                    for (var i = concat.Contents.Count - 1; i >= 0; i--)
-                        Push(concat.Contents[i], currentMode, currentIndent);
+                    for (var i = concat.Count - 1; i >= 0; i--)
+                        Push(concat[i], currentMode, currentIndent);
                     break;
                 case IndentDoc indent:
                     Push(indent.Contents, currentMode, indenter.IncreaseIndent(currentIndent));

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -85,9 +85,9 @@ internal class DocPrinter
         }
         else if (doc is Concat concat)
         {
-            for (var x = concat.Contents.Count - 1; x >= 0; x--)
+            for (var x = concat.Count - 1; x >= 0; x--)
             {
-                this.Push(concat.Contents[x], mode, indent);
+                this.Push(concat[x], mode, indent);
             }
         }
         else if (doc is IndentDoc indentDoc)

--- a/Src/CSharpier/DocPrinter/PropagateBreaks.cs
+++ b/Src/CSharpier/DocPrinter/PropagateBreaks.cs
@@ -104,15 +104,14 @@ internal static class PropagateBreaks
             if (doc is Concat concat)
             {
                 // push onto stack in reverse order so they are processed in the original order
-                for (var x = concat.Contents.Count - 1; x >= 0; --x)
+                for (var x = concat.Count - 1; x >= 0; --x)
                 {
-                    if (forceFlat > 0 && concat.Contents[x] is LineDoc { IsLiteral: false } lineDoc)
+                    if (forceFlat > 0 && concat[x] is LineDoc { IsLiteral: false } lineDoc)
                     {
-                        concat.Contents[x] =
-                            lineDoc.Type == LineDoc.LineType.Soft ? string.Empty : " ";
+                        concat[x] = lineDoc.Type == LineDoc.LineType.Soft ? string.Empty : " ";
                     }
 
-                    docsStack.Push(concat.Contents[x]);
+                    docsStack.Push(concat[x]);
                 }
             }
             else if (doc is IfBreak ifBreak)

--- a/Src/CSharpier/DocSerializer.cs
+++ b/Src/CSharpier/DocSerializer.cs
@@ -127,17 +127,17 @@ internal static class DocSerializer
             {
                 AppendIndent();
                 result.Append("Doc.Concat(");
-                if (concat.Contents.Count > 0)
+                if (concat.Count > 0)
                 {
                     result.AppendLine();
                 }
             }
 
-            for (var x = 0; x < concat.Contents.Count; x++)
+            for (var x = 0; x < concat.Count; x++)
             {
-                Serialize(concat.Contents[x], result, skipConcat ? indent : indent + 1);
+                Serialize(concat[x], result, skipConcat ? indent : indent + 1);
 
-                if (x < concat.Contents.Count - 1)
+                if (x < concat.Count - 1)
                 {
                     result.AppendLine(",");
                 }

--- a/Src/CSharpier/DocTypes/Concat.WithFourChildren.cs
+++ b/Src/CSharpier/DocTypes/Concat.WithFourChildren.cs
@@ -1,0 +1,74 @@
+namespace CSharpier.DocTypes;
+
+internal abstract partial class Concat
+{
+    internal sealed class WithFourChildren(Doc child0, Doc child1, Doc child2, Doc child3) : Concat
+    {
+        private Doc _child0 = child0;
+        private Doc _child1 = child1;
+        private Doc _child2 = child2;
+        private Doc _child3 = child3;
+
+        public override int Count => 4;
+
+        public override Doc this[int index]
+        {
+            get =>
+                index switch
+                {
+                    0 => _child0,
+                    1 => _child1,
+                    2 => _child2,
+                    3 => _child3,
+                    _ => throw new IndexOutOfRangeException(nameof(index)),
+                };
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        _child0 = value;
+                        break;
+                    case 1:
+                        _child1 = value;
+                        break;
+                    case 2:
+                        _child2 = value;
+                        break;
+                    case 3:
+                        _child3 = value;
+                        break;
+                    default:
+                        throw new IndexOutOfRangeException(nameof(index));
+                }
+            }
+        }
+
+        public override void RemoveAt(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    _child0 = _child1;
+                    _child1 = _child2;
+                    _child2 = _child3;
+                    _child3 = Doc.Null;
+                    break;
+                case 1:
+                    _child1 = _child2;
+                    _child2 = _child3;
+                    _child3 = Doc.Null;
+                    break;
+                case 2:
+                    _child2 = _child3;
+                    _child3 = Doc.Null;
+                    break;
+                case 3:
+                    _child3 = Doc.Null;
+                    break;
+                default:
+                    throw new IndexOutOfRangeException(nameof(index));
+            }
+        }
+    }
+}

--- a/Src/CSharpier/DocTypes/Concat.WithManyChildren.cs
+++ b/Src/CSharpier/DocTypes/Concat.WithManyChildren.cs
@@ -1,0 +1,17 @@
+namespace CSharpier.DocTypes;
+
+internal abstract partial class Concat
+{
+    internal sealed class WithManyChildren(IList<Doc> content) : Concat
+    {
+        public override int Count => content.Count;
+
+        public override Doc this[int index]
+        {
+            get => content[index];
+            set => content[index] = value;
+        }
+
+        public override void RemoveAt(int index) => content.RemoveAt(index);
+    }
+}

--- a/Src/CSharpier/DocTypes/Concat.WithThreeChildren.cs
+++ b/Src/CSharpier/DocTypes/Concat.WithThreeChildren.cs
@@ -1,0 +1,63 @@
+namespace CSharpier.DocTypes;
+
+internal abstract partial class Concat
+{
+    internal sealed class WithThreeChildren(Doc child0, Doc child1, Doc child2) : Concat
+    {
+        private Doc _child0 = child0;
+        private Doc _child1 = child1;
+        private Doc _child2 = child2;
+
+        public override int Count => 3;
+
+        public override Doc this[int index]
+        {
+            get =>
+                index switch
+                {
+                    0 => _child0,
+                    1 => _child1,
+                    2 => _child2,
+                    _ => throw new IndexOutOfRangeException(nameof(index)),
+                };
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        _child0 = value;
+                        break;
+                    case 1:
+                        _child1 = value;
+                        break;
+                    case 2:
+                        _child2 = value;
+                        break;
+                    default:
+                        throw new IndexOutOfRangeException(nameof(index));
+                }
+            }
+        }
+
+        public override void RemoveAt(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    _child0 = _child1;
+                    _child1 = _child2;
+                    _child2 = Doc.Null;
+                    break;
+                case 1:
+                    _child1 = _child2;
+                    _child2 = Doc.Null;
+                    break;
+                case 2:
+                    _child2 = Doc.Null;
+                    break;
+                default:
+                    throw new IndexOutOfRangeException(nameof(index));
+            }
+        }
+    }
+}

--- a/Src/CSharpier/DocTypes/Concat.WithTwoChildren.cs
+++ b/Src/CSharpier/DocTypes/Concat.WithTwoChildren.cs
@@ -1,0 +1,52 @@
+namespace CSharpier.DocTypes;
+
+internal abstract partial class Concat
+{
+    internal sealed class WithTwoChildren(Doc child0, Doc child1) : Concat
+    {
+        private Doc _child0 = child0;
+        private Doc _child1 = child1;
+        public override int Count => 2;
+
+        public override Doc this[int index]
+        {
+            get =>
+                index switch
+                {
+                    0 => _child0,
+                    1 => _child1,
+                    _ => throw new IndexOutOfRangeException(nameof(index)),
+                };
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        _child0 = value;
+                        break;
+                    case 1:
+                        _child1 = value;
+                        break;
+                    default:
+                        throw new IndexOutOfRangeException(nameof(index));
+                }
+            }
+        }
+
+        public override void RemoveAt(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    _child0 = _child1;
+                    _child1 = Doc.Null;
+                    break;
+                case 1:
+                    _child1 = Doc.Null;
+                    break;
+                default:
+                    throw new IndexOutOfRangeException(nameof(index));
+            }
+        }
+    }
+}

--- a/Src/CSharpier/DocTypes/Concat.cs
+++ b/Src/CSharpier/DocTypes/Concat.cs
@@ -1,6 +1,38 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class Concat(IList<Doc> contents) : Doc
+internal abstract partial class Concat : Doc
 {
-    public IList<Doc> Contents { get; set; } = contents;
+    public abstract int Count { get; }
+
+    public abstract Doc this[int index] { get; set; }
+
+    public abstract void RemoveAt(int index);
+
+    public bool Any(Func<Doc, bool> predicate)
+    {
+        for (var i = 0; i < Count; i++)
+        {
+            if (predicate(this[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static Concat Create(IList<Doc> collection) => new WithManyChildren(collection);
+
+    public static Doc Create(ReadOnlySpan<Doc> collection)
+    {
+        return collection.Length switch
+        {
+            0 => Doc.Null,
+            1 => collection[0],
+            2 => new WithTwoChildren(collection[0], collection[1]),
+            3 => new WithThreeChildren(collection[0], collection[1], collection[2]),
+            4 => new WithFourChildren(collection[0], collection[1], collection[2], collection[3]),
+            _ => new WithManyChildren(collection.ToArray()),
+        };
+    }
 }

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -49,12 +49,14 @@ internal abstract class Doc
         new() { Type = commentType, Comment = comment };
 
     public static Doc Concat(List<Doc> contents) =>
-        contents.Count == 1 ? contents[0] : new Concat(contents);
+        contents.Count == 1 ? contents[0] : DocTypes.Concat.Create(contents);
 
     // prevents allocating an array if there is only a single parameter
     public static Doc Concat(Doc contents) => contents;
 
-    public static Doc Concat(params Doc[] contents) => new Concat(contents);
+    public static Doc Concat(Doc[] contents) => DocTypes.Concat.Create((IList<Doc>)contents);
+
+    public static Doc Concat(params ReadOnlySpan<Doc> contents) => DocTypes.Concat.Create(contents);
 
     public static Doc Join(Doc separator, IEnumerable<Doc> array)
     {

--- a/Src/CSharpier/DocTypes/DocUtilities.cs
+++ b/Src/CSharpier/DocTypes/DocUtilities.cs
@@ -14,7 +14,7 @@ internal static class DocUtilities
         return doc switch
         {
             IHasContents hasContents => ContainsBreak(hasContents.Contents),
-            Concat concat => concat.Contents.Any(ContainsBreak),
+            Concat concat => concat.Any(ContainsBreak),
             IfBreak ifBreak => ContainsBreak(ifBreak.FlatContents),
             _ => false,
         };
@@ -39,6 +39,33 @@ internal static class DocUtilities
     }
 
     private static void RemoveInitialDoubleHardLine(IList<Doc> docs, ref bool removeNextHardLine)
+    {
+        var x = 0;
+        while (x < docs.Count)
+        {
+            var doc = docs[x];
+
+            if (doc is HardLine)
+            {
+                if (removeNextHardLine)
+                {
+                    docs[x] = Doc.Null;
+                    return;
+                }
+
+                removeNextHardLine = true;
+            }
+            else
+            {
+                RemoveInitialDoubleHardLine(doc, ref removeNextHardLine);
+                return;
+            }
+
+            x++;
+        }
+    }
+
+    private static void RemoveInitialDoubleHardLineConcat(Concat docs, ref bool removeNextHardLine)
     {
         var x = 0;
         while (x < docs.Count)
@@ -112,7 +139,7 @@ internal static class DocUtilities
                         return;
                 }
             case Concat concat:
-                RemoveInitialDoubleHardLine(concat.Contents, ref removeNextHardLine);
+                RemoveInitialDoubleHardLineConcat(concat, ref removeNextHardLine);
                 return;
         }
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/CompilationUnit.cs
@@ -18,16 +18,16 @@ internal static class CompilationUnit
         {
             // really ugly code to prevent a comment at the end of a file from continually inserting new blank lines
             if (
-                finalTrivia is Concat { Contents.Count: > 1 } list
+                finalTrivia is Concat { Count: > 1 } list
                 && docs.Count > 0
-                && docs[^1] is Concat { Contents.Count: > 1 } previousList
-                && previousList.Contents[^1] is HardLine
-                && previousList.Contents[^2] is HardLine
+                && docs[^1] is Concat { Count: > 1 } previousList
+                && previousList[^1] is HardLine
+                && previousList[^2] is HardLine
             )
             {
-                while (list.Contents[0] is HardLine { SkipBreakIfFirstInGroup: true })
+                while (list[0] is HardLine { SkipBreakIfFirstInGroup: true })
                 {
-                    list.Contents.RemoveAt(0);
+                    list.RemoveAt(0);
                 }
 
                 docs.Add(finalTrivia);


### PR DESCRIPTION
Taking inspiration from Roslyn I added several implementation of `Concat` one for each number of children and `WithManyChildren`.
This lets us use `Concat(params ReadOnlySpan<Doc> values`, this way we can use `WithTwoChildren` or `WithThreeChildren` when there is a small numbers of values, only allocating to an array when there is a large number of `Doc` types.

This currently saves 1MB however I expect this number to go up when combined with #1502