### PR TITLE
perf: replace `StringBuilder` with `ValueListBuilder<char>`

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/MembersWithForcedLines.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using CSharpier.Core.DocTypes;
 using CSharpier.Core.Utilities;
@@ -10,6 +11,7 @@ namespace CSharpier.Core.CSharp.SyntaxPrinter;
 
 internal static class MembersWithForcedLines
 {
+    [SkipLocalsInit]
     public static List<Doc> Print<T>(
         CSharpSyntaxNode node,
         IReadOnlyList<T> members,
@@ -24,7 +26,7 @@ internal static class MembersWithForcedLines
             result.Add(Doc.HardLine);
         }
 
-        var unFormattedCode = new StringBuilder();
+        var unFormattedCode = new ValueListBuilder<char>(stackalloc char[64]);
         var printUnformatted = false;
         var lastMemberForcedBlankLine = false;
         for (var memberIndex = 0; memberIndex < members.Count; memberIndex++)
@@ -35,7 +37,7 @@ internal static class MembersWithForcedLines
             if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreEndRegex))
             {
                 skipAddingLineBecauseIgnoreEnded = true;
-                result.Add(unFormattedCode.ToString().Trim());
+                result.Add(unFormattedCode.AsSpan().Trim().ToString());
                 unFormattedCode.Clear();
                 printUnformatted = false;
             }
@@ -229,8 +231,10 @@ internal static class MembersWithForcedLines
 
         if (unFormattedCode.Length > 0)
         {
-            result.Add(unFormattedCode.ToString().Trim());
+            result.Add(unFormattedCode.AsSpan().ToString().Trim());
         }
+
+        unFormattedCode.Dispose();
 
         return result;
     }

--- a/Src/CSharpier.Core/CSharpier.Core.csproj
+++ b/Src/CSharpier.Core/CSharpier.Core.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>True</SignAssembly>
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010049d266ea1aeae09c0abfce28b8728314d4e4807126ee8bc56155a7ddc765997ed3522908b469ae133fc49ef0bfa957df36082c1c2e0ec8cdc05a4ca4dbd4e1bea6c17fc1008555e15af13a8fc871a04ffc38f5e60e6203bfaf01d16a2a283b90572ade79135801c1675bf38b7a5a60ec8353069796eb53a26ffdddc9ee1273be</PublicKey>
     <LangVersion>13</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LovettSoftware.XmlDiff" />

--- a/Src/CSharpier.Core/Utilities/StringBuilderExtensions.cs
+++ b/Src/CSharpier.Core/Utilities/StringBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace CSharpier.Core.Utilities;
@@ -20,6 +21,10 @@ internal static class StringBuilderExtensions
         value.Append(otherValue);
     }
 #endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Append(this ref ValueListBuilder<char> builder, string text) =>
+        builder.Append(text.AsSpan());
 
     public static void TrimStart(this StringBuilder value, params ReadOnlySpan<char> trimChars)
     {

--- a/Src/CSharpier.Core/Utilities/ValueListBuilder.cs
+++ b/Src/CSharpier.Core/Utilities/ValueListBuilder.cs
@@ -42,6 +42,9 @@ internal ref partial struct ValueListBuilder<T>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Clear() => Length = 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(T item)
     {
         var pos = this.pos;


### PR DESCRIPTION
- Replaces `StringBuilder` with `ValueListBuilder<char>`
- Added some extension methods to make this easier
- Uses `SkipLocalsInit` to avoid the cost to zero `stackalloc char[]`

#### Benchmarks
I have no idea why, all the new changes I make are slower in the benchmarks, even when they should be a straight upgrade 🤔 
I'm running into this issue a lot with #1542
### Before
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 133.7 ms | 2.65 ms |  3.54 ms | 133.7 ms | 2000.0000 | 1000.0000 |  31.07 MB |
| Default_CodeFormatter_Complex | 284.9 ms | 5.60 ms | 13.95 ms | 279.1 ms | 5000.0000 | 2000.0000 |  54.59 MB |


### After
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Gen2      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 136.2 ms | 2.69 ms |  5.74 ms | 134.5 ms | 2000.0000 | 1000.0000 |         - |  30.71 MB |
| Default_CodeFormatter_Complex | 285.6 ms | 5.71 ms | 14.93 ms | 278.1 ms | 6000.0000 | 3000.0000 | 1000.0000 |  53.45 MB |