### PR TITLE
Handle weird edge case with switch expression inside parenthesized expression followed by a long invocation chain

### DIFF
--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SwitchExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/SwitchExpressions.test
@@ -119,5 +119,16 @@ class ClassName
                 "someLongString________________________________________________________________"
             ),
         };
+
+        (
+            someValue switch
+            {
+                someValue => 1,
+                _ => 2,
+            }
+        )
+            .SomeLongMethodCall______________________________()
+            .SomeLongMethodCall______________________________()
+            .SomeLongMethodCall______________________________();
     }
 }

--- a/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -106,6 +106,8 @@ internal static class InvocationExpression
                         is ArrayCreationExpressionSyntax
                             or ObjectCreationExpressionSyntax { Initializer: not null }
                 )
+            || groups[0].First().Node
+                is ParenthesizedExpressionSyntax { Expression: SwitchExpressionSyntax }
             ? expanded
             : Doc.ConditionalGroup(Doc.Concat(oneLine), expanded);
     }


### PR DESCRIPTION
closes #1546