### PR TITLE
perf: use static `Func` to prevent unwanted closures

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -27,7 +27,7 @@ internal static partial class BaseMethodDeclaration
         TypeSyntax? returnType = null;
         ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier = null;
         TypeParameterListSyntax? typeParameterList = null;
-        Func<Doc>? identifier = null;
+        Func<CSharpSyntaxNode, PrintingContext, Doc>? identifier = null;
         SyntaxList<TypeParameterConstraintClauseSyntax>? constraintClauses = null;
         ParameterListSyntax? parameterList = null;
         ConstructorInitializerSyntax? constructorInitializer = null;
@@ -46,21 +46,32 @@ internal static partial class BaseMethodDeclaration
             {
                 returnType = methodDeclarationSyntax.ReturnType;
                 explicitInterfaceSpecifier = methodDeclarationSyntax.ExplicitInterfaceSpecifier;
-                identifier = () => Token.Print(methodDeclarationSyntax.Identifier, context);
+                identifier = static (node, context) =>
+                {
+                    var methodDeclarationSyntax = (MethodDeclarationSyntax)node;
+                    return Token.Print(methodDeclarationSyntax.Identifier, context);
+                };
                 typeParameterList = methodDeclarationSyntax.TypeParameterList;
                 constraintClauses = methodDeclarationSyntax.ConstraintClauses;
             }
