### PR TITLE
Use alternative library to parse csharpier- and git-ignore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ The tool command name was changed to just `csharpier`
 The assembly/exe names have changed to just `CSharpier`
 
 ### Support for ignoring files via a .gitignore [#631](https://github.com/belav/csharpier/issues/631)
-**Disabled for performance issues as of 1.0.1** see [#1588](https://github.com/belav/csharpier/issues/1588)
 CSharpier now works as follows when determining if a file should be ignored.
 
 - .gitignore files are considered when determining if a file will be ignored. A .gitignore file at the same level as a given file will take priority over a .gitignore file above it in the directory tree.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="DiffEngine" Version="6.5.7" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Ignore" Version="0.2.1" />
+    <PackageVersion Include="GitignoreParserNet" Version="0.2.0.14" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="LovettSoftware.XmlDiff" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.8" />
@@ -25,6 +25,7 @@
     <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="Scriban" Version="5.10.0" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
+    <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions" Version="21.0.29" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29" />

--- a/Src/CSharpier.Cli/CSharpier.Cli.csproj
+++ b/Src/CSharpier.Cli/CSharpier.Cli.csproj
@@ -13,10 +13,11 @@
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010049d266ea1aeae09c0abfce28b8728314d4e4807126ee8bc56155a7ddc765997ed3522908b469ae133fc49ef0bfa957df36082c1c2e0ec8cdc05a4ca4dbd4e1bea6c17fc1008555e15af13a8fc871a04ffc38f5e60e6203bfaf01d16a2a283b90572ade79135801c1675bf38b7a5a60ec8353069796eb53a26ffdddc9ee1273be</PublicKey>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ignore" />
+    <PackageReference Include="GitignoreParserNet" />
     <PackageReference Include="ini-parser-netstandard" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="NReco.Logging.File" />
+    <PackageReference Include="StrongNamer" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
-using CSharpier.Cli.Options;
-using CSharpier.Core;
 using Ignore;
 
 namespace CSharpier.Cli;
@@ -39,7 +37,6 @@ internal class IgnoreFile
         CancellationToken cancellationToken
     )
     {
-        DebugLogger.Log("Creating IgnoreFile for " + baseDirectoryPath);
         var ignoreFilePaths = FindIgnorePaths(baseDirectoryPath, fileSystem);
         if (ignoreFilePaths.Count == 0)
         {
@@ -113,11 +110,11 @@ internal class IgnoreFile
                 }
             }
 
-            // var gitIgnoreFilePath = fileSystem.Path.Combine(directoryInfo.FullName, ".gitignore");
-            // if (OptionsProvider.UseGitIgnore && fileSystem.File.Exists(gitIgnoreFilePath))
-            // {
-            //     result.Add(gitIgnoreFilePath);
-            // }
+            var gitIgnoreFilePath = fileSystem.Path.Combine(directoryInfo.FullName, ".gitignore");
+            if (fileSystem.File.Exists(gitIgnoreFilePath))
+            {
+                result.Add(gitIgnoreFilePath);
+            }
 
             directoryInfo = directoryInfo.Parent;
         }

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -184,9 +184,10 @@ internal class OptionsProvider
             directoryName,
             this.ignoreFilesByDirectory,
             (searchingDirectory) =>
-                // this.fileSystem.File.Exists(Path.Combine(searchingDirectory, ".gitignore"))
-                //||
-                this.fileSystem.File.Exists(Path.Combine(searchingDirectory, ".csharpierignore")),
+                this.fileSystem.File.Exists(Path.Combine(searchingDirectory, ".gitignore"))
+                || this.fileSystem.File.Exists(
+                    Path.Combine(searchingDirectory, ".csharpierignore")
+                ),
             (searchingDirectory) =>
                 IgnoreFile.CreateAsync(searchingDirectory, this.fileSystem, cancellationToken)
         );

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -542,8 +542,8 @@ public class CommandLineFormatterTests
     public void Multiple_Files_Should_Use_Root_Ignore()
     {
         var context = new TestContext();
-        var unformattedFilePath1 = "SubFolder/1/File1.cs";
-        var unformattedFilePath2 = "SubFolder/2/File2.cs";
+        var unformattedFilePath1 = "Subfolder/1/File1.cs";
+        var unformattedFilePath2 = "Subfolder/2/File2.cs";
         context.WhenAFileExists(unformattedFilePath1, UnformattedClassContent);
         context.WhenAFileExists(unformattedFilePath2, UnformattedClassContent);
         context.WhenAFileExists(".csharpierignore", "Subfolder/**/*.cs");
@@ -604,25 +604,6 @@ public class CommandLineFormatterTests
         var result = Format(context, directoryOrFilePaths: unformattedFilePath1);
 
         result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
-    }
-
-    [Test]
-    public void Ignore_Reports_Errors()
-    {
-        var context = new TestContext();
-        context.WhenAFileExists("Test.cs", UnformattedClassContent);
-        var path = context.WhenAFileExists(".csharpierignore", @"\Src\Uploads\*.cs");
-
-        var result = Format(context);
-
-        result.ExitCode.Should().Be(1);
-        result
-            .ErrorOutputLines.First()
-            .Should()
-            .Contain(
-                $"Error The .csharpierignore file at {path} could not be parsed due to the following line:"
-            );
-        result.ErrorOutputLines.Skip(1).First().Should().Contain(@"\Src\Uploads\*.cs");
     }
 
     [TestCase("File.cs", "!File.cs", false)]

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -628,7 +628,7 @@ public class CommandLineFormatterTests
     [TestCase("File.cs", "!File.cs", false)]
     [TestCase("", "File.cs", true)]
     [TestCase("!File.cs", "File.cs", true)]
