### PR TITLE
Add DocKind and remove IsInstanceOf in DocFitter

### DIFF
--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -74,119 +74,114 @@ internal class DocPrinter
     private void ProcessNextCommand()
     {
         var (indent, mode, doc) = this.RemainingCommands.Pop();
-        switch (doc.Kind)
+        if (doc.Kind is DocKind.Null or DocKind.BreakParent)
         {
-            case DocKind.Null:
-                return;
-            case DocKind.String:
-                this.ProcessString((StringDoc)doc, indent);
-                return;
-            case DocKind.Concat:
-                var concat = (Concat)doc;
-                for (var x = concat.Contents.Count - 1; x >= 0; x--)
+            return;
+        }
+        else if (doc.Kind is DocKind.Trim)
+        {
+            this.CurrentWidth -= this.Output.TrimTrailingWhitespace();
+            this.NewLineNextStringValue = false;
+        }
+        else if (doc.Kind is DocKind.String)
+        {
+            this.ProcessString((StringDoc)doc, indent);
+            return;
+        }
+        else if (doc is Concat concat)
+        {
+            for (var x = concat.Contents.Count - 1; x >= 0; x--)
+            {
+                this.Push(concat.Contents[x], mode, indent);
+            }
+        }
+        else if (doc is IndentDoc indentDoc)
+        {
+            this.Push(indentDoc.Contents, mode, this.Indenter.IncreaseIndent(indent));
+        }
+        else if (doc is Group group)
+        {
+            this.ProcessGroup(group, mode, indent);
+        }
+        else if (doc is IfBreak ifBreak)
+        {
+            var groupMode = mode;
+            if (ifBreak.GroupId != null)
+            {
+                if (!this.GroupModeMap.TryGetValue(ifBreak.GroupId, out groupMode))
                 {
-                    this.Push(concat.Contents[x], mode, indent);
+                    throw new Exception("You cannot use an ifBreak before the group it targets.");
                 }
+            }
 
-                break;
-            case DocKind.Indent:
-                var indentDoc = (IndentDoc)doc;
-                this.Push(indentDoc.Contents, mode, this.Indenter.IncreaseIndent(indent));
-                break;
-            case DocKind.Trim:
+            var contents =
+                groupMode == PrintMode.Break ? ifBreak.BreakContents : ifBreak.FlatContents;
+            this.Push(contents, mode, indent);
+        }
+        else if (doc is LineDoc lineDoc)
+        {
+            this.ProcessLine(lineDoc, mode, indent);
+        }
+        else if (doc is LeadingComment leadingComment)
+        {
+            this.Output.TrimTrailingWhitespace();
+            if ((this.Output.Length != 0 && this.Output[^1] != '\n') || this.NewLineNextStringValue)
+            {
+                this.Output.Append(this.EndOfLine);
+            }
 
-                this.CurrentWidth -= this.Output.TrimTrailingWhitespace();
-                this.NewLineNextStringValue = false;
-                break;
-            case DocKind.Group:
+            this.AppendComment(leadingComment, indent);
 
-                this.ProcessGroup((Group)doc, mode, indent);
-                break;
-            case DocKind.IfBreak:
-                var ifBreak = (IfBreak)doc;
-                var groupMode = mode;
-                if (ifBreak.GroupId != null)
+            this.CurrentWidth = indent.Length;
+            this.NewLineNextStringValue = false;
+            this.SkipNextNewLine = false;
+        }
+        else if (doc is TrailingComment trailingComment)
+        {
+            this.Output.TrimTrailingWhitespace();
+            this.Output.Append(' ').Append(trailingComment.Comment);
+            this.CurrentWidth = indent.Length;
+            if (mode != PrintMode.ForceFlat)
+            {
+                this.NewLineNextStringValue = true;
+                this.SkipNextNewLine = true;
+            }
+        }
+        else if (doc is ForceFlat forceFlat)
+        {
+            this.Push(forceFlat.Contents, PrintMode.ForceFlat, indent);
+        }
+        else if (doc is Region region)
+        {
+            if (region.IsEnd)
+            {
+                // in the case where regions are combined with ignored ranges, the start region
+                // ends up printing inside the unformatted nodes, so we don't have a matching
+                // start region to go with this end region
+                if (this.RegionIndents.TryPop(out var regionIndent))
                 {
-                    if (!this.GroupModeMap.TryGetValue(ifBreak.GroupId, out groupMode))
-                    {
-                        throw new Exception(
-                            "You cannot use an ifBreak before the group it targets."
-                        );
-                    }
-                }
-
-                var contents =
-                    groupMode == PrintMode.Break ? ifBreak.BreakContents : ifBreak.FlatContents;
-                this.Push(contents, mode, indent);
-                break;
-            case DocKind.Line:
-                this.ProcessLine((LineDoc)doc, mode, indent);
-                break;
-            case DocKind.BreakParent:
-                break;
-            case DocKind.LeadingComment:
-
-                this.Output.TrimTrailingWhitespace();
-                if (
-                    (this.Output.Length != 0 && this.Output[^1] != '\n')
-                    || this.NewLineNextStringValue
-                )
-                {
-                    this.Output.Append(this.EndOfLine);
-                }
-
-                this.AppendComment((LeadingComment)doc, indent);
-
-                this.CurrentWidth = indent.Length;
-                this.NewLineNextStringValue = false;
-                this.SkipNextNewLine = false;
-                break;
-            case DocKind.TrailingComment:
-                this.Output.TrimTrailingWhitespace();
-                var trailingComment = (TrailingComment)doc;
-                this.Output.Append(' ').Append(trailingComment.Comment);
-                this.CurrentWidth = indent.Length;
-                if (mode != PrintMode.ForceFlat)
-                {
-                    this.NewLineNextStringValue = true;
-                    this.SkipNextNewLine = true;
-                }
-
-                break;
-            case DocKind.ForceFlat:
-                var forceFlat = (ForceFlat)doc;
-                this.Push(forceFlat.Contents, PrintMode.ForceFlat, indent);
-                break;
-            case DocKind.Region:
-                var region = (Region)doc;
-                if (region.IsEnd)
-                {
-                    // in the case where regions are combined with ignored ranges, the start region
-                    // ends up printing inside the unformatted nodes, so we don't have a matching
-                    // start region to go with this end region
-                    if (this.RegionIndents.TryPop(out var regionIndent))
-                    {
-                        this.Output.Append(regionIndent.Value);
-                    }
-                    else
-                    {
-                        this.Output.Append(indent.Value);
-                    }
+                    this.Output.Append(regionIndent.Value);
                 }
                 else
                 {
                     this.Output.Append(indent.Value);
-                    this.RegionIndents.Push(indent);
                 }
+            }
+            else
+            {
+                this.Output.Append(indent.Value);
+                this.RegionIndents.Push(indent);
+            }
 
-                this.Output.Append(region.Text);
-                break;
-            case DocKind.AlwaysFits:
-                var alwaysFits = (AlwaysFits)doc;
-                this.Push(alwaysFits.Contents, mode, indent);
-                break;
-            default:
-                throw new Exception("didn't handle " + doc);
+            this.Output.Append(region.Text);
+        }
+        else if (doc is AlwaysFits alwaysFits)
+        {
+            this.Push(alwaysFits.Contents, mode, indent);
+        }
+        else
+        {
+            throw new Exception("didn't handle " + doc);
         }
     }
 

