### PR TITLE
Changes to ensure we don't do the same work to create ignore files in two different threads.

### DIFF
--- a/Src/CSharpier.Cli/EditorConfig/EditorConfigFileParser.cs
+++ b/Src/CSharpier.Cli/EditorConfig/EditorConfigFileParser.cs
@@ -25,6 +25,7 @@ internal static class EditorConfigFileParser
 
     public static EditorConfigFile Parse(string filePath, IFileSystem fileSystem)
     {
+        // TODO parallel it seems we re-read this file, should it also use the semaphore?
         DebugLogger.Log("Reading file at " + filePath);
         var directory = fileSystem.Path.GetDirectoryName(filePath);
 

--- a/Src/CSharpier.Cli/EditorConfig/EditorConfigFileParser.cs
+++ b/Src/CSharpier.Cli/EditorConfig/EditorConfigFileParser.cs
@@ -25,8 +25,6 @@ internal static class EditorConfigFileParser
 
     public static EditorConfigFile Parse(string filePath, IFileSystem fileSystem)
     {
-        // TODO parallel it seems we re-read this file, should it also use the semaphore?
-        DebugLogger.Log("Reading file at " + filePath);
         var directory = fileSystem.Path.GetDirectoryName(filePath);
 
         ArgumentNullException.ThrowIfNull(directory);

--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using CSharpier.Core;
-using CSharpier.Core.CSharp.SyntaxPrinter.SyntaxNodePrinters;
 
 namespace CSharpier.Cli;
 

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -64,10 +64,11 @@ internal class OptionsProvider
         }
 
         var specifiedEditorConfig = editorConfigPath is not null
-            ? EditorConfigLocator.FindForDirectoryName(
+            ? await EditorConfigLocator.FindForDirectoryNameAsync(
                 Path.GetDirectoryName(editorConfigPath)!,
                 fileSystem,
-                ignoreFile
+                ignoreFile,
+                cancellationToken
             )
             : null;
 
@@ -89,7 +90,12 @@ internal class OptionsProvider
         if (editorConfigPath is null)
         {
             optionsProvider.editorConfigByDirectory[directoryName] =
-                EditorConfigLocator.FindForDirectoryName(directoryName, fileSystem, ignoreFile);
+                await EditorConfigLocator.FindForDirectoryNameAsync(
+                    directoryName,
+                    fileSystem,
+                    ignoreFile,
+                    cancellationToken
+                );
         }
 
         return optionsProvider;
@@ -167,10 +173,11 @@ internal class OptionsProvider
             searchingDirectory =>
                 this.fileSystem.File.Exists(Path.Combine(searchingDirectory, ".editorconfig")),
             async searchingDirectory =>
-                EditorConfigLocator.FindForDirectoryName(
+                await EditorConfigLocator.FindForDirectoryNameAsync(
                     searchingDirectory,
                     this.fileSystem,
-                    await this.FindIgnoreFileAsync(searchingDirectory, cancellationToken)
+                    await this.FindIgnoreFileAsync(searchingDirectory, cancellationToken),
+                    cancellationToken
                 )
         );
     }

--- a/Src/CSharpier.Core/SharedFunc.cs
+++ b/Src/CSharpier.Core/SharedFunc.cs
@@ -29,6 +29,7 @@ internal sealed class SharedFunc<T> : SemaphoreSlim
         finally
         {
             workspace.Release();
+            RunningFuncs.TryRemove(key, out _);
         }
 
         return workspace.result.Result;

--- a/Src/CSharpier.Core/SharedFunc.cs
+++ b/Src/CSharpier.Core/SharedFunc.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+
+namespace CSharpier.Core;
+
+internal sealed class SharedFunc<T> : SemaphoreSlim
+{
+    private OperationResult result;
+    private static readonly ConcurrentDictionary<string, SharedFunc<T>> RunningFuncs = new();
+
+    private SharedFunc()
+        : base(1, int.MaxValue) { }
+
+    public static async Task<T> GetOrAddAsync(
+        string key,
+        Func<Task<T>> factory,
+        CancellationToken cancellationToken
+    )
+    {
+        var workspace = RunningFuncs.GetOrAdd(key, _ => new());
+        await workspace.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (!workspace.result.HasResult)
+            {
+                workspace.result = new(await factory());
+            }
+        }
+        finally
+        {
+            workspace.Release();
+        }
+
+        return workspace.result.Result;
+    }
+
+    private readonly struct OperationResult(T result)
+    {
+        public readonly bool HasResult = true;
+        public readonly T Result = result;
+    }
+}

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 namespace CSharpier.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.None)]
 public class CommandLineFormatterTests
 {
     private const string UnformattedClassContent = "public class ClassName { public int Field; }";

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace CSharpier.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.None)]
 public class CommandLineFormatterTests
 {
     private const string UnformattedClassContent = "public class ClassName { public int Field; }";

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 namespace CSharpier.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.Fixtures)]
 public class OptionsProviderTests
 {
     [Test]

--- a/Src/CSharpier.Tests/SharedFuncTests.cs
+++ b/Src/CSharpier.Tests/SharedFuncTests.cs
@@ -1,0 +1,52 @@
+using CSharpier.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CSharpier.Tests;
+
+[TestFixture]
+public class SharedFuncTests
+{
+    [Test]
+    public static async Task TwoAwaitsOneRunAsync()
+    {
+        var result = 0;
+        await Task.WhenAll(
+            Task.Run(async () =>
+            {
+                result = await SharedFunc<int>.GetOrAddAsync(
+                    "1",
+                    async () =>
+                    {
+                        await Task.Delay(1000);
+                        return 1;
+                    },
+                    CancellationToken.None
+                );
+            }),
+            Task.Run(async () =>
+            {
+                await Task.Delay(100);
+                result = await SharedFunc<int>.GetOrAddAsync(
+                    "1",
+                    async () =>
+                    {
+                        await Task.Delay(1000);
+                        return 2;
+                    },
+                    CancellationToken.None
+                );
+            })
+        );
+
+        result.Should().Be(1);
+    }
+
+    private static async Task<T> DelayAsync<T>(int millisecondsDelay, T value)
+    {
+        using var delay = Task.Delay(millisecondsDelay);
+        await delay;
+
+        return value;
+    }
+}


### PR DESCRIPTION
Part of #1588, based on #1591 to help avoid any conflicts.

Initial POC shows that we don't redo the work anymore creating `IgnoreFile`, but there are some bugs to address.