### PR TITLE
perf: only run `PreprocessorSymbols` when `#if` found

### DIFF
--- a/Src/CSharpier.Core/CSharp/CSharpScanner.cs
+++ b/Src/CSharpier.Core/CSharp/CSharpScanner.cs
@@ -1,0 +1,47 @@
+using System.Buffers;
+using CSharpier.Core.CSharp.SyntaxPrinter;
+
+namespace CSharpier.Core.CSharp;
+
+internal static class CSharpScanner
+{
+    private const string IfPreprocessor = "#if";
+    private const string CSharpierIgnore = "// csharpier-ignore";
+
+#if NET9_0_OR_GREATER
+    private static readonly SearchValues<string> KeyValues = SearchValues.Create(
+        [IfPreprocessor, CSharpierIgnore],
+        StringComparison.Ordinal
+    );
+
+    public static PrintingContext.CodeInformation Scan(string code)
+    {
+        var index = code.AsSpan().IndexOfAny(KeyValues);
+        if (index < 0)
+        {
+            return new PrintingContext.CodeInformation(false, false);
+        }
+
+        var slice = code.AsSpan(index);
+        if (slice.StartsWith(IfPreprocessor))
+        {
+            return new PrintingContext.CodeInformation(
+                true,
+                slice.Contains(CSharpierIgnore.AsSpan(), StringComparison.Ordinal)
+            );
+        }
+
+        return new PrintingContext.CodeInformation(
+            slice.Contains(IfPreprocessor.AsSpan(), StringComparison.Ordinal),
+            true
+        );
+    }
+#else
+    public static PrintingContext.CodeInformation Scan(string code)
+    {
+        var hasPreprocessor = code.Contains(IfPreprocessor);
+        var hasCSharpierIgnore = code.Contains(CSharpierIgnore);
+        return new PrintingContext.CodeInformation(hasPreprocessor, hasCSharpierIgnore);
+    }
+#endif
+}

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/CSharpierIgnore.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/CSharpierIgnore.cs
@@ -78,15 +78,18 @@ internal static partial class CSharpierIgnore
 
         foreach (var node in list)
         {
-            if (Token.HasLeadingCommentMatching(node, IgnoreEndRegex))
+            if (context.Information.HasCSharpierIgnore)
             {
-                statements.Add(unFormattedCode.AsSpan().Trim().ToString());
-                unFormattedCode.Clear();
-                printUnformatted = false;
-            }
-            else if (Token.HasLeadingCommentMatching(node, IgnoreStartRegex))
-            {
-                printUnformatted = true;
+                if (Token.HasLeadingCommentMatching(node, IgnoreEndRegex))
+                {
+                    statements.Add(unFormattedCode.AsSpan().Trim().ToString());
+                    unFormattedCode.Clear();
+                    printUnformatted = false;
+                }
+                else if (Token.HasLeadingCommentMatching(node, IgnoreStartRegex))
+                {
+                    printUnformatted = true;
+                }
             }
 
             if (printUnformatted)

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/MembersWithForcedLines.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/MembersWithForcedLines.cs
@@ -34,21 +34,24 @@ internal static class MembersWithForcedLines
             var skipAddingLineBecauseIgnoreEnded = false;
             var member = members[memberIndex];
 
-            if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreEndRegex))
+            if (context.Information.HasCSharpierIgnore)
             {
-                skipAddingLineBecauseIgnoreEnded = true;
-                result.Add(unFormattedCode.AsSpan().Trim().ToString());
-                unFormattedCode.Clear();
-                printUnformatted = false;
-            }
-            else if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreStartRegex))
-            {
-                if (!printUnformatted && memberIndex > 0)
+                if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreEndRegex))
                 {
-                    result.Add(Doc.HardLine);
-                    result.Add(ExtraNewLines.Print(member));
+                    skipAddingLineBecauseIgnoreEnded = true;
+                    result.Add(unFormattedCode.AsSpan().Trim().ToString());
+                    unFormattedCode.Clear();
+                    printUnformatted = false;
                 }
-                printUnformatted = true;
+                else if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreStartRegex))
+                {
+                    if (!printUnformatted && memberIndex > 0)
+                    {
+                        result.Add(Doc.HardLine);
+                        result.Add(ExtraNewLines.Print(member));
+                    }
+                    printUnformatted = true;
+                }
             }
 
             if (printUnformatted)

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/PrintingContext.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/PrintingContext.cs
@@ -7,6 +7,7 @@ namespace CSharpier.Core.CSharp.SyntaxPrinter;
 internal class PrintingContext
 {
     public required PrintingContextOptions Options { get; init; }
+    public required CodeInformation Information { get; init; }
     public PrintingContextState State { get; } = new();
 
     private readonly Dictionary<string, int> groupNumberByValue = [];
@@ -59,4 +60,6 @@ internal class PrintingContext
     }
 
     public record TrailingCommaContext(SyntaxTrivia TrailingComment, Doc PrintedTrailingComma);
+
+    public record struct CodeInformation(bool HasPreprocessorSymbols, bool HasCSharpierIgnore);
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SeparatedSyntaxList.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SeparatedSyntaxList.cs
@@ -56,19 +56,22 @@ internal static class SeparatedSyntaxList
         {
             var member = list[x];
 
-            if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreEndRegex))
+            if (context.Information.HasCSharpierIgnore)
             {
-                docs.Append(unFormattedCode.AsSpan().Trim().ToString());
-                unFormattedCode.Clear();
-                printUnformatted = false;
-            }
-            else if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreStartRegex))
-            {
-                if (!printUnformatted && x > 0)
+                if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreEndRegex))
                 {
-                    docs.Append(Doc.HardLine);
+                    docs.Append(unFormattedCode.AsSpan().Trim().ToString());
+                    unFormattedCode.Clear();
+                    printUnformatted = false;
                 }
