### PR TITLE
perf: optimise `Modifiers`, remove linq and array allocations

### DIFF
--- a/Src/CSharpier/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier/SyntaxPrinter/Modifiers.cs
@@ -2,7 +2,7 @@ namespace CSharpier.SyntaxPrinter;
 
 internal static class Modifiers
 {
-    private class DefaultOrder : IComparer<string>
+    private class DefaultOrder : IComparer<SyntaxToken>
     {
         // use the default order from https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
         private static readonly string[] DefaultOrdered =
@@ -26,9 +26,9 @@ internal static class Modifiers
             "async",
         ];
 
-        public int Compare(string? x, string? y)
+        public int Compare(SyntaxToken x, SyntaxToken y)
         {
-            return GetIndex(x) - GetIndex(y);
+            return GetIndex(x.Text) - GetIndex(y.Text);
         }
 
         private static int GetIndex(string? value)
@@ -85,7 +85,7 @@ internal static class Modifiers
     }
 
     private static Doc PrintWithSortedModifiers(
-        SyntaxTokenList modifiers,
+        in SyntaxTokenList modifiers,
         PrintingContext context,
         Func<IReadOnlyList<SyntaxToken>, Doc> print
     )
@@ -100,20 +100,17 @@ internal static class Modifiers
             modifiers.Count > 1
             && !modifiers.Any(o => o.LeadingTrivia.Any(p => p.IsDirective || p.IsComment()));
 
-        var sortedModifiers = (
-            willReorderModifiers
-                ? modifiers.OrderBy(o => o.Text, Comparer)
-                : modifiers.AsEnumerable()
-        ).ToArray();
+        var sortedModifiers = modifiers.ToArray();
+        if (willReorderModifiers)
+        {
+            Array.Sort(sortedModifiers, Comparer);
+        }
 
-        if (
-            willReorderModifiers
-            && sortedModifiers.Zip(modifiers, (original, sorted) => original != sorted).Any()
-        )
+        if (willReorderModifiers && !sortedModifiers.SequenceEqual(modifiers))
         {
             context.State.ReorderedModifiers = true;
         }
 
-        return print(sortedModifiers.ToArray());
+        return print(sortedModifiers);
     }
 }

--- a/Src/CSharpier/Utilities/ListExtensions.cs
+++ b/Src/CSharpier/Utilities/ListExtensions.cs
@@ -75,4 +75,34 @@ internal static class ListExtensions
 
         return first;
     }
+
+    public static SyntaxToken[] ToArray(this in SyntaxTokenList source)
+    {
+        var array = new SyntaxToken[source.Count];
+        // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+        for (var i = 0; i < source.Count; i++)
+        {
+            array[i] = source[i];
+        }
+
+        return array;
+    }
+
+    public static bool SequenceEqual(this SyntaxToken[] left, in SyntaxTokenList right)
+    {
+        if (left.Length != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (left[i] != right[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
- Use non boxing `ToArray` method.
- Use `Array.Sort` instead of `OrderBy` 
  - This could be a mistake. `OrderBy` is a stable sort whereas `Array.Sort` is unstable. If I understand correctly, this won't be a problem as csharpier will never encounter a situation where `SyntaxTokenList` contains 2 modifiers with the same name (but potentially different trivia). I don't know if preprocessor directives could break this 
- Replace `Zip().Any()` with a custom `SequenceEquals` (this prevents boxing `SyntaxTokenList`)
- Remove unnecessary `ToArray` call

Saves 1 MB on Tests benchmark and 1.8 MB on the Complex benchmark. This is a lot more that I expected, dotmemory claims shows a 200KB reduction but the benchmarks think otherwise 🤔 

#### Before
![image](https://github.com/user-attachments/assets/ac10377c-edb0-440d-957f-9e1372564457)

#### After
![image](https://github.com/user-attachments/assets/75165b03-1afa-4a7a-8b2a-d947e036ab9e)



### Benchmarks (on battery power timing is inaccurate)
#### Before
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 138.0 ms | 2.92 ms |  8.43 ms | 137.2 ms | 3000.0000 | 1000.0000 |         - |  32.02 MB |
| Default_CodeFormatter_Complex | 295.4 ms | 7.06 ms | 20.49 ms | 302.7 ms | 6000.0000 | 3000.0000 | 1000.0000 |  56.42 MB |


#### After
| Method                        | Mean     | Error   | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 137.8 ms | 2.61 ms |  5.89 ms | 2000.0000 | 1000.0000 |  31.07 MB |
| Default_CodeFormatter_Complex | 286.0 ms | 5.42 ms | 10.31 ms | 5000.0000 | 2000.0000 |  54.61 MB |

