### PR TITLE
perf: add `TrimStart(this StringBuilder`

### DIFF
--- a/Src/CSharpier/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier/DocPrinter/DocPrinter.cs
@@ -46,11 +46,11 @@ internal class DocPrinter
 
         this.EnsureOutputEndsWithSingleNewLine();
 
-        var result = this.Output.ToString();
         if (this.PrinterOptions.TrimInitialLines)
         {
-            result = result.TrimStart('\n', '\r');
+            this.Output.TrimStart('\n', '\r');
         }
+        var result = this.Output.ToString();
 
         return result;
     }

--- a/Src/CSharpier/Utilities/StringBuilderExtensions.cs
+++ b/Src/CSharpier/Utilities/StringBuilderExtensions.cs
@@ -21,6 +21,17 @@ internal static class StringBuilderExtensions
     }
 #endif
 
+    public static void TrimStart(this StringBuilder value, params ReadOnlySpan<char> trimChars)
+    {
+        int startIndex = 0;
+        while (startIndex < value.Length && trimChars.IndexOf(value[startIndex]) >= 0)
+        {
+            startIndex++;
+        }
+
+        value.Remove(0, startIndex);
+    }
+
     public static bool EndsWithNewLineAndWhitespace(this StringBuilder stringBuilder)
     {
         for (var index = 1; index <= stringBuilder.Length; index++)


### PR DESCRIPTION
Prevents duplication of the result string, saving memory in certain cases, ie. a preprocessor directive at the start of a file.

#### Benchmarks (timing is inaccurate didn't bother rerunning it)
### Before
| Method                        | Mean      | Error    | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |----------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   |  98.32 ms | 1.954 ms | 2.327 ms | 2000.0000 | 1000.0000 |  31.07 MB |
| Default_CodeFormatter_Complex | 206.40 ms | 3.671 ms | 5.716 ms | 5000.0000 | 2000.0000 |  54.58 MB |

### After
| Method                        | Mean      | Error    | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |----------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   |  86.67 ms | 1.675 ms | 1.929 ms | 2000.0000 | 1000.0000 |  31.07 MB |
| Default_CodeFormatter_Complex | 182.89 ms | 3.469 ms | 6.766 ms | 5000.0000 | 2000.0000 |  52.47 MB |