### PR TITLE
perf: delay `string.Replace` call

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -228,7 +228,7 @@ internal static class CommandLineFormatter
 
             async Task FormatFile(
                 string actualFilePath,
-                string originalFilePath,
+                string? originalFilePath = null,
                 bool warnForUnsupported = false
             )
             {
@@ -245,6 +245,11 @@ internal static class CommandLineFormatter
                 var printerOptions = await optionsProvider.GetPrinterOptionsForAsync(
                     actualFilePath,
                     cancellationToken
+                );
+
+                originalFilePath ??= actualFilePath.Replace(
+                    directoryOrFilePath,
+                    originalDirectoryOrFile
                 );
 
                 if (printerOptions is { Formatter: not Formatter.Unknown })
@@ -298,9 +303,7 @@ internal static class CommandLineFormatter
                         "*.*",
                         SearchOption.AllDirectories
                     )
-                    .Select(o =>
-                        FormatFile(o, o.Replace(directoryOrFilePath, originalDirectoryOrFile))
-                    )
+                    .Select(o => FormatFile(o))
                     .ToArray();
                 try
                 {


### PR DESCRIPTION
Delay calling `string.Replace` until after the ignore check. Saves 7.8MB when I run it on the CSharpier repo

## Before
<img width="1543" height="402" alt="image" src="https://github.com/user-attachments/assets/371df3eb-e05e-4b86-b637-1784a1b586ca" />


## After
<img width="1567" height="400" alt="image" src="https://github.com/user-attachments/assets/d40375a0-f0e7-4a12-be96-5f62a97391f3" />
