### PR TITLE
perf: prevent closure creation in `Modifier`

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
@@ -7,28 +7,6 @@ internal static class Modifiers
 {
     private class DefaultOrder : IComparer<SyntaxToken>
     {
-        // use the default order from https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
-        private static readonly string[] DefaultOrdered =
-        [
-            "public",
-            "private",
-            "protected",
-            "internal",
-            "file",
-            "static",
-            "extern",
-            "new",
-            "virtual",
-            "abstract",
-            "sealed",
-            "override",
-            "readonly",
-            "unsafe",
-            "required",
-            "volatile",
-            "async",
-        ];
-
         public int Compare(SyntaxToken x, SyntaxToken y)
         {
             return GetIndex(x.Text) - GetIndex(y.Text);
@@ -36,12 +14,32 @@ internal static class Modifiers
 
         private static int GetIndex(string? value)
         {
-            var result = Array.IndexOf(DefaultOrdered, value);
-            return result == -1 ? int.MaxValue : result;
+            // use the default order from https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
+            return value switch
+            {
+                "public" => 0,
+                "private" => 1,
+                "protected" => 2,
+                "internal" => 3,
+                "file" => 4,
+                "static" => 5,
+                "extern" => 6,
+                "new" => 7,
+                "virtual" => 8,
+                "abstract" => 9,
+                "sealed" => 10,
+                "override" => 11,
+                "readonly" => 12,
+                "unsafe" => 13,
+                "required" => 14,
+                "volatile" => 15,
+                "async" => 16,
+                _ => int.MaxValue,
+            };
         }
     }
 
-    private static readonly DefaultOrder Comparer = new();
+    private static readonly Comparison<SyntaxToken> Comparer = new DefaultOrder().Compare;
 
     public static Doc Print(SyntaxTokenList modifiers, PrintingContext context)
     {
@@ -58,7 +56,7 @@ internal static class Modifiers
         return PrintWithSortedModifiers(
             modifiers,
             context,
-            sortedModifiers =>
+            static (sortedModifiers, context) =>
                 Doc.Group(Doc.Join(" ", sortedModifiers.Select(o => Token.Print(o, context))), " ")
         );
     }
@@ -71,7 +69,7 @@ internal static class Modifiers
         return PrintWithSortedModifiers(
             modifiers,
             context,
-            sortedModifiers =>
+            static (sortedModifiers, context) =>
                 Doc.Group(
                     Token.PrintWithoutLeadingTrivia(sortedModifiers[0], context),
                     " ",
@@ -90,7 +88,7 @@ internal static class Modifiers
     private static Doc PrintWithSortedModifiers(
         in SyntaxTokenList modifiers,
         PrintingContext context,
-        Func<IReadOnlyList<SyntaxToken>, Doc> print
+        Func<IReadOnlyList<SyntaxToken>, PrintingContext, Doc> print
     )
     {
         if (modifiers.Count == 0)
@@ -114,6 +112,6 @@ internal static class Modifiers
             context.State.ReorderedModifiers = true;
         }
 
-        return print(sortedModifiers);
+        return print(sortedModifiers, context);
     }
 }


### PR DESCRIPTION
- Use `Func<IReadOnlyList<SyntaxToken>, PrintingContext, Doc>` to prevent closure formation.
- Replace `Array.IndexOf` with a `switch` expression
- Pass `Comparison<SyntaxToken>` to `Array,Sort` to prevent delegate creation each time.

I did experiment with a `Doc.Join` overload that takes a collection, a `Func<TElement, PrintingContext, Doc>` and `PrintingContext`, it did save 1.2MB but it is ugly as sin and awkward to use.


### Benchmark (Timing is inaccurate)
#### Before
| Method                        | Mean     | Error    | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 222.8 ms | 17.65 ms | 51.50 ms | 3000.0000 | 1000.0000 |  34.58 MB |
| Default_CodeFormatter_Complex | 360.0 ms | 11.02 ms | 31.79 ms | 5000.0000 | 2000.0000 |     53 MB |





#### After
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 137.5 ms | 4.25 ms | 12.00 ms | 133.6 ms | 3000.0000 | 1000.0000 |  34.54 MB |
| Default_CodeFormatter_Complex | 268.2 ms | 5.26 ms | 13.57 ms | 263.0 ms | 5000.0000 | 2000.0000 |   52.6 MB |