-    // [TestCase("File.cs", "", true)]
+    [TestCase("File.cs", "", true)]
     public void CSharpier_Ignore_And_Git_Ignore_Root_Level(
         string gitIgnoreContents,
         string csharpierIgnoreContents,
@@ -651,7 +651,7 @@ public class CommandLineFormatterTests
     [TestCase("File.cs", "!File.cs", false)]
     [TestCase("", "File.cs", true)]
     [TestCase("!File.cs", "File.cs", true)]
-    // [TestCase("File.cs", "", true)]
+    [TestCase("File.cs", "", true)]
     public void CSharpier_Ignore_And_Git_Ignore_Sub_Level(
         string gitIgnoreContents,
         string csharpierIgnoreContents,
@@ -671,28 +671,28 @@ public class CommandLineFormatterTests
             .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
     }
 
-    // [TestCase("File.cs", "!File.cs", false)]
-    // [TestCase("", "File.cs", true)]
-    // [TestCase("!File.cs", "File.cs", true)]
-    // [TestCase("File.cs", "", true)]
-    // public void Two_Git_Ignores(
-    //     string rootGitIgnoreContents,
-    //     string subGitIgnoreContents,
-    //     bool isIgnored
-    // )
-    // {
-    //     var context = new TestContext();
-    //     context.WhenAFileExists("Sub/File.cs", UnformattedClassContent);
-    //     context.WhenAFileExists(".gitignore", rootGitIgnoreContents);
-    //     context.WhenAFileExists("Sub/.gitignore", subGitIgnoreContents);
-    //
-    //     var result = Format(context);
-    //
-    //     result
-    //         .OutputLines.FirstOrDefault()
-    //         .Should()
-    //         .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
-    // }
+    [TestCase("File.cs", "!File.cs", false)]
+    [TestCase("", "File.cs", true)]
+    [TestCase("!File.cs", "File.cs", true)]
+    [TestCase("File.cs", "", true)]
+    public void Two_Git_Ignores(
+        string rootGitIgnoreContents,
+        string subGitIgnoreContents,
+        bool isIgnored
+    )
+    {
+        var context = new TestContext();
+        context.WhenAFileExists("Sub/File.cs", UnformattedClassContent);
+        context.WhenAFileExists(".gitignore", rootGitIgnoreContents);
+        context.WhenAFileExists("Sub/.gitignore", subGitIgnoreContents);
+
+        var result = Format(context);
+
+        result
+            .OutputLines.FirstOrDefault()
+            .Should()
+            .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
+    }
 
     [Test]
     public void Write_Stdout_Should_Only_Write_File()

--- a/docs/Ignore.md
+++ b/docs/Ignore.md
@@ -17,8 +17,6 @@ Uploads/
 ```
 
 ### .gitignore
-**Disabled for performance issues as of 1.0.1** see [#1588](https://github.com/belav/csharpier/issues/1588)
-
 CSharpier will read the contents of `.gitignore` files and use them in addition to a `.csharpierignore` file to determine if a file should be ignored.
 
 If a directory tree contains a `.csharpierignore` file then patterns in that file will always take priority over any `.gitignore` file in the same tree.


### PR DESCRIPTION
Using gitignore parser library instead of building ignore rules ourselves improves csharpier performance drastically even with large repositories and a lot of ignore rules.

This would introduce a potentially breaking change as the rules are now case-sensitive by default since git is as well.

I had to remove one unit test as we would not parse the ignore-files ourselves anymore as well as alter one which was testing case-insensitive paths.