### PR TITLE
fix: Tolerate missing directories when formatting from stdin

### DIFF
--- a/Src/CSharpier.Cli/CommandLineFormatter.cs
+++ b/Src/CSharpier.Cli/CommandLineFormatter.cs
@@ -40,6 +40,15 @@ internal static class CommandLineFormatter
                     filePath = directoryPath;
                     directoryPath = fileSystem.Path.GetDirectoryName(directoryPath);
                     ArgumentNullException.ThrowIfNull(directoryPath);
+
+                    // The directory from --stdin-path may not exist on disk.
+                    // Walk up to the nearest existing ancestor for config resolution.
+                    while (!fileSystem.Directory.Exists(directoryPath))
+                    {
+                        directoryPath = fileSystem.Path.GetDirectoryName(directoryPath);
+                        ArgumentNullException.ThrowIfNull(directoryPath);
+                    }
+
                     pathSupplied = true;
                 }
                 // otherwise someone is running this as a single command and not sending a path

--- a/Src/CSharpier.Cli/Options/OptionsProvider.cs
+++ b/Src/CSharpier.Cli/Options/OptionsProvider.cs
@@ -253,7 +253,10 @@ internal class OptionsProvider
             && !dictionary.TryGetValue(searchingDirectory.FullName, out result)
         )
         {
-            if (shouldConsiderDirectory(searchingDirectory.FullName))
+            if (
+                this.fileSystem.Directory.Exists(searchingDirectory.FullName)
+                && shouldConsiderDirectory(searchingDirectory.FullName)
+            )
             {
                 dictionary[searchingDirectory.FullName] = result = await createFileAsync(
                     searchingDirectory.FullName

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -782,6 +782,20 @@ public class CommandLineFormatterTests
     }
 
     [Test]
+    public void Should_Format_StandardInput_When_StdinFilePath_Directory_Does_Not_Exist()
+    {
+        var context = new TestContext();
+        var result = Format(
+            context,
+            standardInFileContents: UnformattedClassContent,
+            directoryOrFilePaths: "NonExistent/SubDir/File.cs"
+        );
+
+        result.OutputLines.Should().ContainSingle();
+        result.OutputLines.First().Should().Be(FormattedClassContent);
+    }
+
+    [Test]
     public void File_With_Mismatched_Line_Endings_In_Verbatim_String_Should_Pass_Validation()
     {
         var context = new TestContext();


### PR DESCRIPTION
When formatting code passed via stdin, and using `--stdin-path`, the path passed may not exist. This is the case when using CSharpier as a [jj] fix tool: Commits are not checked out, so the directory containing the file being formatted may not actually exist on disk.

When this happened, CSharpier was throwing a DirectoryNotFoundException from FindForDirectoryName in CSharpierConfigParser.

Instead, we can predict this exception and check for configuration in the parent directory, until we find one that does exist.

[jj]: https://jj-vcs.dev

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the issue this PR addresses (use "Fixes #123" or "Closes #123" to auto-close) -->

### Checklist

- [X] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [X] I will not force push after a code review of my PR has started
- [X] I have added tests that cover my changes
