### PR TITLE
perf: add `Any` overload for `SyntaxTokenList`

### DIFF
--- a/Src/CSharpier/Utilities/ListExtensions.cs
+++ b/Src/CSharpier/Utilities/ListExtensions.cs
@@ -34,6 +34,21 @@ internal static class ListExtensions
         return false;
     }
 
+    // Overload for Any to prevent unnecessary allocations of EnumeratorImpl
+    public static bool Any(this in SyntaxTokenList tokenList, Func<SyntaxToken, bool> predicate)
+    {
+        // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var token in tokenList)
+        {
+            if (predicate(token))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static SyntaxTrivia FirstOrDefault(
         this in SyntaxTriviaList source,
         Func<SyntaxTrivia, bool> predicate


### PR DESCRIPTION
Add `Any` overload for `SyntaxTokenList`, saves 0.5 MB on the complex code bencmark. 


### Benchmarks
#### Before
| Method                        | Mean     | Error   | StdDev   | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|---------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Complex | 241.7 ms | 7.22 ms | 21.17 ms | 7000.0000 | 4000.0000 | 1000.0000 |  61.61 MB |

#### After
| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Complex | 234.2 ms | 4.65 ms | 6.82 ms | 7000.0000 | 4000.0000 | 1000.0000 |  61.09 MB |