-                printUnformatted = true;
+                else if (Token.HasLeadingCommentMatching(member, CSharpierIgnore.IgnoreStartRegex))
+                {
+                    if (!printUnformatted && x > 0)
+                    {
+                        docs.Append(Doc.HardLine);
+                    }
+                    printUnformatted = true;
+                }
             }
 
             if (printUnformatted)

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
@@ -8,7 +8,11 @@ internal static class AttributeList
 {
     public static Doc Print(AttributeListSyntax node, PrintingContext context)
     {
-        if (node.Parent is BaseMethodDeclarationSyntax && CSharpierIgnore.HasIgnoreComment(node))
+        if (
+            context.Information.HasCSharpierIgnore
+            && node.Parent is BaseMethodDeclarationSyntax
+            && CSharpierIgnore.HasIgnoreComment(node)
+        )
         {
             return CSharpierIgnore.PrintWithoutFormatting(node, context).Trim();
         }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BaseMethodDeclaration.cs
@@ -118,18 +118,21 @@ internal static partial class BaseMethodDeclaration
                 );
             }
 
-            if (modifiers is { Count: > 0 })
+            if (context.Information.HasCSharpierIgnore)
             {
-                if (CSharpierIgnore.HasIgnoreComment(modifiers.Value[0]))
+                if (modifiers is { Count: > 0 })
                 {
-                    PrintMethodUnformattedWithoutAttributes(modifiers.Value[0].LeadingTrivia);
+                    if (CSharpierIgnore.HasIgnoreComment(modifiers.Value[0]))
+                    {
+                        PrintMethodUnformattedWithoutAttributes(modifiers.Value[0].LeadingTrivia);
+                        return Doc.Group(docs);
+                    }
+                }
+                else if (returnType is not null && CSharpierIgnore.HasIgnoreComment(returnType))
+                {
+                    PrintMethodUnformattedWithoutAttributes(returnType.GetLeadingTrivia());
                     return Doc.Group(docs);
                 }
-            }
-            else if (returnType is not null && CSharpierIgnore.HasIgnoreComment(returnType))
-            {
-                PrintMethodUnformattedWithoutAttributes(returnType.GetLeadingTrivia());
-                return Doc.Group(docs);
             }
         }
 

--- a/Src/CSharpier.Core/Xml/XmlFormatter.cs
+++ b/Src/CSharpier.Core/Xml/XmlFormatter.cs
@@ -36,6 +36,7 @@ public static class XmlFormatter
                     IndentSize = printerOptions.IndentSize,
                     UseTabs = printerOptions.UseTabs,
                 },
+                Information = new PrintingContext.CodeInformation(false, false),
             };
             var doc = Node.Print(rootNode, printingContext);
             var formattedXml = DocPrinter.DocPrinter.Print(doc, printerOptions, lineEnding);

--- a/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
+++ b/Src/CSharpier.Generators/NodePrinterGenerator.sbntxt
@@ -24,7 +24,7 @@ namespace CSharpier.Core.CSharp.SyntaxPrinter
                 throw new InTooDeepException();
             }
 
-            if (CSharpierIgnore.IsNodeIgnored(syntaxNode))
+            if (context.Information.HasCSharpierIgnore && CSharpierIgnore.IsNodeIgnored(syntaxNode))
             {
                 return CSharpierIgnore.PrintWithoutFormatting(syntaxNode, context).Trim();
             }

--- a/Src/CSharpier.Tests/CSharp/SyntaxPrinter/CSharpierIgnoreTests.cs
+++ b/Src/CSharpier.Tests/CSharp/SyntaxPrinter/CSharpierIgnoreTests.cs
@@ -74,6 +74,8 @@ public string Example
                         IndentSize = 4,
                         UseTabs = false,
                     },
+
+                    Information = new PrintingContext.CodeInformation(false, false),
                 }
             )
             .ReplaceLineEndings("\n");


### PR DESCRIPTION
Check code for `#if` before running `GetSymbolSets`. Profiling pegs this method at around 5-7% of runtime.

A similar optimisation could be done for `CSharpierIgnore` comments, but the logic for this would probably be quite janky.


<img width="1579" height="300" alt="image" src="https://github.com/user-attachments/assets/3b022f50-a6ad-40d0-909c-fe40536ff574" />


### Benchmarks


#### Before
| Method                        | Mean     | Error   | StdDev  | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 132.2 ms | 3.14 ms | 8.82 ms | 128.5 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 263.6 ms | 5.13 ms | 7.02 ms | 262.6 ms | 5000.0000 | 2000.0000 |     53 MB |


#### After
| Method                        | Mean     | Error   | StdDev   | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 120.8 ms | 4.24 ms | 12.02 ms | 115.6 ms | 2000.0000 | 1000.0000 |  31.22 MB |
| Default_CodeFormatter_Complex | 245.5 ms | 4.91 ms |  7.35 ms | 243.7 ms | 5000.0000 | 2000.0000 |  51.73 MB |


