### PR TITLE
perf: replace `ToImmutableHashSet` with manual implementation

### DIFF
--- a/Src/CSharpier.Core/Utilities/ListExtensions.cs
+++ b/Src/CSharpier.Core/Utilities/ListExtensions.cs
@@ -1,5 +1,6 @@
 using CSharpier.Core.DocTypes;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace CSharpier.Core.Utilities;
 
@@ -107,5 +108,18 @@ internal static class ListExtensions
         }
 
         return true;
+    }
+
+    public static bool Contains(this ref ValueListBuilder<SyntaxKind> kinds, SyntaxKind kind)
+    {
+        foreach (var element in kinds.AsSpan())
+        {
+            if (element == kind)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Replace boxing, Linq and `ToImmutableHashSet` call with a manual `ValueListBuilder` version.

- Added a basic contains method because I can't get the built in `Span.Contains` to work generically with enums 🤷 
   - Note that the hashset rarely goes above 4 items in my tests, so we won't be missing out on any vectorisation

Thought I'd already pushed this, I'll go through my backlog and see what else I've missed



### Benchmark (timing is inaccurate)
#### Before
| Method                        | Mean     | Error   | StdDev  | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 130.5 ms | 2.59 ms | 6.11 ms | 128.2 ms | 3000.0000 | 1000.0000 |  34.58 MB |
| Default_CodeFormatter_Complex | 261.4 ms | 5.16 ms | 7.87 ms | 260.0 ms | 5000.0000 | 2000.0000 |  53.04 MB |


#### After
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 140.1 ms | 4.20 ms | 12.00 ms | 136.2 ms | 3000.0000 | 1000.0000 |  34.55 MB |
| Default_CodeFormatter_Complex | 265.4 ms | 5.20 ms |  6.95 ms | 265.9 ms | 5000.0000 | 2000.0000 |  51.99 MB |