--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -74,115 +74,119 @@ internal class DocPrinter
     private void ProcessNextCommand()
     {
         var (indent, mode, doc) = this.RemainingCommands.Pop();
-        if (doc == Doc.Null)
+        switch (doc.Kind)
         {
-            return;
-        }
-
-        if (doc is StringDoc stringDoc)
-        {
-            this.ProcessString(stringDoc, indent);
-        }
-        else if (doc is Concat concat)
-        {
-            for (var x = concat.Contents.Count - 1; x >= 0; x--)
-            {
-                this.Push(concat.Contents[x], mode, indent);
-            }
-        }
-        else if (doc is IndentDoc indentDoc)
-        {
-            this.Push(indentDoc.Contents, mode, this.Indenter.IncreaseIndent(indent));
-        }
-        else if (doc is Trim)
-        {
-            this.CurrentWidth -= this.Output.TrimTrailingWhitespace();
-            this.NewLineNextStringValue = false;
-        }
-        else if (doc is Group group)
-        {
-            this.ProcessGroup(group, mode, indent);
-        }
-        else if (doc is IfBreak ifBreak)
-        {
-            var groupMode = mode;
-            if (ifBreak.GroupId != null)
-            {
-                if (!this.GroupModeMap.TryGetValue(ifBreak.GroupId, out groupMode))
+            case DocKind.Null:
+                return;
+            case DocKind.String:
+                this.ProcessString((StringDoc)doc, indent);
+                return;
+            case DocKind.Concat:
+                var concat = (Concat)doc;
+                for (var x = concat.Contents.Count - 1; x >= 0; x--)
                 {
-                    throw new Exception("You cannot use an ifBreak before the group it targets.");
+                    this.Push(concat.Contents[x], mode, indent);
                 }
-            }
 
-            var contents =
-                groupMode == PrintMode.Break ? ifBreak.BreakContents : ifBreak.FlatContents;
-            this.Push(contents, mode, indent);
-        }
-        else if (doc is LineDoc line)
-        {
-            this.ProcessLine(line, mode, indent);
-        }
-        else if (doc is BreakParent) { }
-        else if (doc is LeadingComment leadingComment)
-        {
-            this.Output.TrimTrailingWhitespace();
-            if ((this.Output.Length != 0 && this.Output[^1] != '\n') || this.NewLineNextStringValue)
-            {
-                this.Output.Append(this.EndOfLine);
-            }
+                break;
+            case DocKind.Indent:
+                var indentDoc = (IndentDoc)doc;
+                this.Push(indentDoc.Contents, mode, this.Indenter.IncreaseIndent(indent));
+                break;
+            case DocKind.Trim:
 
-            this.AppendComment(leadingComment, indent);
+                this.CurrentWidth -= this.Output.TrimTrailingWhitespace();
+                this.NewLineNextStringValue = false;
+                break;
+            case DocKind.Group:
 
-            this.CurrentWidth = indent.Length;
-            this.NewLineNextStringValue = false;
-            this.SkipNextNewLine = false;
-        }
-        else if (doc is TrailingComment trailingComment)
-        {
-            this.Output.TrimTrailingWhitespace();
-            this.Output.Append(' ').Append(trailingComment.Comment);
-            this.CurrentWidth = indent.Length;
-            if (mode != PrintMode.ForceFlat)
-            {
-                this.NewLineNextStringValue = true;
-                this.SkipNextNewLine = true;
-            }
-        }
-        else if (doc is ForceFlat forceFlat)
-        {
-            this.Push(forceFlat.Contents, PrintMode.ForceFlat, indent);
-        }
-        else if (doc is Region region)
-        {
-            if (region.IsEnd)
-            {
-                // in the case where regions are combined with ignored ranges, the start region
-                // ends up printing inside the unformatted nodes, so we don't have a matching
-                // start region to go with this end region
-                if (this.RegionIndents.TryPop(out var regionIndent))
+                this.ProcessGroup((Group)doc, mode, indent);
+                break;
+            case DocKind.IfBreak:
+                var ifBreak = (IfBreak)doc;
+                var groupMode = mode;
+                if (ifBreak.GroupId != null)
                 {
-                    this.Output.Append(regionIndent.Value);
+                    if (!this.GroupModeMap.TryGetValue(ifBreak.GroupId, out groupMode))
+                    {
+                        throw new Exception(
+                            "You cannot use an ifBreak before the group it targets."
+                        );
+                    }
+                }
+
+                var contents =
+                    groupMode == PrintMode.Break ? ifBreak.BreakContents : ifBreak.FlatContents;
+                this.Push(contents, mode, indent);
+                break;
+            case DocKind.Line:
+                this.ProcessLine((LineDoc)doc, mode, indent);
+                break;
+            case DocKind.BreakParent:
+                break;
+            case DocKind.LeadingComment:
+
+                this.Output.TrimTrailingWhitespace();
+                if (
+                    (this.Output.Length != 0 && this.Output[^1] != '\n')
+                    || this.NewLineNextStringValue
+                )
+                {
+                    this.Output.Append(this.EndOfLine);
+                }
+
+                this.AppendComment((LeadingComment)doc, indent);
+
+                this.CurrentWidth = indent.Length;
+                this.NewLineNextStringValue = false;
+                this.SkipNextNewLine = false;
+                break;
+            case DocKind.TrailingComment:
+                this.Output.TrimTrailingWhitespace();
+                var trailingComment = (TrailingComment)doc;
+                this.Output.Append(' ').Append(trailingComment.Comment);
+                this.CurrentWidth = indent.Length;
+                if (mode != PrintMode.ForceFlat)
+                {
+                    this.NewLineNextStringValue = true;
+                    this.SkipNextNewLine = true;
+                }
+
+                break;
+            case DocKind.ForceFlat:
+                var forceFlat = (ForceFlat)doc;
+                this.Push(forceFlat.Contents, PrintMode.ForceFlat, indent);
+                break;
+            case DocKind.Region:
+                var region = (Region)doc;
+                if (region.IsEnd)
+                {
+                    // in the case where regions are combined with ignored ranges, the start region
+                    // ends up printing inside the unformatted nodes, so we don't have a matching
+                    // start region to go with this end region
+                    if (this.RegionIndents.TryPop(out var regionIndent))
+                    {
+                        this.Output.Append(regionIndent.Value);
+                    }
+                    else
+                    {
+                        this.Output.Append(indent.Value);
+                    }
                 }
                 else
                 {
                     this.Output.Append(indent.Value);
+                    this.RegionIndents.Push(indent);
                 }
-            }
-            else
-            {
-                this.Output.Append(indent.Value);
-                this.RegionIndents.Push(indent);
-            }
 
-            this.Output.Append(region.Text);
-        }
-        else if (doc is AlwaysFits temp)
-        {
-            this.Push(temp.Contents, mode, indent);
-        }
-        else
-        {
-            throw new Exception("didn't handle " + doc);
+                this.Output.Append(region.Text);
+                break;
+            case DocKind.AlwaysFits:
+                var alwaysFits = (AlwaysFits)doc;
+                this.Push(alwaysFits.Contents, mode, indent);
+                break;
+            default:
+                throw new Exception("didn't handle " + doc);
         }
     }
 

