### PR TITLE
perf: use `ValueListBuilder<T>` for constant buffers

### DIFF
--- a/Src/CSharpier/DocTypes/Doc.cs
+++ b/Src/CSharpier/DocTypes/Doc.cs
@@ -56,6 +56,16 @@ internal abstract class Doc
 
     public static Doc Concat(params Doc[] contents) => new Concat(contents);
 
+    public static Doc Concat(ref ValueListBuilder<Doc> contents)
+    {
+        return contents.Length switch
+        {
+            0 => Null,
+            1 => contents[0],
+            _ => new Concat(contents.AsSpan().ToArray()),
+        };
+    }
+
     public static Doc Join(Doc separator, IEnumerable<Doc> enumerable)
     {
         var docs = new List<Doc>();

--- a/Src/CSharpier/SyntaxPrinter/AttributeLists.cs
+++ b/Src/CSharpier/SyntaxPrinter/AttributeLists.cs
@@ -13,7 +13,7 @@ internal static class AttributeLists
             return Doc.Null;
         }
 
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null]);
         Doc separator = node
             is TypeParameterSyntax
                 or ParameterSyntax
@@ -21,13 +21,15 @@ internal static class AttributeLists
             ? Doc.Line
             : Doc.HardLine;
 
-        docs.Add(Doc.Join(separator, attributeLists.Select(o => AttributeList.Print(o, context))));
+        docs.Append(
+            Doc.Join(separator, attributeLists.Select(o => AttributeList.Print(o, context)))
+        );
 
         if (node is not (ParameterSyntax or TypeParameterSyntax))
         {
-            docs.Add(separator);
+            docs.Append(separator);
         }
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SeparatedSyntaxList.cs
@@ -144,12 +144,7 @@ internal static class SeparatedSyntaxList
             docs.Append(unFormattedCode.ToString().Trim());
         }
 
-        var output = docs.Length switch
-        {
-            0 => Doc.Null,
-            1 => docs[0],
-            _ => Doc.Concat(docs.AsSpan().ToArray()),
-        };
+        var output = Doc.Concat(ref docs);
         docs.Dispose();
 
         return output;

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousMethodExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousMethodExpression.cs
@@ -4,19 +4,17 @@ internal static class AnonymousMethodExpression
 {
     public static Doc Print(AnonymousMethodExpressionSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            Modifiers.Print(node.Modifiers, context),
-            Token.Print(node.DelegateKeyword, context),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null]);
+        docs.Append(Modifiers.Print(node.Modifiers, context));
+        docs.Append(Token.Print(node.DelegateKeyword, context));
 
         if (node.ParameterList != null)
         {
-            docs.Add(ParameterList.Print(node.ParameterList, context));
+            docs.Append(ParameterList.Print(node.ParameterList, context));
         }
 
-        docs.Add(Block.Print(node.Block, context));
+        docs.Append(Block.Print(node.Block, context));
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectMemberDeclarator.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AnonymousObjectMemberDeclarator.cs
@@ -4,21 +4,21 @@ internal static class AnonymousObjectMemberDeclarator
 {
     public static Doc Print(AnonymousObjectMemberDeclaratorSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null]);
         if (
             node.Parent is AnonymousObjectCreationExpressionSyntax parent
             && node != parent.Initializers.First()
         )
         {
-            docs.Add(ExtraNewLines.Print(node));
+            docs.Append(ExtraNewLines.Print(node));
         }
 
         if (node.NameEquals != null)
         {
-            docs.Add(Token.PrintWithSuffix(node.NameEquals.Name.Identifier, " ", context));
-            docs.Add(Token.PrintWithSuffix(node.NameEquals.EqualsToken, " ", context));
+            docs.Append(Token.PrintWithSuffix(node.NameEquals.Name.Identifier, " ", context));
+            docs.Append(Token.PrintWithSuffix(node.NameEquals.EqualsToken, " ", context));
         }
