### PR TITLE
test: Fix failure caused by 1.0 assembly renaming

### DIFF
--- a/Src/CSharpier.Cli.Tests/CliTests.cs
+++ b/Src/CSharpier.Cli.Tests/CliTests.cs
@@ -300,7 +300,7 @@ public class CliTests
         {
             ArgumentList =
             {
-                Path.Combine(Directory.GetCurrentDirectory(), "dotnet-csharpier.dll"),
+                Path.Combine(Directory.GetCurrentDirectory(), "CSharpier.dll"),
                 "format",
             },
             RedirectStandardInput = false,


### PR DESCRIPTION
It appears it wasn't detected because it was skipped in CI, etc.

The test run via `dotnet test` was now reporting failures.