### PR TITLE
perf: use `params ReadOnlySpan` for `List.Add`

### DIFF
--- a/Src/CSharpier/Utilities/ListExtensions.cs
+++ b/Src/CSharpier/Utilities/ListExtensions.cs
@@ -2,13 +2,21 @@ namespace CSharpier.Utilities;
 
 internal static class ListExtensions
 {
-    public static void Add(this List<Doc> list, params Doc[] values)
+    public static void Add(this List<Doc> list, params ReadOnlySpan<Doc> values)
     {
         if (values.Length == 1 && values[0] == Doc.Null)
         {
             return;
         }
+
+#if NETSTANDARD2_0
+        foreach (var items in values)
+        {
+            list.Add(items);
+        }
+#else
         list.AddRange(values);
+#endif
     }
 
     public static void AddIfNotNull(this List<Doc> value, Doc doc)


### PR DESCRIPTION
Saves 0.09MB on the `CodeAxesTest` and 0.5MB on #1533

### Benchmarks (timing is inaccurate)
#### Before
| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Complex | 228.4 ms | 4.55 ms | 6.53 ms | 7000.0000 | 4000.0000 | 1000.0000 |  61.62 MB 

#### After

| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Complex | 210.4 ms | 3.41 ms | 3.35 ms | 7000.0000 | 4000.0000 | 1000.0000 |  61.09 MB |