### PR TITLE
docs: fix missing format command in pre-commit config

### DIFF
--- a/docs/Pre-commit.md
+++ b/docs/Pre-commit.md
@@ -42,7 +42,7 @@ repos:
         description: Install the .NET tools listed at .config/dotnet-tools.json.
       - id: csharpier
         name: Run CSharpier on C# files
-        entry: dotnet tool run CSharpier
+        entry: dotnet tool run CSharpier format
         language: system
         types:
           - c#


### PR DESCRIPTION
The command for running the CSharpier tool is `dotnet tool run CSharpier format FILENAME`. `format` was missing in the sample hook configuration.