### PR TITLE
docs: fix pre-commit task-runner.json

### DIFF
--- a/docs/Pre-commit.md
+++ b/docs/Pre-commit.md
@@ -66,7 +66,15 @@ Modify the file at `.husky/task-runner.json`. Include any file extensions that y
         "name": "Run csharpier",
         "command": "dotnet",
         "args": [ "csharpier", "format", "${staged}" ],
-        "include": [ "**/*.{cs,csx,config,csproj,props,slnx,targets,xaml,xml}" ]
+        "include": [
+            "**/*.cs",
+            "**/*.csx",
+            "**/*.csproj",
+            "**/*.props",
+            "**/*.targets",
+            "**/*.xml",
+            "**/*.config"
+        ]
     }]
 }
 ```


### PR DESCRIPTION
Running the suggested task-runner.json before would match no files, as husky .net does not support the {a,b} splitting pattern.

before:
<img width="353" height="83" alt="image" src="https://github.com/user-attachments/assets/0e7a4131-2224-4b77-bc32-f62d6efebe03" />
after:
<img width="370" height="122" alt="image" src="https://github.com/user-attachments/assets/e8344a43-089d-418f-b784-10f603335660" />