### PR TITLE
Write all log messages to stderr

### DIFF
--- a/Src/CSharpier.Cli/ConsoleLogger.cs
+++ b/Src/CSharpier.Cli/ConsoleLogger.cs
@@ -24,26 +24,12 @@ internal class ConsoleLogger(IConsole console, LogLevel loggingLevel, LogFormat 
 
         void Write(string value)
         {
-            if (logLevel >= LogLevel.Error)
-            {
-                console.WriteError(value);
-            }
-            else
-            {
-                console.Write(value);
-            }
+            console.WriteError(value);
         }
 
         void WriteLine(string? value = null)
         {
-            if (logLevel >= LogLevel.Error)
-            {
-                console.WriteErrorLine(value);
-            }
-            else
-            {
-                console.WriteLine(value);
-            }
+            console.WriteErrorLine(value);
         }
 
         if (!this.IsEnabled(logLevel))

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -38,8 +38,9 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, compilationErrorsAsWarnings: true);
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.First()
+            .ErrorOutputLines.First()
             .Replace('\\', '/')
             .Should()
             .Be("Warning ./Invalid.cs - Failed to compile so was not formatted.");
@@ -105,8 +106,9 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, directoryOrFilePaths: "Unsupported.js");
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.First()
+            .ErrorOutputLines.First()
             .Replace('\\', '/')
             .Should()
             .Be("Warning ./Unsupported.js - Is an unsupported file type.");
@@ -134,7 +136,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
-        result.OutputLines.First().Should().StartWith("Formatted 0 files");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 0 files");
     }
 
     [Test]
@@ -166,7 +169,8 @@ public class CommandLineFormatterTests
         );
 
         var result = await Format(context);
-        result.OutputLines.First().Should().StartWith("Formatted 1 files");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 1 files");
 
         context
             .GetFileContent(unformattedFilePath)
@@ -197,7 +201,8 @@ public class CommandLineFormatterTests
         );
 
         var result = await Format(context);
-        result.OutputLines.First().Should().StartWith("Formatted 1 files");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 1 files");
 
         context.GetFileContent(unformattedFilePath).Should().Be(FormattedClassContent);
     }
@@ -228,7 +233,8 @@ public class CommandLineFormatterTests
         if (shouldPass)
         {
             result.ExitCode.Should().Be(0);
-            result.ErrorOutputLines.Should().BeEmpty();
+            result.OutputLines.Should().BeEmpty();
+            result.ErrorOutputLines.Should().NotContain("Test.csproj uses version");
         }
         else
         {
@@ -260,8 +266,9 @@ public class CommandLineFormatterTests
         var result = await Format(context);
 
         result.ExitCode.Should().Be(0);
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.First()
+            .ErrorOutputLines.First()
             .Should()
             .EndWith($"Test.csproj uses an unknown version of CSharpier.MsBuild");
     }
@@ -305,11 +312,13 @@ public class CommandLineFormatterTests
         if (shouldPass)
         {
             result.ExitCode.Should().Be(0);
-            result.ErrorOutputLines.Should().BeEmpty();
+            result.OutputLines.Should().BeEmpty();
+            result.ErrorOutputLines.Should().NotContain("Test.csproj uses version");
         }
         else
         {
             result.ExitCode.Should().Be(1);
+            result.OutputLines.Should().BeEmpty();
             result
                 .ErrorOutputLines.First()
                 .Should()
@@ -337,7 +346,7 @@ public class CommandLineFormatterTests
         var result = await Format(context);
 
         result.ExitCode.Should().Be(0);
-        result.ErrorOutputLines.Should().BeEmpty();
+        result.OutputLines.Should().BeEmpty();
     }
 
     [Test]
@@ -442,7 +451,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -459,7 +469,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, includeGenerated: true);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
     }
 
     [Test]
@@ -521,7 +532,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -543,7 +555,8 @@ public class CommandLineFormatterTests
             directoryOrFilePaths: Path.Combine(GetRootPath(), baseDirectory)
         );
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -561,7 +574,8 @@ public class CommandLineFormatterTests
             directoryOrFilePaths: [unformattedFilePath1, unformattedFilePath2]
         );
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -584,7 +598,8 @@ public class CommandLineFormatterTests
             directoryOrFilePaths: [unformattedFilePath1, unformattedFilePath2]
         );
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -597,7 +612,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, directoryOrFilePaths: "Directory.WithPeriod");
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -611,7 +627,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, directoryOrFilePaths: unformattedFilePath1);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -632,8 +649,9 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.FirstOrDefault()
+            .ErrorOutputLines.FirstOrDefault()
             .Should()
             .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
     }
@@ -656,8 +674,9 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.FirstOrDefault()
+            .ErrorOutputLines.FirstOrDefault()
             .Should()
             .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
     }
@@ -680,8 +699,9 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.FirstOrDefault()
+            .ErrorOutputLines.FirstOrDefault()
             .Should()
             .StartWith(isIgnored ? "Formatted 0 files in " : "Formatted 1 files in ");
     }
@@ -702,7 +722,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 0 files in ");
     }
 
     [Test]
@@ -715,7 +736,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context, directoryOrFilePaths: "Sub");
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
     }
 
     [Test]
@@ -737,7 +759,8 @@ public class CommandLineFormatterTests
 
         var result = await Format(context);
 
-        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
     }
 
     [Test]
@@ -871,8 +894,8 @@ class ClassName
             .GetFileContent("file1.cs")
             .Should()
             .Be(contents.Replace("static public", "public static"));
-        result.ErrorOutputLines.Should().BeEmpty();
-        result.OutputLines.First().Should().StartWith("Formatted 1 files in");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 1 files in");
     }
 
     [Test]
