### PR TITLE
Fix NullPointerException in CSharpier Rider plugin when directories are inaccessible

### DIFF
--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
@@ -204,9 +204,14 @@ public class CSharpierProcessProvider implements DocumentListener, Disposable, I
 
     private String findVersionInCsProj(Path currentDirectory) {
         this.logger.debug("Looking for " + currentDirectory + "/*.csproj");
-        for (var pathToCsProj : currentDirectory
-            .toFile()
-            .listFiles((dir, name) -> name.toLowerCase().endsWith(".csproj"))) {
+        File[] csProjFiles = currentDirectory.toFile()
+            .listFiles((dir, name) -> name.toLowerCase().endsWith(".csproj"));
+        if (csProjFiles == null) {
+            this.logger.debug("Unable to list files in directory: " + currentDirectory +
+                " (directory may not exist, not be a directory, or be temporarily inaccessible)");
+            return null;
+        }
+        for (var pathToCsProj : csProjFiles) {
             try {
                 var xmlDocument = DocumentBuilderFactory.newInstance()
                     .newDocumentBuilder()


### PR DESCRIPTION
## Summary
- Fixed NullPointerException in `CSharpierProcessProvider.findVersionInCsProj()` method
- Added defensive null check for `File.listFiles()` return value
- Enhanced debug logging for directory access failures

## Problem
The Rider plugin was crashing with NPE when Git filesystem operations made directories temporarily inaccessible, causing `File.listFiles()` to return null. The enhanced for loop would then throw NullPointerException when trying to iterate over the null array.

## Error Details
**Environment:** Linux Mint Debian Edition, CSharpier plugin 2.2.2, Rider 2025.2.1

**Stack trace from IDE Internal Errors dialog:**
```
java.lang.NullPointerException
	at com.intellij.csharpier.CSharpierProcessProvider.findVersionInCsProj(CSharpierProcessProvider.java:207)
	at com.intellij.csharpier.CSharpierProcessProvider.findVersionInCsProjOfParentsDirectories(CSharpierProcessProvider.java:188)
	at com.intellij.csharpier.CSharpierProcessProvider.getCSharpierVersion(CSharpierProcessProvider.java:128)
```

## Solution
Added defensive programming pattern:
- Store `listFiles()` result in variable before iteration
- Check for null and return gracefully with debug logging
- Maintain normal functionality when directories are accessible

## Test plan
- [x] Code compiles and builds successfully
- [x] Fix prevents NPE when directories are inaccessible
- [x] Normal functionality preserved when directories are accessible
- [x] Appropriate debug logging added for troubleshooting