### PR TITLE
Fix condition causing FirstTargetFramework build property erasure

### DIFF
--- a/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
+++ b/Src/CSharpier.MsBuild/build/CSharpier.MsBuild.targets
@@ -10,7 +10,7 @@
     <CSharpierCommand Condition="'$(CSharpier_Check)' == 'true'">check</CSharpierCommand>
     <CSharpierArgs Condition="'$(CSharpier_LogLevel)' != ''">$(CSharpierArgs) --log-level $(CSharpier_LogLevel)</CSharpierArgs>
     <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
-    <FirstTargetFramework Condition=" '$(FirstTargetFrameworks)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
+    <FirstTargetFramework Condition=" '$(FirstTargetFramework)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
     <NullOutput>NUL</NullOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
Many of my test projects fail to build when `csharpier` is added to them. They fail with this message:

```
Build FAILED.

"/Users/danny/src/tdg5/csharpier-build-issue-reproduction/App.Tests.csproj" (Rebuild target) (1:7) ->
"/Users/danny/src/tdg5/csharpier-build-issue-reproduction/App.Tests.csproj" (CSharpierFormatInner target) (1:8) ->
  /usr/local/share/dotnet/sdk/9.0.300/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(201,38):
    error MSB4184: The expression "[MSBuild]::VersionLessThan('', 6.0)" cannot be
    evaluated. Version string was not in a correct format.
    [/Users/danny/src/tdg5/csharpier-build-issue-reproduction/App.Tests.csproj]
```

For some reason, I only run into this problem with my test projects that include `xunit.v3`, but I'm fairly certain this is a `csharpier` issue.

A minimal reproduction of the issue can be found at [tdg5/csharpier-build-issue-reproduction](https://github.com/tdg5/csharpier-build-issue-reproduction).

I believe the issue is that the `FirstTargetFramework` build property is getting clobbered due to a typo in a condition that's meant to check if `FirstTargetFramework` already has a value, but fails to do so because of the typo.

This PR fixes the typo and my build failures.

Let me know if I can answer any questions or provide any other context. Thanks!