-            else if (node is DestructorDeclarationSyntax destructorDeclarationSyntax)
+            else if (node is DestructorDeclarationSyntax)
             {
-                identifier = () =>
-                    Doc.Concat(
+                identifier = static (node, context) =>
+                {
+                    var destructorDeclarationSyntax = (DestructorDeclarationSyntax)node;
+                    return Doc.Concat(
                         Token.Print(destructorDeclarationSyntax.TildeToken, context),
                         Token.Print(destructorDeclarationSyntax.Identifier, context)
                     );
+                };
             }
             else if (node is ConstructorDeclarationSyntax constructorDeclarationSyntax)
             {
-                identifier = () => Token.Print(constructorDeclarationSyntax.Identifier, context);
+                identifier = static (node, context) =>
+                {
+                    var constructorDeclarationSyntax = (ConstructorDeclarationSyntax)node;
+                    return Token.Print(constructorDeclarationSyntax.Identifier, context);
+                };
                 constructorInitializer = constructorDeclarationSyntax.Initializer;
             }
 
@@ -71,7 +82,11 @@ internal static partial class BaseMethodDeclaration
             attributeLists = localFunctionStatementSyntax.AttributeLists;
             modifiers = localFunctionStatementSyntax.Modifiers;
             returnType = localFunctionStatementSyntax.ReturnType;
-            identifier = () => Token.Print(localFunctionStatementSyntax.Identifier, context);
+            identifier = static (node, context) =>
+            {
+                var localFunctionStatementSyntax = (LocalFunctionStatementSyntax)node;
+                return Token.Print(localFunctionStatementSyntax.Identifier, context);
+            };
             typeParameterList = localFunctionStatementSyntax.TypeParameterList;
             parameterList = localFunctionStatementSyntax.ParameterList;
             constraintClauses = localFunctionStatementSyntax.ConstraintClauses;
@@ -163,7 +178,7 @@ internal static partial class BaseMethodDeclaration
 
         if (identifier != null)
         {
-            declarationGroup.Add(identifier());
+            declarationGroup.Add(identifier(node, context));
         }
 
         if (node is ConversionOperatorDeclarationSyntax conversionOperatorDeclarationSyntax)

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
@@ -11,7 +11,7 @@ internal static class BasePropertyDeclaration
     {
         EqualsValueClauseSyntax? initializer = null;
         ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifierSyntax = null;
-        Func<Doc>? identifier = null;
+        Func<SyntaxNode, PrintingContext, Doc>? identifier = null;
         Doc eventKeyword = Doc.Null;
         ArrowExpressionClauseSyntax? expressionBody = null;
         SyntaxToken? semicolonToken = null;
@@ -21,25 +21,37 @@ internal static class BasePropertyDeclaration
             expressionBody = propertyDeclarationSyntax.ExpressionBody;
             initializer = propertyDeclarationSyntax.Initializer;
             explicitInterfaceSpecifierSyntax = propertyDeclarationSyntax.ExplicitInterfaceSpecifier;
-            identifier = () => Token.Print(propertyDeclarationSyntax.Identifier, context);
+            identifier = static (node, context) =>
+            {
+                var propertyDeclarationSyntax = (PropertyDeclarationSyntax)node;
+                return Token.Print(propertyDeclarationSyntax.Identifier, context);
+            };
             semicolonToken = propertyDeclarationSyntax.SemicolonToken;
         }
         else if (node is IndexerDeclarationSyntax indexerDeclarationSyntax)
         {
             expressionBody = indexerDeclarationSyntax.ExpressionBody;
             explicitInterfaceSpecifierSyntax = indexerDeclarationSyntax.ExplicitInterfaceSpecifier;
-            identifier = () =>
-                Doc.Concat(
+            identifier = static (node, context) =>
+            {
+                var indexerDeclarationSyntax = (IndexerDeclarationSyntax)node;
+                return Doc.Concat(
                     Token.Print(indexerDeclarationSyntax.ThisKeyword, context),
                     Node.Print(indexerDeclarationSyntax.ParameterList, context)
                 );
+            };
+
             semicolonToken = indexerDeclarationSyntax.SemicolonToken;
         }
         else if (node is EventDeclarationSyntax eventDeclarationSyntax)
         {
             eventKeyword = Token.PrintWithSuffix(eventDeclarationSyntax.EventKeyword, " ", context);
             explicitInterfaceSpecifierSyntax = eventDeclarationSyntax.ExplicitInterfaceSpecifier;
-            identifier = () => Token.Print(eventDeclarationSyntax.Identifier, context);
+            identifier = static (node, context) =>
+            {
+                var eventDeclarationSyntax = (EventDeclarationSyntax)node;
+                return Token.Print(eventDeclarationSyntax.Identifier, context);
+            };
             semicolonToken = eventDeclarationSyntax.SemicolonToken;
         }
 
@@ -56,7 +68,7 @@ internal static class BasePropertyDeclaration
                         Token.Print(explicitInterfaceSpecifierSyntax.DotToken, context)
                     )
                     : Doc.Null,
-                identifier != null ? identifier() : Doc.Null,
+                identifier != null ? identifier(node, context) : Doc.Null,
                 Contents(node, expressionBody, context),
                 initializer != null ? EqualsValueClause.Print(initializer, context) : Doc.Null,
                 semicolonToken.HasValue ? Token.Print(semicolonToken.Value, context) : Doc.Null

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseTypeDeclaration.cs
@@ -15,7 +15,7 @@ internal static class BaseTypeDeclaration
         SyntaxList<TypeParameterConstraintClauseSyntax>? constraintClauses = null;
         SyntaxToken? recordKeyword = null;
         SyntaxToken? keyword = null;
-        Func<Doc>? members = null;
+        Func<CSharpSyntaxNode, PrintingContext, Doc>? members = null;
         SyntaxToken? semicolonToken = null;
 
         if (node is TypeDeclarationSyntax typeDeclarationSyntax)
@@ -24,14 +24,17 @@ internal static class BaseTypeDeclaration
             constraintClauses = typeDeclarationSyntax.ConstraintClauses;
             if (typeDeclarationSyntax.Members.Count > 0)
             {
-                members = () =>
-                    Doc.Indent(
+                members = static (node, context) =>
+                {
+                    var typeDeclarationSyntax = (TypeDeclarationSyntax)node;
+                    return Doc.Indent(
                         MembersWithForcedLines.Print(
                             typeDeclarationSyntax,
                             typeDeclarationSyntax.Members,
                             context
                         )
                     );
+                };
             }
 
             if (node is ClassDeclarationSyntax classDeclarationSyntax)
@@ -66,14 +69,17 @@ internal static class BaseTypeDeclaration
         {
             if (enumDeclarationSyntax.Members.Count > 0)
             {
-                members = () =>
-                    Doc.Indent(
+                members = static (node, context) =>
+                {
+                    var enumDeclarationSyntax = (EnumDeclarationSyntax)node;
+                    return Doc.Indent(
                         MembersWithForcedLines.Print(
                             enumDeclarationSyntax,
                             enumDeclarationSyntax.Members,
                             context
                         )
                     );
+                };
             }
 
             keyword = enumDeclarationSyntax.EnumKeyword;
@@ -151,7 +157,7 @@ internal static class BaseTypeDeclaration
 
         if (members != null)
         {
-            var membersContent = members();
+            var membersContent = members(node, context);
 
             DocUtilities.RemoveInitialDoubleHardLine(membersContent);
 


### PR DESCRIPTION
Pass values function arguments instead of capturing them in a closure.

Not sure why `Func` is used here. I'm assuming that it's delibrately deferring the calculation because `PrintingContext` might change? IIRC calculating `indentifier` eagerly didn't cause any tests to fail.

### Benchmarks (timing is inaccurate should be the same)
#### Before
| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 133.0 ms | 2.56 ms | 2.84 ms | 3000.0000 | 1000.0000 |  34.58 MB |
| Default_CodeFormatter_Complex | 271.5 ms | 5.40 ms | 7.92 ms | 5000.0000 | 2000.0000 |  52.95 MB |


#### After
| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 129.9 ms | 2.16 ms | 3.24 ms | 3000.0000 | 1000.0000 |  34.55 MB |
| Default_CodeFormatter_Complex | 260.5 ms | 5.15 ms | 7.55 ms | 5000.0000 | 2000.0000 |  52.64 MB |