--- a/Src/CSharpier/DocPrinter/PropagateBreaks.cs
+++ b/Src/CSharpier/DocPrinter/PropagateBreaks.cs
@@ -2,7 +2,11 @@ namespace CSharpier.DocPrinter;
 
 internal static class PropagateBreaks
 {
-    private class MarkerDoc : Doc { }
+    private class MarkerDoc : Doc
+    {
+        internal MarkerDoc()
+            : base(DocKind.Marker) { }
+    }
 
     private static readonly MarkerDoc TraverseDocOnExitStackMarker = new();
 

--- a/Src/CSharpier/DocTypes/AlwaysFits.cs
+++ b/Src/CSharpier/DocTypes/AlwaysFits.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class AlwaysFits(Doc printedTrivia) : Doc
+internal sealed class AlwaysFits(Doc printedTrivia) : Doc(DocKind.AlwaysFits)
 {
     public readonly Doc Contents = printedTrivia;
 }

--- a/Src/CSharpier/DocTypes/BreakParent.cs
+++ b/Src/CSharpier/DocTypes/BreakParent.cs
@@ -1,5 +1,9 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class BreakParent : Doc, IBreakParent { }
+internal sealed class BreakParent : Doc, IBreakParent
+{
+    internal BreakParent()
+        : base(DocKind.BreakParent) { }
+}
 
 internal interface IBreakParent { }

--- a/Src/CSharpier/DocTypes/Concat.cs
+++ b/Src/CSharpier/DocTypes/Concat.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class Concat(IList<Doc> contents) : Doc
+internal sealed class Concat(IList<Doc> contents) : Doc(DocKind.Concat)
 {
     public IList<Doc> Contents { get; set; } = contents;
 }

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal enum DocKind
+internal enum DocKind : byte
 {
     Trim,
     TrailingComment,

--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -1,7 +1,28 @@
 namespace CSharpier.DocTypes;
 
-internal abstract class Doc
+internal enum DocKind
 {
+    Trim,
+    TrailingComment,
+    AlwaysFits,
+    BreakParent,
+    String,
+    Region,
+    Null,
+    Line,
+    LeadingComment,
+    Indent,
+    IfBreak,
+    Group,
+    Marker,
+    Concat,
+    ForceFlat,
+}
+
+internal abstract class Doc(DocKind kind)
+{
+    public DocKind Kind { get; } = kind;
+
     public string Print()
     {
         return DocPrinter.DocPrinter.Print(this, new PrinterOptions(), Environment.NewLine);

--- a/Src/CSharpier/DocTypes/ForceFlat.cs
+++ b/Src/CSharpier/DocTypes/ForceFlat.cs
@@ -2,5 +2,8 @@ namespace CSharpier.DocTypes;
 
 internal sealed class ForceFlat : Doc, IHasContents
 {
+    internal ForceFlat()
+        : base(DocKind.ForceFlat) { }
+
     public Doc Contents { get; set; } = Null;
 }

--- a/Src/CSharpier/DocTypes/Group.cs
+++ b/Src/CSharpier/DocTypes/Group.cs
@@ -2,6 +2,9 @@ namespace CSharpier.DocTypes;
 
 internal class Group : Doc, IHasContents
 {
+    internal Group()
+        : base(DocKind.Group) { }
+
     public Doc Contents { get; set; } = Null;
     public bool Break { get; set; }
     public string? GroupId { get; set; }

--- a/Src/CSharpier/DocTypes/IfBreak.cs
+++ b/Src/CSharpier/DocTypes/IfBreak.cs
@@ -2,11 +2,15 @@ namespace CSharpier.DocTypes;
 
 internal class IfBreak : Doc
 {
+    internal IfBreak()
+        : base(DocKind.IfBreak) { }
+
     public Doc FlatContents { get; set; } = Null;
     public Doc BreakContents { get; set; } = Null;
     public string? GroupId { get; set; }
 }
 
+// we don't need a doc kind for this because we only look for this class in serializer
 internal sealed class IndentIfBreak : IfBreak
 {
     public IndentIfBreak(Doc contents, string groupId)

--- a/Src/CSharpier/DocTypes/IndentDoc.cs
+++ b/Src/CSharpier/DocTypes/IndentDoc.cs
@@ -2,5 +2,8 @@ namespace CSharpier.DocTypes;
 
 internal sealed class IndentDoc : Doc, IHasContents
 {
+    internal IndentDoc()
+        : base(DocKind.Indent) { }
+
     public Doc Contents { get; set; } = Null;
 }

--- a/Src/CSharpier/DocTypes/LeadingComment.cs
+++ b/Src/CSharpier/DocTypes/LeadingComment.cs
@@ -2,6 +2,9 @@ namespace CSharpier.DocTypes;
 
 internal sealed class LeadingComment : Doc
 {
+    internal LeadingComment()
+        : base(DocKind.LeadingComment) { }
+
     public CommentType Type { get; init; }
     public string Comment { get; init; } = string.Empty;
 }

--- a/Src/CSharpier/DocTypes/LineDoc.cs
+++ b/Src/CSharpier/DocTypes/LineDoc.cs
@@ -2,6 +2,10 @@ namespace CSharpier.DocTypes;
 
 internal class LineDoc : Doc
 {
+    internal LineDoc()
+        : base(DocKind.Line) { }
+
+    // TODO maybe these should be the DocKinds?
     public enum LineType
     {
         Normal,

--- a/Src/CSharpier/DocTypes/NullDoc.cs
+++ b/Src/CSharpier/DocTypes/NullDoc.cs
@@ -4,5 +4,6 @@ internal sealed class NullDoc : Doc
 {
     public static NullDoc Instance { get; } = new();
 
-    private NullDoc() { }
+    private NullDoc()
+        : base(DocKind.Null) { }
 }

--- a/Src/CSharpier/DocTypes/Region.cs
+++ b/Src/CSharpier/DocTypes/Region.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class Region(string text) : Doc
+internal sealed class Region(string text) : Doc(DocKind.Region)
 {
     public string Text { get; } = text;
     public bool IsEnd { get; init; }

--- a/Src/CSharpier/DocTypes/StringDoc.cs
+++ b/Src/CSharpier/DocTypes/StringDoc.cs
@@ -1,6 +1,6 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class StringDoc(string value, bool isDirective = false) : Doc
+internal sealed class StringDoc(string value, bool isDirective = false) : Doc(DocKind.String)
 {
     public string Value { get; } = value;
     public bool IsDirective { get; } = isDirective;

--- a/Src/CSharpier/DocTypes/TrailingComment.cs
+++ b/Src/CSharpier/DocTypes/TrailingComment.cs
@@ -2,6 +2,9 @@ namespace CSharpier.DocTypes;
 
 internal sealed class TrailingComment : Doc
 {
+    internal TrailingComment()
+        : base(DocKind.TrailingComment) { }
+
     public CommentType Type { get; set; }
     public string Comment { get; set; } = string.Empty;
 }

--- a/Src/CSharpier/DocTypes/Trim.cs
+++ b/Src/CSharpier/DocTypes/Trim.cs
@@ -1,3 +1,7 @@
 namespace CSharpier.DocTypes;
 
-internal sealed class Trim : Doc { }
+internal sealed class Trim : Doc
+{
+    internal Trim()
+        : base(DocKind.Trim) { }
+}


### PR DESCRIPTION
This modified all `Doc` classes to define a `DocKind` which can then be used in place of `IsInstanceOf`.

Before
![image](https://github.com/user-attachments/assets/7c7b1b41-bdc5-4093-81ca-b5435fde644f)

After changing `DocFitter`
![image](https://github.com/user-attachments/assets/007a05c8-eede-497a-a870-be7d430dbd9c)
