### PR TITLE
 perf: add `Concat(IEnumerable)` overload and remove `ToArray`

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
@@ -80,7 +80,6 @@ internal static class Modifiers
                             sortedModifiers
                                 .Skip(1)
                                 .Select(o => Token.PrintWithSuffix(o, " ", context))
-                                .ToArray()
                         )
                         : Doc.Null
                 )

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ArrayType.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ArrayType.cs
@@ -9,7 +9,7 @@ internal static class ArrayType
     {
         return Doc.Concat(
             Node.Print(node.ElementType, context),
-            Doc.Concat(node.RankSpecifiers.Select(o => Node.Print(o, context)).ToArray())
+            Doc.Concat(node.RankSpecifiers.Select(o => Node.Print(o, context)))
         );
     }
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/AttributeList.cs
@@ -102,6 +102,6 @@ internal static class AttributeList
 
         docs.Append(Token.Print(node.CloseBracketToken, context));
 
-        return Doc.Group(docs.AsSpan().ToArray());
+        return Doc.Group(Doc.Concat(ref docs));
     }
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BasePropertyDeclaration.cs
@@ -92,9 +92,8 @@ internal static class BasePropertyDeclaration
                     Token.Print(node.AccessorList.OpenBraceToken, context),
                     Doc.Indent(
                         node.AccessorList.Accessors.Select(o =>
-                                PrintAccessorDeclarationSyntax(o, separator, context)
-                            )
-                            .ToArray()
+                            PrintAccessorDeclarationSyntax(o, separator, context)
+                        )
                     ),
                     separator,
                     Token.Print(node.AccessorList.CloseBraceToken, context)

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/BinaryExpression.cs
@@ -42,9 +42,7 @@ internal static class BinaryExpression
                 && conditionalExpressionSyntax.WhenFalse != node
             );
 
-        return shouldNotIndent
-            ? Doc.Group(docs)
-            : Doc.Group(docs[0], Doc.Indent(docs.Skip(1).ToList()));
+        return shouldNotIndent ? Doc.Group(docs) : Doc.Group(docs[0], Doc.Indent(docs.Skip(1)));
     }
 
     // The goal of this is to group operators of the same precedence such that they all break or none of them break

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/ImplicitArrayCreationExpression.cs
@@ -7,7 +7,7 @@ internal static class ImplicitArrayCreationExpression
 {
     public static Doc Print(ImplicitArrayCreationExpressionSyntax node, PrintingContext context)
     {
-        var commas = node.Commas.Select(o => Token.Print(o, context)).ToArray();
+        var commas = node.Commas.Select(o => Token.Print(o, context));
         return Doc.Group(
             Token.Print(node.NewKeyword, context),
             Token.Print(node.OpenBracketToken, context),

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -92,11 +92,11 @@ internal static class InvocationExpression
         }
 
         var expanded = Doc.Concat(
-            Doc.Concat(groups[0].Select(o => o.Doc).ToArray()),
+            Doc.Concat(groups[0].Select(o => o.Doc)),
             shouldMergeFirstTwoGroups
                 ? Doc.IndentIf(
                     groups.Count > 2 && groups[1].Last().Doc is not Group { Contents: IndentDoc },
-                    Doc.Concat(groups[1].Select(o => o.Doc).ToArray())
+                    Doc.Concat(groups[1].Select(o => o.Doc))
                 )
                 : Doc.Null,
             PrintIndentedGroup(groups.Skip(shouldMergeFirstTwoGroups ? 2 : 1).ToList())

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/Parameter.cs
@@ -53,6 +53,6 @@ internal static class Parameter
             docs.Append(EqualsValueClause.Print(node.Default, context));
         }
 
-        return hasAttribute ? Doc.Group(docs.AsSpan().ToArray()) : Doc.Concat(ref docs);
+        return hasAttribute ? Doc.Group(Doc.Concat(ref docs)) : Doc.Concat(ref docs);
     }
 }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/SwitchSection.cs
@@ -19,10 +19,7 @@ internal static class SwitchSection
             docs.Append(
                 Doc.Indent(
                     node.Statements.First() is BlockSyntax ? Doc.Null : Doc.HardLine,
-                    Doc.Join(
-                        Doc.HardLine,
-                        node.Statements.Select(o => Node.Print(o, context)).ToArray()
-                    )
+                    Doc.Join(Doc.HardLine, node.Statements.Select(o => Node.Print(o, context)))
                 )
             );
         }

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Token.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Token.cs
@@ -168,13 +168,14 @@ internal static class Token
             || syntaxToken.Parent is CollectionExpressionSyntax
                 && syntaxToken.RawSyntaxKind() == SyntaxKind.CloseBracketToken;
 
