### PR TITLE
Suppress diagnostics when a different formatter is explicitly configured

### DIFF
--- a/Src/CSharpier.VSCode/src/DiagnosticsService.ts
+++ b/Src/CSharpier.VSCode/src/DiagnosticsService.ts
@@ -95,9 +95,15 @@ export class DiagnosticsService implements vscode.CodeActionProvider, vscode.Dis
         document: vscode.TextDocument,
         onlyAllowLessDiagnostics = false,
     ): Promise<void> {
+        const defaultFormatter = vscode.workspace
+            .getConfiguration("editor", document)
+            .get<string>("defaultFormatter");
+
         let shouldRunDiagnostics =
             !!vscode.workspace.getWorkspaceFolder(document.uri) &&
-            (workspace.getConfiguration("csharpier").get<boolean>("enableDiagnostics") ?? true);
+            (workspace.getConfiguration("csharpier").get<boolean>("enableDiagnostics") ?? true) &&
+            (defaultFormatter == null || defaultFormatter === "csharpier.csharpier-vscode");
+
 
         let currentDiagnostics = this.diagnosticCollection.get(document.uri);
 


### PR DESCRIPTION
## Description

When `editor.defaultFormatter` is explicitly set to a formatter other than CSharpier for a given language, CSharpier diagnostics are no longer shown for that language.

## Related Issue

Fixes #1403
Fixes #1663