### PR TITLE
Save Rider plugin settings globally

### DIFF
--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierProcessProvider.java
@@ -271,7 +271,7 @@ public class CSharpierProcessProvider implements DocumentListener, Disposable, I
             ICSharpierProcess csharpierProcess;
             if (
                 Semver.gte(version, serverVersion) &&
-                !CSharpierSettings.getInstance(this.project).getDisableCSharpierServer()
+                !CSharpierSettings.getInstance().getDisableCSharpierServer()
             ) {
                 csharpierProcess = new CSharpierProcessServer(customPath, version, this.project);
             } else if (Semver.gte(version, "0.12.0")) {
@@ -279,7 +279,7 @@ public class CSharpierProcessProvider implements DocumentListener, Disposable, I
 
                 if (
                     Semver.gte(version, serverVersion) &&
-                    CSharpierSettings.getInstance(this.project).getDisableCSharpierServer()
+                    CSharpierSettings.getInstance().getDisableCSharpierServer()
                 ) {
                     this.logger.debug(
                             "CSharpier server is disabled, falling back to piping via stdin"

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettings.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettings.java
@@ -1,9 +1,9 @@
 package com.intellij.csharpier;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,8 +11,8 @@ import org.jetbrains.annotations.NotNull;
 public class CSharpierSettings implements PersistentStateComponent<CSharpierSettings> {
 
     @NotNull
-    static CSharpierSettings getInstance(@NotNull Project project) {
-        return project.getService(CSharpierSettings.class);
+    static CSharpierSettings getInstance() {
+        return ApplicationManager.getApplication().getService(CSharpierSettings.class);
     }
 
     private boolean runOnSave;

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettingsComponent.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CSharpierSettingsComponent.java
@@ -1,7 +1,6 @@
 package com.intellij.csharpier;
 
 import com.intellij.openapi.options.SearchableConfigurable;
-import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
@@ -14,15 +13,11 @@ import org.jetbrains.annotations.Nullable;
 
 public class CSharpierSettingsComponent implements SearchableConfigurable {
 
-    private final Project project;
     private JBCheckBox runOnSaveCheckBox = new JBCheckBox("Run on Save");
     private JBCheckBox disableCSharpierServerCheckBox = new JBCheckBox("Disable CSharpier Server");
     private JBCheckBox useCustomPath = new JBCheckBox("Override CSharpier Executable");
     private JBTextField customPathTextField = new JBTextField();
 
-    public CSharpierSettingsComponent(@NotNull Project project) {
-        this.project = project;
-    }
 
     @NotNull
     @Override
@@ -85,20 +80,20 @@ public class CSharpierSettingsComponent implements SearchableConfigurable {
     @Override
     public boolean isModified() {
         return (
-            CSharpierSettings.getInstance(this.project).getRunOnSave() !=
+            CSharpierSettings.getInstance().getRunOnSave() !=
                 this.runOnSaveCheckBox.isSelected() ||
-            CSharpierSettings.getInstance(this.project).getCustomPath() !=
+            CSharpierSettings.getInstance().getCustomPath() !=
             this.customPathTextField.getText() ||
-            CSharpierSettings.getInstance(this.project).getUseCustomPath() !=
+            CSharpierSettings.getInstance().getUseCustomPath() !=
             this.useCustomPath.isSelected() ||
-            CSharpierSettings.getInstance(this.project).getDisableCSharpierServer() !=
+            CSharpierSettings.getInstance().getDisableCSharpierServer() !=
             this.disableCSharpierServerCheckBox.isSelected()
         );
     }
 
     @Override
     public void apply() {
-        var settings = CSharpierSettings.getInstance(this.project);
+        var settings = CSharpierSettings.getInstance();
 
         settings.setRunOnSave(this.runOnSaveCheckBox.isSelected());
         settings.setCustomPath(this.customPathTextField.getText());
@@ -108,7 +103,7 @@ public class CSharpierSettingsComponent implements SearchableConfigurable {
 
     @Override
     public void reset() {
-        var settings = CSharpierSettings.getInstance(this.project);
+        var settings = CSharpierSettings.getInstance();
         this.runOnSaveCheckBox.setSelected(settings.getRunOnSave());
         this.useCustomPath.setSelected(settings.getUseCustomPath());
         this.customPathTextField.setText(settings.getCustomPath());

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CustomPathInstaller.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/CustomPathInstaller.java
@@ -16,8 +16,8 @@ public class CustomPathInstaller {
     String customPath;
 
     public CustomPathInstaller(Project project) {
-        if (CSharpierSettings.getInstance(project).getUseCustomPath()) {
-            this.customPath = CSharpierSettings.getInstance(project).getCustomPath();
+        if (CSharpierSettings.getInstance().getUseCustomPath()) {
+            this.customPath = CSharpierSettings.getInstance().getCustomPath();
         }
 
         this.dotNetProvider = DotNetProvider.getInstance(project);

--- a/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ReformatWithCSharpierOnSaveListener.java
+++ b/Src/CSharpier.Rider/src/main/java/com/intellij/csharpier/ReformatWithCSharpierOnSaveListener.java
@@ -19,7 +19,7 @@ public class ReformatWithCSharpierOnSaveListener implements FileDocumentManagerL
             return;
         }
 
-        var cSharpierSettings = CSharpierSettings.getInstance(project);
+        var cSharpierSettings = CSharpierSettings.getInstance();
         if (!cSharpierSettings.getRunOnSave()) {
             return;
         }

--- a/Src/CSharpier.Rider/src/main/resources/META-INF/plugin.xml
+++ b/Src/CSharpier.Rider/src/main/resources/META-INF/plugin.xml
@@ -8,11 +8,11 @@
     <projectService serviceImplementation="com.intellij.csharpier.CSharpierProcessProvider" />
     <projectService serviceImplementation="com.intellij.csharpier.DotNetProvider" />
     <projectService serviceImplementation="com.intellij.csharpier.FormattingService" />
-    <projectService serviceImplementation="com.intellij.csharpier.CSharpierSettings" />
+    <applicationService serviceImplementation="com.intellij.csharpier.CSharpierSettings" />
     <projectService serviceImplementation="com.intellij.csharpier.InstallerService" />
     <notificationGroup id="CSharpier" displayType="STICKY_BALLOON" />
     <postStartupActivity implementation="com.intellij.csharpier.CSharpierStartup" />
-    <projectConfigurable
+    <applicationConfigurable
       displayName="CSharpier"
       parentId="tools"
       id="com.intellij.csharpier.CSharpierSettingsComponent"


### PR DESCRIPTION
This changes settings storage from the project level to the global settings, allowing users to configure CSharpier once, and not for each solution they open.

I was able to test it locally and it works, but I'm not an expert on IntelliJ plugins and can't entirely rule out that this breaks something somewhere. So far the only observed effect should be that people will have their settings reset to defaults with the update and will have to reconfigure the plugin once.

Closes #1739.