-        docs.Add(Node.Print(node.Expression, context));
-        return Doc.Concat(docs);
+        docs.Append(Node.Print(node.Expression, context));
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Argument.cs
@@ -9,17 +9,17 @@ internal static class Argument
 
     public static Doc PrintModifiers(ArgumentSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>(2);
+        var docs = new ValueListBuilder<Doc>([null, null]);
         if (node.NameColon != null)
         {
-            docs.Add(BaseExpressionColon.Print(node.NameColon, context));
+            docs.Append(BaseExpressionColon.Print(node.NameColon, context));
         }
 
         if (node.RefKindKeyword.RawSyntaxKind() != SyntaxKind.None)
         {
-            docs.Add(Token.PrintWithSuffix(node.RefKindKeyword, " ", context));
+            docs.Append(Token.PrintWithSuffix(node.RefKindKeyword, " ", context));
         }
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
@@ -9,19 +9,19 @@ internal static class AttributeList
             return CSharpierIgnore.PrintWithoutFormatting(node, context).Trim();
         }
 
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null]);
         if (
             node.Parent is CompilationUnitSyntax compilationUnitSyntax
             && compilationUnitSyntax.AttributeLists.First() != node
         )
         {
-            docs.Add(ExtraNewLines.Print(node));
+            docs.Append(ExtraNewLines.Print(node));
         }
 
-        docs.Add(Token.Print(node.OpenBracketToken, context));
+        docs.Append(Token.Print(node.OpenBracketToken, context));
         if (node.Target != null)
         {
-            docs.Add(
+            docs.Append(
                 Token.Print(node.Target.Identifier, context),
                 Token.PrintWithSuffix(node.Target.ColonToken, " ", context)
             );
@@ -72,17 +72,19 @@ internal static class AttributeList
             context
         );
 
-        docs.Add(
+        docs.Append(
             node.Attributes.Count > 1
                 ? Doc.Indent(Doc.SoftLine, printSeparatedSyntaxList)
                 : printSeparatedSyntaxList
         );
 
-        docs.Add(
-            node.Attributes.Count > 1 ? Doc.SoftLine : Doc.Null,
-            Token.Print(node.CloseBracketToken, context)
-        );
+        if (node.Attributes.Count > 1)
+        {
+            docs.Append(Doc.SoftLine);
+        }
 
-        return Doc.Group(docs);
+        docs.Append(Token.Print(node.CloseBracketToken, context));
+
+        return Doc.Group(docs.AsSpan().ToArray());
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseFieldDeclaration.cs
@@ -4,20 +4,20 @@ internal static class BaseFieldDeclaration
 {
     public static Doc Print(BaseFieldDeclarationSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Modifiers.PrintSorted(node.Modifiers, context),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null]);
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Modifiers.PrintSorted(node.Modifiers, context));
         if (node is EventFieldDeclarationSyntax eventFieldDeclarationSyntax)
         {
-            docs.Add(Token.PrintWithSuffix(eventFieldDeclarationSyntax.EventKeyword, " ", context));
+            docs.Append(
+                Token.PrintWithSuffix(eventFieldDeclarationSyntax.EventKeyword, " ", context)
+            );
         }
 
-        docs.Add(
+        docs.Append(
             VariableDeclaration.Print(node.Declaration, context),
             Token.Print(node.SemicolonToken, context)
         );
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
@@ -38,11 +38,9 @@ internal static class BasePropertyDeclaration
             semicolonToken = eventDeclarationSyntax.SemicolonToken;
         }
 
-        var docs = new List<Doc> { AttributeLists.Print(node, node.AttributeLists, context) };
-
         return Doc.Group(
             Doc.Concat(
-                Doc.Concat(docs),
+                AttributeLists.Print(node, node.AttributeLists, context),
                 Modifiers.PrintSorted(node.Modifiers, context),
                 eventKeyword,
                 Node.Print(node.Type, context),
@@ -112,31 +110,31 @@ internal static class BasePropertyDeclaration
         PrintingContext context
     )
     {
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null]);
         if (node.AttributeLists.Count > 0 || node.Body != null || node.ExpressionBody != null)
         {
-            docs.Add(Doc.HardLine);
+            docs.Append(Doc.HardLine);
         }
         else
         {
-            docs.Add(separator);
+            docs.Append(separator);
         }
 
-        docs.Add(AttributeLists.Print(node, node.AttributeLists, context));
-        docs.Add(Modifiers.PrintSorted(node.Modifiers, context));
-        docs.Add(Token.Print(node.Keyword, context));
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Modifiers.PrintSorted(node.Modifiers, context));
+        docs.Append(Token.Print(node.Keyword, context));
 
         if (node.Body != null)
         {
-            docs.Add(Block.Print(node.Body, context));
+            docs.Append(Block.Print(node.Body, context));
         }
         else if (node.ExpressionBody != null)
         {
-            docs.Add(ArrowExpressionClause.Print(node.ExpressionBody, context));
+            docs.Append(ArrowExpressionClause.Print(node.ExpressionBody, context));
         }
 
