### PR TITLE
perf: use `ValueListBuilder` for `BaseMethodDeclaration`

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
@@ -89,6 +89,6 @@ internal static class AttributeList
 
         docs.Append(Token.Print(node.CloseBracketToken, context));
 
-        return Doc.Group(docs.AsSpan().ToArray());
+        return Doc.Group(ref docs);
     }
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -80,19 +80,21 @@ internal static partial class BaseMethodDeclaration
             semicolonToken = localFunctionStatementSyntax.SemicolonToken;
         }
 
-        var docs = new List<Doc>();
-        var declarationGroup = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null, null]);
 
         if (node is LocalFunctionStatementSyntax)
         {
-            docs.Add(ExtraNewLines.Print(node));
+            docs.Append(ExtraNewLines.Print(node));
         }
 
         if (attributeLists is { Count: > 0 })
         {
-            docs.Add(AttributeLists.Print(node, attributeLists.Value, context));
+            docs.Append(AttributeLists.Print(node, attributeLists.Value, context));
 
-            void PrintMethodUnformattedWithoutAttributes(SyntaxTriviaList syntaxTriviaList)
+            void PrintMethodUnformattedWithoutAttributes(
+                SyntaxTriviaList syntaxTriviaList,
+                ref ValueListBuilder<Doc> docs
+            )
             {
                 var attributeStart = attributeLists
                     .Value[0]
@@ -110,7 +112,7 @@ internal static partial class BaseMethodDeclaration
                     .ToString()
                     .Trim();
 
-                docs.Add(
+                docs.Append(
                     RemoveWhiteSpaceLineEndingsRegex.Replace(
                         methodWithoutAttributes,
                         context.Options.LineEnding
@@ -122,21 +124,32 @@ internal static partial class BaseMethodDeclaration
             {
                 if (CSharpierIgnore.HasIgnoreComment(modifiers.Value[0]))
                 {
-                    PrintMethodUnformattedWithoutAttributes(modifiers.Value[0].LeadingTrivia);
-                    return Doc.Group(docs);
+                    PrintMethodUnformattedWithoutAttributes(
+                        modifiers.Value[0].LeadingTrivia,
+                        ref docs
+                    );
+                    var returnDoc = Doc.Group(ref docs);
+                    docs.Dispose();
+                    return returnDoc;
                 }
             }
             else if (returnType is not null && CSharpierIgnore.HasIgnoreComment(returnType))
             {
-                PrintMethodUnformattedWithoutAttributes(returnType.GetLeadingTrivia());
-                return Doc.Group(docs);
+                PrintMethodUnformattedWithoutAttributes(returnType.GetLeadingTrivia(), ref docs);
+                var returnDoc = Doc.Group(ref docs);
+                docs.Dispose();
+                return returnDoc;
             }
         }
 
+        var declarationGroup = new ValueListBuilder<Doc>(
+            [null, null, null, null, null, null, null, null]
+        );
+
         if (modifiers is { Count: > 0 })
         {
-            docs.Add(Token.PrintLeadingTrivia(modifiers.Value[0], context));
-            declarationGroup.Add(
+            docs.Append(Token.PrintLeadingTrivia(modifiers.Value[0], context));
+            declarationGroup.Append(
                 Modifiers.PrintSorterWithoutLeadingTrivia(modifiers.Value, context)
             );
         }
@@ -145,17 +158,17 @@ internal static partial class BaseMethodDeclaration
         {
             if (modifiers is not { Count: > 0 })
             {
-                docs.Add(Token.PrintLeadingTrivia(returnType.GetLeadingTrivia(), context));
+                docs.Append(Token.PrintLeadingTrivia(returnType.GetLeadingTrivia(), context));
                 context.State.SkipNextLeadingTrivia = true;
             }
 
-            declarationGroup.Add(Node.Print(returnType, context), " ");
+            declarationGroup.Append(Node.Print(returnType, context), " ");
             context.State.SkipNextLeadingTrivia = false;
         }
 
         if (explicitInterfaceSpecifier != null)
         {
-            declarationGroup.Add(
+            declarationGroup.Append(
                 Node.Print(explicitInterfaceSpecifier.Name, context),
                 Token.Print(explicitInterfaceSpecifier.DotToken, context)
             );
@@ -163,12 +176,12 @@ internal static partial class BaseMethodDeclaration
 
         if (identifier != null)
         {
-            declarationGroup.Add(identifier());
+            declarationGroup.Append(identifier());
         }
 
         if (node is ConversionOperatorDeclarationSyntax conversionOperatorDeclarationSyntax)
         {
-            declarationGroup.Add(
+            declarationGroup.Append(
                 Token.PrintWithSuffix(
                     conversionOperatorDeclarationSyntax.ImplicitOrExplicitKeyword,
                     " ",
@@ -189,7 +202,7 @@ internal static partial class BaseMethodDeclaration
         }
         else if (node is OperatorDeclarationSyntax operatorDeclarationSyntax)
         {
-            declarationGroup.Add(
+            declarationGroup.Append(
                 Node.Print(operatorDeclarationSyntax.ReturnType, context),
                 " ",
                 operatorDeclarationSyntax.ExplicitInterfaceSpecifier is not null
@@ -203,24 +216,24 @@ internal static partial class BaseMethodDeclaration
 
         if (typeParameterList != null && typeParameterList.Parameters.Any())
         {
-            declarationGroup.Add(TypeParameterList.Print(typeParameterList, context));
+            declarationGroup.Append(TypeParameterList.Print(typeParameterList, context));
         }
 
         if (parameterList != null)
         {
             if (parameterList.Parameters.Any())
             {
-                declarationGroup.Add(ParameterList.Print(parameterList, context));
+                declarationGroup.Append(ParameterList.Print(parameterList, context));
             }
             else
             {
-                declarationGroup.Add(
+                declarationGroup.Append(
                     Token.Print(parameterList.OpenParenToken, context),
                     Token.Print(parameterList.CloseParenToken, context)
                 );
             }
 
-            declarationGroup.Add(Doc.IfBreak(Doc.Null, Doc.SoftLine));
+            declarationGroup.Append(Doc.IfBreak(Doc.Null, Doc.SoftLine));
         }
 
         if (constructorInitializer != null)
@@ -230,7 +243,7 @@ internal static partial class BaseMethodDeclaration
                 ArgumentList.Print(constructorInitializer.ArgumentList, context)
             );
 
-            declarationGroup.Add(
+            declarationGroup.Append(
                 Doc.Group(
                     Doc.Indent(Doc.HardLine),
                     Doc.Indent(colonToken),
@@ -240,30 +253,31 @@ internal static partial class BaseMethodDeclaration
             );
         }
 
-        docs.Add(Doc.Group(declarationGroup));
+        docs.Append(Doc.Group(ref declarationGroup));
+        declarationGroup.Dispose();
 
         if (constraintClauses != null)
         {
-            docs.Add(ConstraintClauses.Print(constraintClauses.Value, context));
+            docs.Append(ConstraintClauses.Print(constraintClauses.Value, context));
         }
 
         if (body != null)
         {
-            docs.Add(Block.Print(body, context));
+            docs.Append(Block.Print(body, context));
         }
         else
         {
             if (expressionBody != null)
             {
-                docs.Add(ArrowExpressionClause.Print(expressionBody, context));
+                docs.Append(ArrowExpressionClause.Print(expressionBody, context));
             }
         }
 
         if (semicolonToken.HasValue)
         {
-            docs.Add(Token.Print(semicolonToken.Value, context));
+            docs.Append(Token.Print(semicolonToken.Value, context));
         }
 
-        return Doc.Group(docs);
+        return Doc.Group(ref docs);
     }
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -53,6 +53,6 @@ internal static class Parameter
             docs.Append(EqualsValueClause.Print(node.Default, context));
         }
 
-        return hasAttribute ? Doc.Group(docs.AsSpan().ToArray()) : Doc.Concat(ref docs);
+        return hasAttribute ? Doc.Group(ref docs) : Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier.Core/DocTypes/Doc.cs
+++ b/Src/CSharpier.Core/DocTypes/Doc.cs
@@ -129,6 +129,9 @@ internal abstract class Doc
 
     public static Group Group(params Doc[] contents) => new() { Contents = Concat(contents) };
 
+    public static Group Group(ref ValueListBuilder<Doc> contents) =>
+        new() { Contents = Concat(ref contents) };
+
     // prevents allocating an array if there is only a single parameter
     public static IndentDoc Indent(Doc contents) => new() { Contents = contents };
 


### PR DESCRIPTION
Replace `List<Doc>` with `ValueListBuilder<Doc>`

### Benchmark (timing is inaccurate)
#### Before

| Method                        | Mean     | Error   | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 154.7 ms | 3.06 ms |  6.98 ms | 3000.0000 | 1000.0000 |  35.16 MB |
| Default_CodeFormatter_Complex | 337.9 ms | 9.81 ms | 28.93 ms | 5000.0000 | 2000.0000 |   54.8 MB |



#### After
| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 131.1 ms | 2.59 ms | 4.79 ms | 3000.0000 | 1000.0000 |  34.52 MB |
| Default_CodeFormatter_Complex | 261.1 ms | 5.16 ms | 5.07 ms | 5000.0000 | 2000.0000 |  52.37 MB |
