### PR TITLE
fix: prevent race condition for `GroupWithNewId`

### DIFF
--- a/Src/CSharpier.Core/DocTypes/Doc.cs
+++ b/Src/CSharpier.Core/DocTypes/Doc.cs
@@ -110,8 +110,7 @@ internal abstract class Doc
 
     public static Group GroupWithNewId(out string groupId, Doc contents)
     {
-        groupId = "Group_" + groupNumber;
-        Interlocked.Increment(ref groupNumber);
+        groupId = "Group_" + Interlocked.Increment(ref groupNumber);
         var group = Group(contents);
         group.GroupId = groupId;
         return group;


### PR DESCRIPTION
Multiple threads calling `GroupWithNewId` may read the same value of `groupNumber` resulting in duplicate `groudId`'s.

This method isn't used, but hasn't been deleted yet, so I thought I'd fix this.

```C#
var hash = new ConcurrentDictionary<int,int>();
var range = Enumerable.Range(0, 1_000_000).ToArray();

Parallel.ForEach(range, (_) =>
{
    var val = groupNumber;
    Interlocked.Increment(ref groupNumber);
    // val = Interlocked.Increment(ref groupNumber); // this fixes the issue
    hash.TryAdd(val, 0);
});

Console.WriteLine(hash.Count);

// 714524 (should be 1000000)
```