### PR TITLE
feat(editorconfig): add support for insert_final_newline

### DIFF
--- a/Src/CSharpier.Cli/EditorConfig/EditorConfigSections.cs
+++ b/Src/CSharpier.Cli/EditorConfig/EditorConfigSections.cs
@@ -53,6 +53,11 @@ internal class EditorConfigSections
             printerOptions.EndOfLine = endOfLine;
         }
 
+        if (resolvedConfiguration.InsertFinalNewline is { } insertFinalNewline)
+        {
+            printerOptions.InsertFinalNewline = insertFinalNewline;
+        }
+
         return printerOptions;
     }
 
@@ -63,6 +68,7 @@ internal class EditorConfigSections
         public int? TabWidth { get; }
         public int? MaxLineLength { get; }
         public EndOfLine? EndOfLine { get; }
+        public bool? InsertFinalNewline { get; }
         public string? Formatter { get; }
 
         public ResolvedConfiguration(List<Section> sections)
@@ -107,6 +113,14 @@ internal class EditorConfigSections
             if (Enum.TryParse(endOfLine, true, out EndOfLine result))
             {
                 this.EndOfLine = result;
+            }
+
+            var insertFinalNewline = sections
+                .LastOrDefault(o => o.InsertFinalNewline != null)
+                ?.InsertFinalNewline;
+            if (bool.TryParse(insertFinalNewline, out bool insertFinalNewlineValue))
+            {
+                this.InsertFinalNewline = insertFinalNewlineValue;
             }
 
             this.Formatter = sections.LastOrDefault(o => o.Formatter is not null)?.Formatter;

--- a/Src/CSharpier.Cli/EditorConfig/Section.cs
+++ b/Src/CSharpier.Cli/EditorConfig/Section.cs
@@ -12,6 +12,7 @@ internal class Section(SectionData section, string directory)
     public string? TabWidth { get; } = section.Keys["tab_width"];
     public string? MaxLineLength { get; } = section.Keys["max_line_length"];
     public string? EndOfLine { get; } = section.Keys["end_of_line"];
+    public string? InsertFinalNewline { get; } = section.Keys["insert_final_newline"];
     public string? Formatter { get; } = section.Keys["csharpier_formatter"];
 
     public bool IsMatch(string fileName, bool ignoreDirectory)

--- a/Src/CSharpier.Core/DocPrinter/DocPrinter.cs
+++ b/Src/CSharpier.Core/DocPrinter/DocPrinter.cs
@@ -52,7 +52,13 @@ internal class DocPrinter
         {
             this.Output.TrimStart('\n', '\r');
         }
-        var result = this.Output.ToString();
+
+        var result = this.Output.ToString().TrimEnd('\r', '\n');
+
+        if (this.PrinterOptions.InsertFinalNewline)
+        {
+            result += this.EndOfLine;
+        }
 
         return result;
     }

--- a/Src/CSharpier.Core/PrinterOptions.cs
+++ b/Src/CSharpier.Core/PrinterOptions.cs
@@ -24,6 +24,7 @@ internal class PrinterOptions(Formatter formatter)
 
     public int Width { get; set; } = 100;
     public EndOfLine EndOfLine { get; set; } = EndOfLine.Auto;
+    public bool InsertFinalNewline { get; set; } = true;
     public bool TrimInitialLines { get; init; } = true;
     public bool IncludeGenerated { get; set; }
     public Formatter Formatter { get; set; } = formatter;
@@ -37,17 +38,8 @@ internal class PrinterOptions(Formatter formatter)
             return printerOptions.EndOfLine == EndOfLine.CRLF ? "\r\n" : "\n";
         }
 
-        var lineIndex = code.IndexOf('\n');
-        if (lineIndex <= 0)
-        {
-            return "\n";
-        }
-        if (code[lineIndex - 1] == '\r')
-        {
-            return "\r\n";
-        }
-
-        return "\n";
+        var fileHasClrfEnding = code.Contains("\r\n");
+        return fileHasClrfEnding ? "\r\n" : "\n";
     }
 
     public static Formatter GetFormatter(string filePath)

--- a/Src/CSharpier.Tests/InsertFinalNewlineTests.cs
+++ b/Src/CSharpier.Tests/InsertFinalNewlineTests.cs
@@ -1,0 +1,62 @@
+using CSharpier.Core;
+using CSharpier.Core.CSharp;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CSharpier.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+internal sealed class InsertFinalNewlineTests
+{
+    [Test]
+    public async Task InsertFinalNewlineTests_Should_Add_Newlines_When_Not_Defined()
+    {
+        var code =
+            @"class ClassName
+{
+    private string blah = @""hello, world"";
+}";
+        var printerOptions = new PrinterOptions(Formatter.CSharp) {};
+
+        var result = await CSharpFormatter.FormatAsync(code, printerOptions);
+
+        var expected = $"{code}\n";
+        result.Code.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task InsertFinalNewlineTests_Should_Add_Newlines()
+    {
+        var code =
+            @"class ClassName
+{
+    private string blah = @""hello, world"";
+}";
+
+        var printerOptions = new PrinterOptions(Formatter.CSharp) { InsertFinalNewline = true };
+
+        var result = await CSharpFormatter.FormatAsync(code, printerOptions);
+
+        var expected = $"{code}\n";
+        result.Code.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task InsertFinalNewlineTests_Should_Remove_Newlines()
+    {
+        var code =
+            @"class ClassName
+{
+    private string blah = @""hello, world"";
+}
+";
+
+        var printerOptions = new PrinterOptions(Formatter.CSharp) { InsertFinalNewline = false };
+
+        var result = await CSharpFormatter.FormatAsync(code, printerOptions);
+
+        var expected = code.TrimEnd('\r', '\n');
+        result.Code.Should().Be(expected);
+    }
+}

--- a/Src/CSharpier.Tests/OptionsProviderTests.cs
+++ b/Src/CSharpier.Tests/OptionsProviderTests.cs
@@ -331,6 +331,7 @@ indent_style = space
 indent_size = 2
 max_line_length = 10
 end_of_line = crlf
+insert_final_newline = false
 "
         );
 
@@ -340,6 +341,7 @@ end_of_line = crlf
         result.IndentSize.Should().Be(2);
         result.Width.Should().Be(10);
         result.EndOfLine.Should().Be(EndOfLine.CRLF);
+        result.InsertFinalNewline.Should().BeFalse();
     }
 
     [Test]
@@ -360,6 +362,8 @@ indent_size = 2
 max_line_length = 10
 ; Windows-style line endings
 end_of_line = crlf
+; Remove final newlines
+insert_final_newline = false
 "
         );
 
@@ -369,6 +373,7 @@ end_of_line = crlf
         result.IndentSize.Should().Be(2);
         result.Width.Should().Be(10);
         result.EndOfLine.Should().Be(EndOfLine.CRLF);
+        result.InsertFinalNewline.Should().BeFalse();
     }
 
     [Test]


### PR DESCRIPTION
Currently `csharpier` insists in always adding a new line.

I found that there are existing issues that have been closed regarding this:

- https://github.com/belav/csharpier/issues/1670

Currently this causes a bit of problems in my workflow. The organization I work for sets `.editorconfig` with `insert_final_newline` set to false. This causes my PRs to often fail when linting is run, as `dotnet format` respects the `.editorconfig` file, and since the files have newlines, `dotnet format --verify-no-changes` fails.

I personally agree that we should have newlines, but I'm not in a position to change how the orginization I work for sets their configurations.