-        docs.Add(Token.Print(node.SemicolonToken, context));
+        docs.Append(Token.Print(node.SemicolonToken, context));
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/DelegateDeclaration.cs
@@ -4,23 +4,25 @@ internal static class DelegateDeclaration
 {
     public static Doc Print(DelegateDeclarationSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Modifiers.PrintSorted(node.Modifiers, context),
-            Token.PrintWithSuffix(node.DelegateKeyword, " ", context),
-            Node.Print(node.ReturnType, context),
-            { " ", Token.Print(node.Identifier, context) },
-        };
+        var docs = new ValueListBuilder<Doc>(
+            [null, null, null, null, null, null, null, null, null, null]
+        );
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Modifiers.PrintSorted(node.Modifiers, context));
+        docs.Append(Token.PrintWithSuffix(node.DelegateKeyword, " ", context));
+        docs.Append(Node.Print(node.ReturnType, context));
+        docs.Append(" ");
+        docs.Append(Token.Print(node.Identifier, context));
+
         if (node.TypeParameterList != null)
         {
-            docs.Add(Node.Print(node.TypeParameterList, context));
+            docs.Append(Node.Print(node.TypeParameterList, context));
         }
-        docs.Add(
+        docs.Append(
             Node.Print(node.ParameterList, context),
             ConstraintClauses.Print(node.ConstraintClauses, context),
             Token.Print(node.SemicolonToken, context)
         );
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EnumMemberDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/EnumMemberDeclaration.cs
@@ -4,16 +4,15 @@ internal static class EnumMemberDeclaration
 {
     public static Doc Print(EnumMemberDeclarationSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Modifiers.Print(node.Modifiers, context),
-            Token.Print(node.Identifier, context),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null]);
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Modifiers.Print(node.Modifiers, context));
+        docs.Append(Token.Print(node.Identifier, context));
+
         if (node.EqualsValue != null)
         {
-            docs.Add(EqualsValueClause.Print(node.EqualsValue, context));
+            docs.Append(EqualsValueClause.Print(node.EqualsValue, context));
         }
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/ForStatement.cs
@@ -4,8 +4,7 @@ internal static class ForStatement
 {
     public static Doc Print(ForStatementSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
+        return Doc.Concat(
             ExtraNewLines.Print(node),
             Doc.Group(
                 Token.Print(node.ForKeyword, context),
@@ -45,9 +44,7 @@ internal static class ForStatement
             {
                 ForStatementSyntax => Doc.Group(Doc.HardLine, Node.Print(node.Statement, context)),
                 _ => OptionalBraces.Print(node.Statement, context),
-            },
-        };
-
-        return Doc.Concat(docs);
+            }
+        );
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/IfStatement.cs
@@ -4,13 +4,13 @@ internal static class IfStatement
 {
     public static Doc Print(IfStatementSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null, null]);
         if (node.Parent is not ElseClauseSyntax)
         {
-            docs.Add(ExtraNewLines.Print(node));
+            docs.Append(ExtraNewLines.Print(node));
         }
 
-        docs.Add(
+        docs.Append(
             Token.Print(node.IfKeyword, context),
             " ",
             Doc.Group(
@@ -27,9 +27,9 @@ internal static class IfStatement
 
         if (node.Else != null)
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Else, context));
+            docs.Append(Doc.HardLine, Node.Print(node.Else, context));
         }
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Interpolation.cs
@@ -4,27 +4,26 @@ internal static class Interpolation
 {
     public static Doc Print(InterpolationSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            Token.Print(node.OpenBraceToken, context),
-            Node.Print(node.Expression, context),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null]);
+        docs.Append(Token.Print(node.OpenBraceToken, context));
+        docs.Append(Node.Print(node.Expression, context));
+
         if (node.AlignmentClause != null)
         {
-            docs.Add(
+            docs.Append(
                 Token.PrintWithSuffix(node.AlignmentClause.CommaToken, " ", context),
                 Node.Print(node.AlignmentClause.Value, context)
             );
         }
         if (node.FormatClause != null)
         {
-            docs.Add(
+            docs.Append(
                 Token.Print(node.FormatClause.ColonToken, context),
                 Token.Print(node.FormatClause.FormatStringToken, context)
             );
         }
 
-        docs.Add(Token.Print(node.CloseBraceToken, context));
-        return Doc.Concat(docs);
+        docs.Append(Token.Print(node.CloseBraceToken, context));
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LabeledStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/LabeledStatement.cs
@@ -4,21 +4,20 @@ internal static class LabeledStatement
 {
     public static Doc Print(LabeledStatementSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            ExtraNewLines.Print(node),
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Token.Print(node.Identifier, context),
-            Token.Print(node.ColonToken, context),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null]);
+        docs.Append(ExtraNewLines.Print(node));
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Token.Print(node.Identifier, context));
+        docs.Append(Token.Print(node.ColonToken, context));
+
         if (node.Statement is BlockSyntax blockSyntax)
         {
-            docs.Add(Block.Print(blockSyntax, context));
+            docs.Append(Block.Print(blockSyntax, context));
         }
         else
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Statement, context));
+            docs.Append(Doc.HardLine, Node.Print(node.Statement, context));
         }
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NamespaceDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/NamespaceDeclaration.cs
@@ -4,15 +4,6 @@ internal static class NamespaceDeclaration
 {
     public static Doc Print(NamespaceDeclarationSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Modifiers.Print(node.Modifiers, context),
-            Token.Print(node.NamespaceKeyword, context),
-            " ",
-            Node.Print(node.Name, context),
-        };
-
         var innerDocs = new List<Doc>();
         var hasMembers = node.Members.Count > 0;
         var hasUsing = node.Usings.Count > 0;
@@ -29,7 +20,12 @@ internal static class NamespaceDeclaration
 
         DocUtilities.RemoveInitialDoubleHardLine(innerDocs);
 
-        docs.Add(
+        return Doc.Concat(
+            AttributeLists.Print(node, node.AttributeLists, context),
+            Modifiers.Print(node.Modifiers, context),
+            Token.Print(node.NamespaceKeyword, context),
+            " ",
+            Node.Print(node.Name, context),
             Doc.Group(
                 Doc.Line,
                 Token.Print(node.OpenBraceToken, context),
@@ -39,6 +35,5 @@ internal static class NamespaceDeclaration
                 Token.Print(node.SemicolonToken, context)
             )
         );
-        return Doc.Concat(docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -6,32 +6,32 @@ internal static class Parameter
     {
         var hasAttribute = node.AttributeLists.Any();
         var groupId = hasAttribute ? Guid.NewGuid().ToString() : string.Empty;
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null]);
 
         if (hasAttribute)
         {
-            docs.Add(AttributeLists.Print(node, node.AttributeLists, context));
-            docs.Add(Doc.IndentIfBreak(Doc.Line, groupId));
+            docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+            docs.Append(Doc.IndentIfBreak(Doc.Line, groupId));
         }
 
         if (node.Modifiers.Any())
         {
-            docs.Add(Modifiers.Print(node.Modifiers, context));
+            docs.Append(Modifiers.Print(node.Modifiers, context));
         }
 
         if (node.Type != null)
         {
-            docs.Add(Node.Print(node.Type, context), " ");
+            docs.Append(Node.Print(node.Type, context), " ");
         }
 
-        docs.Add(Token.Print(node.Identifier, context));
+        docs.Append(Token.Print(node.Identifier, context));
         if (node.Default != null)
         {
-            docs.Add(EqualsValueClause.Print(node.Default, context));
+            docs.Append(EqualsValueClause.Print(node.Default, context));
         }
 
-        return hasAttribute ? Doc.GroupWithId(groupId, docs)
-            : docs.Count == 1 ? docs[0]
-            : Doc.Concat(docs);
+        return hasAttribute
+            ? Doc.GroupWithId(groupId, docs.AsSpan().ToArray())
+            : Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -44,7 +44,6 @@ internal static class Parameter
         }
 
         return hasAttribute ? Doc.Group(docs.AsSpan().ToArray())
-            : docs.Count == 1 ? docs[0]
             : Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -43,7 +43,6 @@ internal static class Parameter
             docs.Append(EqualsValueClause.Print(node.Default, context));
         }
 
