### PR TITLE
Fix case of modifier reorder with leading trivia

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxNodeComparer.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxNodeComparer.cs
@@ -1,4 +1,3 @@
-using CSharpier.Core.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -139,7 +138,10 @@ internal partial class SyntaxNodeComparer
         this.formattedStack.Push((formattedStart, formattedStart));
         while (this.originalStack.Count > 0)
         {
-            var result = this.Compare(this.originalStack.Pop(), this.formattedStack.Pop());
+            var lhs = this.originalStack.Pop();
+            var rhs = this.formattedStack.Pop();
+            var result = this.Compare(lhs, rhs);
+            //   var result = this.Compare(this.originalStack.Pop(), this.formattedStack.Pop());
             if (result.IsInvalid)
             {
                 return result;
@@ -543,6 +545,25 @@ internal partial class SyntaxNodeComparer
         }
 
         return Equal;
+    }
+
+    private CompareResult CompareModifierToken(
+        SyntaxToken originalToken,
+        SyntaxToken formattedToken
+    )
+    {
+        if (this.ReorderedModifiers)
+        {
+            // Ignore trivia when modifiers are reordered as trivia move with modifiers
+            if (originalToken.ValueText != formattedToken.ValueText)
+            {
+                return NotEqual(originalToken.Span, formattedToken.Span);
+            }
+
+            return Equal;
+        }
+
+        return this.Compare(originalToken, formattedToken);
     }
 }
 

--- a/Src/CSharpier.Core/CSharp/SyntaxNodeComparer.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxNodeComparer.cs
@@ -138,10 +138,7 @@ internal partial class SyntaxNodeComparer
         this.formattedStack.Push((formattedStart, formattedStart));
         while (this.originalStack.Count > 0)
         {
-            var lhs = this.originalStack.Pop();
-            var rhs = this.formattedStack.Pop();
-            var result = this.Compare(lhs, rhs);
-            //   var result = this.Compare(this.originalStack.Pop(), this.formattedStack.Pop());
+            var result = this.Compare(this.originalStack.Pop(), this.formattedStack.Pop());
             if (result.IsInvalid)
             {
                 return result;

--- a/Src/CSharpier.Generators/SyntaxNodeComparerGenerator.cs
+++ b/Src/CSharpier.Generators/SyntaxNodeComparerGenerator.cs
@@ -114,7 +114,7 @@ namespace CSharpier.Core.CSharp
 #endif
             }
         }
-        
+
 """
         );
 
@@ -242,7 +242,7 @@ namespace CSharpier.Core.CSharp
                 {
                     var compare =
                         propertyType.Name == nameof(SyntaxTokenList)
-                            ? "CompareFunc"
+                            ? (propertyName == "Modifiers" ? "CompareModifierToken" : "CompareFunc")
                             : "static (_, _) => default";
                     if (propertyName == "Modifiers")
                     {

--- a/Src/CSharpier.Tests/CSharp/SyntaxNodeComparerTests.cs
+++ b/Src/CSharpier.Tests/CSharp/SyntaxNodeComparerTests.cs
@@ -548,7 +548,7 @@ public class SyntaxNodeComparerTests
     public void Sorted_Usings_With_Header_Pass_Validation()
     {
         var left = """
-            // some copyright 
+            // some copyright
 
             using Zebra;
             using Apple;
@@ -1000,6 +1000,30 @@ var someValue = $"""
         result.Should().BeEmpty();
     }
 
+    [Test]
+    public void Unsorted_Modifiers_With_Comment_Pass_Validation()
+    {
+        var left = """
+                public class OrderListItemModel : BindableBase
+                {
+                    // foobar
+                    override public int GetHashCode() => 1;
+                }
+            """;
+
+        var right = """
+                public class OrderListItemModel : BindableBase
+                {
+                    // foobar
+                    public override int GetHashCode() => 1;
+                }
+            """;
+
+        var result = CompareSource(left, right, reorderedModifiers: true);
+
+        result.Should().BeEmpty();
+    }
+
     private static void ResultShouldBe(string actual, string expected)
     {
         actual.ReplaceLineEndings().Should().Be(expected.ReplaceLineEndings());
@@ -1009,13 +1033,14 @@ var someValue = $"""
         string left,
         string right,
         bool reorderedUsingsWithDisabledText = false,
-        bool movedTrailingTrivia = false
+        bool movedTrailingTrivia = false,
+        bool reorderedModifiers = false
     )
     {
         var result = new SyntaxNodeComparer(
             left,
             right,
-            false,
+            reorderedModifiers,
             reorderedUsingsWithDisabledText,
             movedTrailingTrivia,
             SourceCodeKind.Regular,


### PR DESCRIPTION
## Description

Formatting our code base I ran into a validation issue regarding the following code

```c#
namespace Models
{
    public class OrderListItemModel : BindableBase
    {
        // foobar
        override public int GetHashCode() => 67;
    }
}
```
The issue being when the modifiers are reordered the leading trivia `// foobar` is associated with a different modifier.

I had a go at fixing this issue.

## Related Issue
n/a

### Checklist

- [x] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [x] I will not force push after a code review of my PR has started
- [x] I have added tests that cover my changes
