### PR TITLE
fix: cli mismatch correctly skips folders

### DIFF
--- a/Src/CSharpier.Cli/HasMismatchedCliAndMsBuildVersions.cs
+++ b/Src/CSharpier.Cli/HasMismatchedCliAndMsBuildVersions.cs
@@ -55,7 +55,7 @@ internal static class HasMismatchedCliAndMsBuildVersions
         IEnumerable<string> EnumerateFiles(string directory)
         {
             // using optionsProvider is slower so just hard coding the ones that could cause performance issues
-            if (fileSystem.Path.GetDirectoryName(directory) is "node_modules" or ".git")
+            if (fileSystem.Directory.GetParent(directory)?.Name is "node_modules" or ".git")
             {
                 yield break;
             }


### PR DESCRIPTION
Fixes #1781

I wonder if it would be worth using `FileSystemEnumerator` here, probably causing a bit of toil by enumerating each directory twice. Will be a pain to test without `IFileSystem` 🤔 