+        var leadingTrivia = syntaxToken.LeadingTrivia;
         var printedTrivia = PrivatePrintLeadingTrivia(
-            syntaxToken.LeadingTrivia,
+            leadingTrivia,
             context,
             skipLastHardline: isClosingBrace
         );
 
-        var hasDirective = Enumerable.Any(syntaxToken.LeadingTrivia, o => o.IsDirective);
+        var hasDirective = Enumerable.Any(leadingTrivia, o => o.IsDirective);
 
         if (hasDirective)
         {
@@ -198,9 +199,9 @@ internal static class Token
 
         Doc extraNewLines = Doc.Null;
 
-        if (hasDirective || Enumerable.Any(syntaxToken.LeadingTrivia, o => o.IsComment()))
+        if (hasDirective || Enumerable.Any(leadingTrivia, o => o.IsComment()))
         {
-            extraNewLines = ExtraNewLines.Print(syntaxToken.LeadingTrivia);
+            extraNewLines = ExtraNewLines.Print(leadingTrivia);
         }
 
         return printedTrivia != Doc.Null || extraNewLines != Doc.Null

--- a/Src/CSharpier.Core/DocTypes/Doc.cs
+++ b/Src/CSharpier.Core/DocTypes/Doc.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using CSharpier.Core.Utilities;
 
 namespace CSharpier.Core.DocTypes;
@@ -53,6 +54,21 @@ internal abstract class Doc
 
     public static Doc Concat(params Doc[] contents) => new Concat(contents);
 
+    [SkipLocalsInit]
+    public static Doc Concat(IEnumerable<Doc> contents)
+    {
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null, null]);
+
+        foreach (var item in contents)
+        {
+            docs.Append(item);
+        }
+
+        var returnDoc = Concat(ref docs);
+        docs.Dispose();
+        return returnDoc;
+    }
+
     public static Doc Concat(ref ValueListBuilder<Doc> contents)
     {
         return contents.Length switch
@@ -63,23 +79,26 @@ internal abstract class Doc
         };
     }
 
+    [SkipLocalsInit]
     public static Doc Join(Doc separator, IEnumerable<Doc> enumerable)
     {
-        var docs = new List<Doc>();
+        var docs = new ValueListBuilder<Doc>([null, null, null, null, null, null, null, null]);
 
         var x = 0;
         foreach (var doc in enumerable)
         {
             if (x != 0)
             {
-                docs.Add(separator);
+                docs.Append(separator);
             }
 
-            docs.Add(doc);
+            docs.Append(doc);
             x++;
         }
 
-        return docs.Count == 1 ? docs[0] : Concat(docs);
+        var returnDoc = Concat(ref docs);
+        docs.Dispose();
+        return returnDoc;
     }
 
     public static ForceFlat ForceFlat(List<Doc> contents) =>
@@ -134,6 +153,9 @@ internal abstract class Doc
     public static IndentDoc Indent(params Doc[] contents) => new() { Contents = Concat(contents) };
 
     public static IndentDoc Indent(List<Doc> contents) => new() { Contents = Concat(contents) };
+
+    public static IndentDoc Indent(IEnumerable<Doc> contents) =>
+        new() { Contents = Concat(contents) };
 
     public static Doc IndentIf(bool condition, Doc contents)
     {


### PR DESCRIPTION
- Add `Concat(IEnumerable)` overload to remove `ToArray` call. This is beneficial because most uses only have one item so we don't have to create an array.
    - Synergises nicely with #1524
- Prevent repeat calls to `syntaxToken.LeadingTrivia`
- Use `ValueListBuilder` inside `Doc.Join`

### Benchmark (Timing is inaccurate)
#### Before
| Method                        | Mean     | Error   | StdDev  | Median   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 131.9 ms | 3.30 ms | 8.86 ms | 128.0 ms | 3000.0000 | 1000.0000 |  34.57 MB |
| Default_CodeFormatter_Complex | 261.3 ms | 5.16 ms | 4.03 ms | 261.3 ms | 5000.0000 | 2000.0000 |  53.03 MB |




#### After
| Method                        | Mean     | Error   | StdDev   | Gen0      | Gen1      | Allocated |
|------------------------------ |---------:|--------:|---------:|----------:|----------:|----------:|
| Default_CodeFormatter_Tests   | 139.0 ms | 2.96 ms |  8.59 ms | 3000.0000 | 1000.0000 |  34.35 MB |
| Default_CodeFormatter_Complex | 282.8 ms | 5.59 ms | 13.39 ms | 5000.0000 | 2000.0000 |  52.53 MB |



