### PR TITLE
Improving performance of HasMismatchedCliAndMsBuildVersions

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -303,10 +303,11 @@ internal static class CommandLineFormatter
             {
                 if (
                     !commandLineOptions.NoMSBuildCheck
-                    && HasMismatchedCliAndMsBuildVersions.Check(
+                    && await HasMismatchedCliAndMsBuildVersions.Check(
                         directoryOrFilePath,
                         fileSystem,
-                        logger
+                        logger,
+                        cancellationToken
                     )
                 )
                 {


### PR DESCRIPTION
Skip over trying to find *.csproj in node_modules or .git folders. Makes things slightly slower in some cases but significantly faster for other cases.

closes #1781 
