### PR TITLE
Fix typo in about section of CSharpier descriptions

### DIFF
--- a/docs/About.md
+++ b/docs/About.md
@@ -4,7 +4,7 @@ id: About
 hide_table_of_contents: true
 ---
 
-CSharpier is an opinionated code formatter for c# and XML. It uses parses your code and re-prints it using its own rules.
+CSharpier is an opinionated code formatter for c# and XML. It parses your code and re-prints it using its own rules.
 The printing process was ported from [prettier](https://github.com/prettier/prettier) but has evolved over time.  
 
 CSharpier provides a few basic options that affect formatting and follows the [Option Philosophy](https://prettier.io/docs/en/option-philosophy.html) of prettier. Option requests are out of scope for CSharpier, they will be closed without discussion.


### PR DESCRIPTION
## Description

Changed "It uses Parses" to "It parses" in about section to fix the typo

## Related Issue

None

### Checklist

- [x] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [x] I will not force push after a code review of my PR has started
- [x] I have added tests that cover my changes
