### PR TITLE
Enable run on save by default in Rider plugin

### DIFF
--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettings.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettings.java
@@ -15,7 +15,7 @@ public class CSharpierSettings implements PersistentStateComponent<CSharpierSett
         return project.getService(CSharpierSettings.class);
     }
 
-    private boolean runOnSave;
+    private boolean runOnSave = true;
 
     public boolean getRunOnSave() {
         return this.runOnSave;


### PR DESCRIPTION
This removes the possible frustration of people installing the plugin and then thinking it doesn't work, when their edits aren't being formatted.