-        return hasAttribute ? Doc.Group(docs.AsSpan().ToArray())
-            : Doc.Concat(ref docs);
+        return hasAttribute ? Doc.Group(docs.AsSpan().ToArray()) : Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -43,7 +43,7 @@ internal static class Parameter
             docs.Append(EqualsValueClause.Print(node.Default, context));
         }
 
-        return hasAttribute ? Doc.Group(docs.AsSpan.ToArray)
+        return hasAttribute ? Doc.Group(docs.AsSpan().ToArray())
             : docs.Count == 1 ? docs[0]
             : Doc.Concat(ref docs);
     }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/QueryBody.cs
@@ -4,21 +4,20 @@ internal static class QueryBody
 {
     public static Doc Print(QueryBodySyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            Doc.Join(Doc.Line, node.Clauses.Select(o => Node.Print(o, context))),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null]);
+        docs.Append(Doc.Join(Doc.Line, node.Clauses.Select(o => Node.Print(o, context))));
+
         if (node.Clauses.Count > 0)
         {
-            docs.Add(Doc.Line);
+            docs.Append(Doc.Line);
         }
 
-        docs.Add(Node.Print(node.SelectOrGroup, context));
+        docs.Append(Node.Print(node.SelectOrGroup, context));
         if (node.Continuation != null)
         {
-            docs.Add(" ", QueryContinuation.Print(node.Continuation, context));
+            docs.Append(" ", QueryContinuation.Print(node.Continuation, context));
         }
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/RecursivePattern.cs
@@ -14,15 +14,15 @@ internal static class RecursivePattern
 
     private static Doc Print(RecursivePatternSyntax node, bool includeType, PrintingContext context)
     {
-        var result = new List<Doc>();
+        var result = new ValueListBuilder<Doc>([null, null, null, null, null, null, null]);
         if (node.Type != null && includeType)
         {
-            result.Add(Node.Print(node.Type, context));
+            result.Append(Node.Print(node.Type, context));
         }
 
         if (node.PositionalPatternClause != null)
         {
-            result.Add(
+            result.Append(
                 node.Parent
                     is SwitchExpressionArmSyntax
                         or CasePatternSwitchLabelSyntax
@@ -64,13 +64,13 @@ internal static class RecursivePattern
             {
                 if (node.Type != null)
                 {
-                    result.Add(" ");
+                    result.Append(" ");
                 }
-                result.Add("{ }");
+                result.Append("{ }");
             }
             else
             {
-                result.Add(
+                result.Append(
                     Doc.Group(
                         node.Type != null
                         && !node.PropertyPatternClause.OpenBraceToken.LeadingTrivia.Any(o =>
@@ -103,9 +103,9 @@ internal static class RecursivePattern
 
         if (node.Designation != null)
         {
-            result.Add(" ", Node.Print(node.Designation, context));
+            result.Append(" ", Node.Print(node.Designation, context));
         }
 
-        return Doc.Concat(result);
+        return Doc.Concat(ref result);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
@@ -4,17 +4,15 @@ internal static class SwitchSection
 {
     public static Doc Print(SwitchSectionSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            Doc.Join(Doc.HardLine, node.Labels.Select(o => Node.Print(o, context))),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null]);
+        docs.Append(Doc.Join(Doc.HardLine, node.Labels.Select(o => Node.Print(o, context))));
         if (node.Statements is [BlockSyntax blockSyntax])
         {
-            docs.Add(Block.Print(blockSyntax, context));
+            docs.Append(Block.Print(blockSyntax, context));
         }
         else
         {
-            docs.Add(
+            docs.Append(
                 Doc.Indent(
                     node.Statements.First() is BlockSyntax ? Doc.Null : Doc.HardLine,
                     Doc.Join(
@@ -24,6 +22,6 @@ internal static class SwitchSection
                 )
             );
         }
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TryStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/TryStatement.cs
@@ -4,19 +4,20 @@ internal static class TryStatement
 {
     public static Doc Print(TryStatementSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            ExtraNewLines.Print(node),
-            AttributeLists.Print(node, node.AttributeLists, context),
-            Token.Print(node.TryKeyword, context),
-            Block.Print(node.Block, context),
-            node.Catches.Any() ? Doc.HardLine : Doc.Null,
-            Doc.Join(Doc.HardLine, node.Catches.Select(o => CatchClause.Print(o, context))),
-        };
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null, null]);
+        docs.Append(ExtraNewLines.Print(node));
+        docs.Append(AttributeLists.Print(node, node.AttributeLists, context));
+        docs.Append(Token.Print(node.TryKeyword, context));
+        docs.Append(Block.Print(node.Block, context));
+        docs.Append(node.Catches.Any() ? Doc.HardLine : Doc.Null);
+        docs.Append(
+            Doc.Join(Doc.HardLine, node.Catches.Select(o => CatchClause.Print(o, context)))
+        );
+
         if (node.Finally != null)
         {
-            docs.Add(Doc.HardLine, FinallyClause.Print(node.Finally, context));
+            docs.Append(Doc.HardLine, FinallyClause.Print(node.Finally, context));
         }
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingStatement.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/UsingStatement.cs
@@ -4,9 +4,9 @@ internal static class UsingStatement
 {
     public static Doc Print(UsingStatementSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc>
-        {
-            ExtraNewLines.Print(node),
+        var docs = new ValueListBuilder<Doc>([null, null, null, null]);
+        docs.Append(ExtraNewLines.Print(node));
+        docs.Append(
             Doc.Group(
                 Token.Print(node.AwaitKeyword, context),
                 node.AwaitKeyword.RawSyntaxKind() != SyntaxKind.None ? " " : Doc.Null,
@@ -25,21 +25,22 @@ internal static class UsingStatement
                 ),
                 Token.Print(node.CloseParenToken, context),
                 Doc.IfBreak(Doc.Null, Doc.SoftLine)
-            ),
-        };
+            )
+        );
+
         if (node.Statement is UsingStatementSyntax)
         {
-            docs.Add(Doc.HardLine, Node.Print(node.Statement, context));
+            docs.Append(Doc.HardLine, Node.Print(node.Statement, context));
         }
         else if (node.Statement is BlockSyntax blockSyntax)
         {
-            docs.Add(Block.Print(blockSyntax, context));
+            docs.Append(Block.Print(blockSyntax, context));
         }
         else
         {
-            docs.Add(Doc.Indent(Doc.HardLine, Node.Print(node.Statement, context)));
+            docs.Append(Doc.Indent(Doc.HardLine, Node.Print(node.Statement, context)));
         }
 
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclarator.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/VariableDeclarator.cs
@@ -4,15 +4,17 @@ internal static class VariableDeclarator
 {
     public static Doc Print(VariableDeclaratorSyntax node, PrintingContext context)
     {
-        var docs = new List<Doc> { Token.Print(node.Identifier, context) };
+        var docs = new ValueListBuilder<Doc>([null, null, null]);
+        docs.Append(Token.Print(node.Identifier, context));
+
         if (node.ArgumentList != null)
         {
-            docs.Add(BracketedArgumentList.Print(node.ArgumentList, context));
+            docs.Append(BracketedArgumentList.Print(node.ArgumentList, context));
         }
         if (node.Initializer != null)
         {
-            docs.Add(EqualsValueClause.Print(node.Initializer, context));
+            docs.Append(EqualsValueClause.Print(node.Initializer, context));
         }
-        return Doc.Concat(docs);
+        return Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier/SyntaxPrinter/Token.cs
@@ -146,12 +146,7 @@ internal static class Token
             docs.Append(suffixDoc);
         }
 
-        var returnDoc = docs.Length switch
-        {
-            <= 0 => Doc.Null,
-            1 => docs[0],
-            _ => Doc.Concat(docs.AsSpan().ToArray()),
-        };
+        var returnDoc = Doc.Concat(ref docs);
         docs.Dispose();
 
         return returnDoc;
@@ -413,7 +408,7 @@ internal static class Token
             }
         }
 
-        var returnDoc = docs.Length > 0 ? Doc.Concat(docs.AsSpan().ToArray()) : Doc.Null;
+        var returnDoc = Doc.Concat(ref docs);
         docs.Dispose();
 
         return returnDoc;


### PR DESCRIPTION
Follow on from #1502, using `ValueListBuilder` to replace known `List<Doc>` sizes.

- Most of these changes aren't measurable in the benchmarks, many are insignificant, although I suspect this is partly due to the limited code found in the benchmark file.
- This PR will increase the performance benefits of #1524



@belav what do you think the best way of replacing a list that uses a collection initializer is?

 I can either add the items directly into the scratch buffer and manually update `Length`
```C#
var docs = new ValueListBuilder<Doc>
([
    Modifiers.Print(node.Modifiers, context),
    Token.Print(node.DelegateKeyword, context),
    null,null
]);
docs.Length = 2;
```

Or create the buffer and then append the items via params.
```C#
var docs = new ValueListBuilder<Doc>([null, null, null, null]);
docs.Append(
    Modifiers.Print(node.Modifiers, context),
    Token.Print(node.DelegateKeyword, context)
);
```
Or Append each item
```C#
var docs = new ValueListBuilder<Doc>([null, null, null, null]);
docs.Append(Modifiers.Print(node.Modifiers, context));
docs.Append(Token.Print(node.DelegateKeyword, context));
```