### PR TITLE
perf: check leading trivia span length before `GetLeadingTrivia`

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Token.cs
@@ -446,6 +446,13 @@ internal static class Token
 
     public static bool HasLeadingCommentMatching(SyntaxNode node, Regex regex)
     {
+        // exit if the leading trivia length is smaller than the smallest regex
+        var leadingTriviaLength = node.Span.Start - node.FullSpan.Start;
+        if (leadingTriviaLength < 19)
+        {
+            return false;
+        }
+
         // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
         foreach (var o in node.GetLeadingTrivia())
         {


### PR DESCRIPTION
Use underlying `TextSpan` to get the leading trivia length, if it's less than the smallest `// chsarpier-ignore` comment then we know it can't match the regex. We can then skip calling the slow `GetLeadingTriva` method.

Note that this might break if a new regex is less than 19, however this would be caught by the tests.

I wonder why the underlying roslyn implementaion doesn't do this check 🤔 Retrieving the first token when it doesn't have leading trivia seems pretty inefficient.

### Benchmarks
#### Before
| Method                        | Mean     | Error   | StdDev  | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 131.9 ms | 3.30 ms | 8.86 ms | 128.0 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 261.3 ms | 5.16 ms | 4.03 ms | 261.3 ms | 5000.0000 | 2000.0000 |  53.03 MB |

#### After (timing seems to all over the place)
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Gen2     | Allocated |        
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|---------:|----------:|        
| Default_CodeFormatter_Tests   | 134.1 ms | 6.19 ms | 18.16 ms | 133.9 ms | 3333.3333 | 1666.6667 | 333.3333 |   34.2 MB |        
| Default_CodeFormatter_Complex | 201.4 ms | 6.57 ms | 19.37 ms | 194.2 ms | 5000.0000 | 2000.0000 |        - |  52.99 MB |        

| Method                        | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 112.9 ms | 2.23 ms | 5.72 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 254.1 ms | 4.25 ms | 3.76 ms | 5000.0000 | 2000.0000 |  53.07 MB |

| Method                        | Mean      | Error    | StdDev   | Median    | Gen0      | Gen1      | Allocated |
|------------------------------ |----------:|---------:|---------:|----------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   |  93.12 ms | 1.859 ms | 5.245 ms |  91.10 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 183.21 ms | 3.538 ms | 4.960 ms | 183.62 ms | 5000.0000 | 2000.0000 |     53 MB |

| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 120.9 ms | 1.60 ms |  1.33 ms | 120.8 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 206.5 ms | 6.56 ms | 18.73 ms | 200.7 ms | 5000.0000 | 2000.0000 |  53.05 MB |


