### PR TITLE
perf: preventing boxing of `SyntaxList<ConstrainClause>`

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
+++ b/Src/CSharpier/SyntaxPrinter/ConstraintClauses.cs
@@ -3,19 +3,17 @@ namespace CSharpier.SyntaxPrinter;
 internal static class ConstraintClauses
 {
     public static Doc Print(
-        IEnumerable<TypeParameterConstraintClauseSyntax> constraintClauses,
+        SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
         PrintingContext context
     )
     {
-        var constraintClausesList = constraintClauses.ToList();
-
-        if (constraintClausesList.Count == 0)
+        if (constraintClauses.Count == 0)
         {
             return Doc.Null;
         }
         var body = Doc.Join(
             Doc.HardLine,
-            constraintClausesList.Select(o => TypeParameterConstraintClause.Print(o, context))
+            constraintClauses.Select(o => TypeParameterConstraintClause.Print(o, context))
         );
 
         return Doc.Group(Doc.Indent(Doc.HardLine, body));

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -229,7 +229,7 @@ internal static class BaseMethodDeclaration
 
         if (constraintClauses != null)
         {
-            docs.Add(ConstraintClauses.Print(constraintClauses, context));
+            docs.Add(ConstraintClauses.Print(constraintClauses.Value, context));
         }
 
         if (body != null)

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -6,7 +6,7 @@ internal static class BaseTypeDeclaration
     {
         ParameterListSyntax? parameterList = null;
         TypeParameterListSyntax? typeParameterList = null;
-        var constraintClauses = Enumerable.Empty<TypeParameterConstraintClauseSyntax>();
+        SyntaxList<TypeParameterConstraintClauseSyntax>? constraintClauses = null;
         SyntaxToken? recordKeyword = null;
         SyntaxToken? keyword = null;
         Func<Doc>? members = null;
@@ -125,7 +125,10 @@ internal static class BaseTypeDeclaration
             docs.Add(Doc.Group(Doc.Indent(Doc.Line, baseListDoc)));
         }
 
-        docs.Add(ConstraintClauses.Print(constraintClauses, context));
+        if (constraintClauses != null)
+        {
+            docs.Add(ConstraintClauses.Print(constraintClauses.Value, context));
+        }
 
         if (members != null)
         {


### PR DESCRIPTION
This is a nitpick PR, it probably saves 0.07 MB on the complex code benchmark

- convert `ConstraintClauses.Print`  to use `SyntaxList<TypeParameterConstraintClauseSyntax>` to prevent boxing