@@ -899,8 +922,8 @@ class ClassName
 
         var result = await Format(context);
 
-        result.ErrorOutputLines.Should().BeEmpty();
-        result.OutputLines.First().Should().StartWith("Formatted 1 files in");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 1 files in");
     }
 
     [Test]
@@ -919,8 +942,8 @@ class ClassName
 
         var result = await Format(context);
 
-        result.ErrorOutputLines.Should().BeEmpty();
-        result.OutputLines.First().Should().StartWith("Formatted 1 files in");
+        result.OutputLines.Should().BeEmpty();
+        result.ErrorOutputLines.First().Should().StartWith("Formatted 1 files in");
     }
 
     [Test]
@@ -935,8 +958,9 @@ class ClassName
 
         var result = await Format(context);
 
+        result.OutputLines.Should().BeEmpty();
         result
-            .OutputLines.First()
+            .ErrorOutputLines.First()
             .Should()
             .Be($"Warning The configuration file at {configPath} was empty.");
     }

--- a/Src/CSharpierProcess.Tests/CliTests.cs
+++ b/Src/CSharpierProcess.Tests/CliTests.cs
@@ -69,8 +69,8 @@ public class CliTests
             .WithArguments("format BasicFile.cs")
             .ExecuteAsync();
 
-        result.ErrorOutput.Should().BeNullOrEmpty();
-        result.Output.Should().StartWith("Formatted 1 files in ");
+        result.Output.Should().BeNullOrEmpty();
+        result.ErrorOutput.Should().StartWith("Formatted 1 files in ");
         result.ExitCode.Should().Be(0);
         (await ReadAllTextAsync("BasicFile.cs")).Should().Be(formattedContent);
     }
@@ -89,7 +89,7 @@ public class CliTests
             .WithArguments($"format {subdirectory}")
             .ExecuteAsync();
 
-        result.Output.Should().StartWith("Formatted 1 files in ");
+        result.ErrorOutput.Should().StartWith("Formatted 1 files in ");
         result.ExitCode.Should().Be(0);
         (await ReadAllTextAsync("Subdirectory/BasicFile.cs")).Should().Be(formattedContent);
     }
@@ -514,7 +514,7 @@ public class CliTests
             .ExecuteAsync();
 
         result
-            .Output.Replace('\\', '/')
+            .ErrorOutput.Replace('\\', '/')
             .Should()
             .StartWith("Warning ./CheckUnformatted.cs - Was not formatted.");
         result.ExitCode.Should().Be(0);
@@ -632,8 +632,8 @@ public class CliTests
 
         var result = await new CsharpierProcess().WithArguments("format .").ExecuteAsync();
 
-        result.Output.Should().StartWith("Formatted 0 files in ");
-        result.ErrorOutput.Should().BeEmpty();
+        result.ErrorOutput.Should().StartWith("Formatted 0 files in ");
+        result.Output.Should().BeEmpty();
         result.ExitCode.Should().Be(0);
     }
 
@@ -644,9 +644,9 @@ public class CliTests
 
         var result = await new CsharpierProcess().WithArguments("format .").ExecuteAsync();
 
-        result.ErrorOutput.Should().BeEmpty();
+        result.Output.Should().BeEmpty();
         result.ExitCode.Should().Be(0);
-        result.Output.Should().StartWith("Warning The csproj at ");
+        result.ErrorOutput.Should().StartWith("Warning The csproj at ");
     }
 
     private const string CsprojContentWithCSharpierMsBuild99 = """
@@ -667,9 +667,9 @@ public class CliTests
             .WithArguments("format --no-msbuild-check .")
             .ExecuteAsync();
 
-        result.ErrorOutput.Should().BeEmpty();
+        result.Output.Should().BeEmpty();
         result.ExitCode.Should().Be(0);
-        result.Output.Should().StartWith("Formatted 1 files in ");
+        result.ErrorOutput.Should().StartWith("Formatted 1 files in ");
     }
 
     [Test]
@@ -681,9 +681,9 @@ public class CliTests
             .WithArguments("check --no-msbuild-check .")
             .ExecuteAsync();
 
-        result.ErrorOutput.Should().BeEmpty();
+        result.Output.Should().BeEmpty();
         result.ExitCode.Should().Be(0);
-        result.Output.Should().StartWith("Checked 1 files in ");
+        result.ErrorOutput.Should().StartWith("Checked 1 files in ");
     }
 
     [Test]
@@ -804,7 +804,7 @@ public class CliTests
             var result = await new CsharpierProcess()
                 .WithArguments($"format {folder}")
                 .ExecuteAsync();
-            result.ErrorOutput.Should().BeEmpty();
+            result.Output.Should().BeEmpty();
         }
 
         var formatTasks = folders.Select(FormatFolder).ToArray();

--- a/Src/CSharpierProcess.Tests/ServerTests.cs
+++ b/Src/CSharpierProcess.Tests/ServerTests.cs
@@ -71,7 +71,7 @@ public class ServerTests
         {
             process.Start();
 
-            var portString = (await process.StandardOutput.ReadLineAsync() ?? string.Empty).Replace(
+            var portString = (await process.StandardError.ReadLineAsync() ?? string.Empty).Replace(
                 "Started on ",
                 string.Empty
             );


### PR DESCRIPTION
## Description

Diagnostic output is often expected to go to standard error, leaving standard output for program output (which is the formatted file when using `--write-stdout` or reading from stdin).

Changes ConsoleLogger to write all log messages to stderr, and updates all tests to match.

## Related Issue

Related to #1851, but isn't the complete fix (that issue needs the exit code changed)

### Checklist

- [X] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [X] I will not force push after a code review of my PR has started
- [X] I have added tests that cover my changes
