### PR TITLE
Ignore DTD to avoid it throwing an exception. Make sure we check for …

### DIFF
--- a/Src/CSharpier.Core/Xml/XmlFormatter.cs
+++ b/Src/CSharpier.Core/Xml/XmlFormatter.cs
@@ -70,6 +70,7 @@ public static class XmlFormatter
             ValidationType = ValidationType.None,
             CheckCharacters = true,
             Async = true,
+            DtdProcessing = DtdProcessing.Ignore,
         };
 
         using var xmlReader = XmlReader.Create(stringReader, settings);

--- a/Src/CSharpier.Tests/FormattingTests/BaseTest.cs
+++ b/Src/CSharpier.Tests/FormattingTests/BaseTest.cs
@@ -29,8 +29,6 @@ public class BaseTest
 
         foreach (var group in files.GroupBy(o => o.Directory!.Name))
         {
-            var formattingType = group.Key;
-
             foreach (var file in group)
             {
                 var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.Name);
@@ -122,6 +120,7 @@ public class BaseTest
 
         result.CompilationErrors.Should().BeEmpty();
         result.FailureMessage.Should().BeEmpty();
+        result.WarningMessage.Should().BeEmpty();
 
         if (normalizedCode != expectedCode && !BuildServerDetector.Detected)
         {


### PR DESCRIPTION
…warnings after formatting to be sure tests are actually formatting code

closes #1809

