### PR TITLE
Break before operator on expression-bodied methods

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ArrowExpressionClause.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ArrowExpressionClause.cs
@@ -9,9 +9,11 @@ internal static class ArrowExpressionClause
     {
         return Doc.Group(
             Doc.Indent(
+                Doc.IfBreak("", " "),
+                Doc.SoftLine,
+                Token.Print(node.ArrowToken, context),
                 " ",
-                Token.PrintWithSuffix(node.ArrowToken, Doc.Line, context),
-                Node.Print(node.Expression, context)
+                Doc.Indent(Node.Print(node.Expression, context))
             )
         );
     }

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/AssignmentExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/AssignmentExpressions.test
@@ -69,18 +69,18 @@ class ClassName
                 );
     }
 
-    public SomeExpressionBodyMethod() =>
-        nonChainFormatting = anotherVariable1 = (
-            someCondition________________________________
-            || someOtherCondition___________________________
-        );
+    public SomeExpressionBodyMethod()
+        => nonChainFormatting = anotherVariable1 = (
+                someCondition________________________________
+                || someOtherCondition___________________________
+            );
 
-    public SomeExpressionBodyMethod() =>
-        chainFormatting =
-            anotherVariable1 =
-            anotherVariable2 =
-                (
-                    someCondition________________________________
-                    || someOtherCondition___________________________
-                );
+    public SomeExpressionBodyMethod()
+        => chainFormatting =
+                anotherVariable1 =
+                anotherVariable2 =
+                    (
+                        someCondition________________________________
+                        || someOtherCondition___________________________
+                    );
 }

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/BinaryExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/BinaryExpressions.test
@@ -1,8 +1,8 @@
 class TestClass
 {
-    public string SomeProperty =>
-        "someLongStringValue__________________________"
-        + "someOtherLongStringValue_______________________________";
+    public string SomeProperty
+        => "someLongStringValue__________________________"
+            + "someOtherLongStringValue_______________________________";
 
     void TestMethod()
     {

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/CollectionExpressions.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/CollectionExpressions.test
@@ -107,28 +107,28 @@ class MyClass
         _items ??= [];
     }
 
-    public TheoryData<string[]> ArgsData =>
-        [
-            [],
-            [ArgConstants.UseProgramMain],
-            [ArgConstants.GlobalInteractivity, ArgConstants.WebAssemblyInteractivity],
-            [
-                ArgConstants.NoInteractivity,
-                ArgConstants.UseProgramMain,
-                ArgConstants.NoHttps,
-                ArgConstants.Empty,
-            ],
-        ];
+    public TheoryData<string[]> ArgsData
+        => [
+                [],
+                [ArgConstants.UseProgramMain],
+                [ArgConstants.GlobalInteractivity, ArgConstants.WebAssemblyInteractivity],
+                [
+                    ArgConstants.NoInteractivity,
+                    ArgConstants.UseProgramMain,
+                    ArgConstants.NoHttps,
+                    ArgConstants.Empty,
+                ],
+            ];
 
-    public ReadOnlySpan<HttpMethod> Methods() =>
-        [
-            HttpMethod.None,
-            HttpMethod.Put,
-            HttpMethod.Post,
-            HttpMethod.Patch,
-            HttpMethod.None,
-            HttpMethod.Connect,
-        ];
+    public ReadOnlySpan<HttpMethod> Methods()
+        => [
+                HttpMethod.None,
+                HttpMethod.Put,
+                HttpMethod.Post,
+                HttpMethod.Patch,
+                HttpMethod.None,
+                HttpMethod.Connect,
+            ];
 
     public List<DayOfWeek> DaysOfWeek { get; } =
     [

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ConversionOperatorDeclarations.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ConversionOperatorDeclarations.test
@@ -12,12 +12,11 @@ class Test
         return new Test();
     }
 
-    public static implicit operator Test(Person p) =>
-        new Test(p.First + "                        " + p.Last);
+    public static implicit operator Test(Person p)
+        => new Test(p.First + "                        " + p.Last);
 
     public static implicit operator Test(int x) => new Test(x);
 
-    public static implicit operator Test(
-        bool reallyLongNameThatWillMakeThisBreak________________
-    ) => new Test(x);
+    public static implicit operator Test(bool reallyLongNameThatWillMakeThisBreak________________)
+        => new Test(x);
 }

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/Directives.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/Directives.test
@@ -18,10 +18,10 @@ public class ClassName
 {
     public bool SomeProperty =>
 #if !DEBUG
-        someValue
-        && // trailing comment with endif should work properly
+            someValue
+            && // trailing comment with endif should work properly
 #endif
-        someOtherValue;
+            someOtherValue;
 
     void MethodWithOnlyDisabled()
     {

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ExpressionBodies.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ExpressionBodies.test
@@ -1,0 +1,53 @@
+public class ClassName
+{
+    public string LambdaBod => this.Property;
+
+    public string LongNameForcesALineBreakSoWeCanTestEvenLonger____________________
+        => this.Property;
+
+    public SomeExpressionBodyMethod()
+        => nonChainFormatting = anotherVariable1 = (
+                someCondition________________________________
+                || someOtherCondition___________________________
+            );
+
+    public SomeExpressionBodyMethod()
+        => chainFormatting =
+                anotherVariable1 =
+                anotherVariable2 =
+                    (
+                        someCondition________________________________
+                        || someOtherCondition___________________________
+                    );
+
+    public void MethodName()
+    {
+        CallMethod(() =>
+            CallOtherMethod___________________________________________________________()
+        );
+    }
+
+    public void Complicated()
+    {
+        someLongAssObject.SomeLongAssFunction(
+            (someLongAssArg, someLongerAsserArg) =>
+                someLongAssArg.SomeLongAssMethod(someLongerAsserArg.SomeLongAssProperty)
+        );
+    }
+
+    private bool ShouldNotBeDescribedKind(ITypeDefinition typeDefinition)
+        => typeDefinition.Kind switch
+            {
+                TypeKind.Class => (_configuration.Kinds & DescribeKind.Class) != DescribeKind.Class,
+                TypeKind.Interface => (_configuration.Kinds & DescribeKind.Interface)
+                    != DescribeKind.Interface,
+                TypeKind.Struct => (_configuration.Kinds & DescribeKind.Struct)
+                    != DescribeKind.Struct,
+                TypeKind.Delegate => (_configuration.Kinds & DescribeKind.Delegate)
+                    != DescribeKind.Delegate,
+                TypeKind.Enum => (_configuration.Kinds & DescribeKind.Enum) != DescribeKind.Enum,
+                TypeKind.Void or TypeKind.NInt or TypeKind.NUInt or TypeKind.FunctionPointer =>
+                    throw new UnreachableException(),
+                _ => true,
+            };
+}

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MethodDeclarations.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/MethodDeclarations.test
@@ -55,8 +55,8 @@ public class ClassName
 
     private Doc ShortMethod() => Method();
 
-    private Doc ShortishMethod(SomeClass one) =>
-        CallSomeOtherLongMethodSoThatItBreaks____________________(one);
+    private Doc ShortishMethod(SomeClass one)
+        => CallSomeOtherLongMethodSoThatItBreaks____________________(one);
 
     private Doc MethodWithParameters_______________________(
         SomeClass one,

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ObnoxiousEdgeCases.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ObnoxiousEdgeCases.test
@@ -61,12 +61,12 @@ class ClassName
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
             TAccountClaimsPrincipalFactory
     >(this IRemoteAuthenticationBuilder<RemoteAuthenticationState, RemoteUserAccount> builder)
-        where TAccountClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount> =>
-        builder.AddAccountClaimsPrincipalFactory<
-            RemoteAuthenticationState,
-            RemoteUserAccount,
-            TAccountClaimsPrincipalFactory
-        >();
+        where TAccountClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount>
+        => builder.AddAccountClaimsPrincipalFactory<
+                RemoteAuthenticationState,
+                RemoteUserAccount,
+                TAccountClaimsPrincipalFactory
+            >();
 
     private static readonly Action<IApplicationBuilder> ActionNotImplemented =
         new Action<IApplicationBuilder>(_ =>
@@ -88,37 +88,35 @@ class ClassName
         }
     }
 
-    public void Condition(
-        Func<ConditionParameters<TSource, TDestination, TMember>, bool> condition
-    ) =>
-        PathMapActions.Add(pm =>
-        {
-            Expression<
-                Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>
-            > expr = (src, dest, srcMember, destMember, ctxt) =>
-                condition(
-                    new ConditionParameters<TSource, TDestination, TMember>(
-                        src,
-                        dest,
-                        srcMember,
-                        destMember,
-                        ctxt
-                    )
-                );
-            pm.Condition = expr;
-        });
+    public void Condition(Func<ConditionParameters<TSource, TDestination, TMember>, bool> condition)
+        => PathMapActions.Add(pm =>
+            {
+                Expression<
+                    Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>
+                > expr = (src, dest, srcMember, destMember, ctxt) =>
+                    condition(
+                        new ConditionParameters<TSource, TDestination, TMember>(
+                            src,
+                            dest,
+                            srcMember,
+                            destMember,
+                            ctxt
+                        )
+                    );
+                pm.Condition = expr;
+            });
 
     public override Type SourceType
     {
-        get =>
-            _sourceType ??=
-                CustomMapExpression?.ReturnType
-                ?? CustomMapFunction?.ReturnType
-                ?? (
-                    _sourceMembers.Length > 0
-                        ? _sourceMembers[_sourceMembers.Length - 1].GetMemberType()
-                        : Parameter.ParameterType
-                );
+        get
+            => _sourceType ??=
+                    CustomMapExpression?.ReturnType
+                    ?? CustomMapFunction?.ReturnType
+                    ?? (
+                        _sourceMembers.Length > 0
+                            ? _sourceMembers[_sourceMembers.Length - 1].GetMemberType()
+                            : Parameter.ParameterType
+                    );
         protected set => _sourceType = value;
     }
 
@@ -126,14 +124,18 @@ class ClassName
         this Expression expression,
         Expression then,
         Expression @else
-    ) =>
-        expression.Type.IsValueType
-            ? (
-                expression.Type.IsNullableType()
-                    ? Condition(Property(expression, "HasValue"), ToType(@else, then.Type), then)
-                    : @else
-            )
-            : Condition(ReferenceEqual(expression, Null), then, ToType(@else, then.Type));
+    )
+        => expression.Type.IsValueType
+                ? (
+                    expression.Type.IsNullableType()
+                        ? Condition(
+                            Property(expression, "HasValue"),
+                            ToType(@else, then.Type),
+                            then
+                        )
+                        : @else
+                )
+                : Condition(ReferenceEqual(expression, Null), then, ToType(@else, then.Type));
 
     private bool VisitChildForCompare(Pair<XmlNode> tuple, ref int result)
     {

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/PropertyDeclarations.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/PropertyDeclarations.test
@@ -28,8 +28,8 @@ public class ClassName
 
     public string LambdaBod => this.Property;
 
-    public string LongNameForcesALineBreakSoWeCanTestEvenLonger____________________ =>
-        this.Property;
+    public string LongNameForcesALineBreakSoWeCanTestEvenLonger____________________
+        => this.Property;
 
     public string Property
     {


### PR DESCRIPTION
An experimental change to support the discussion in #205. I have no strong feelings about whether this should be merged, but wanted to put it out there.