### PR TITLE
Stop .gitignore walk at git worktree boundary

### DIFF
--- a/Src/CSharpier.Cli/IgnoreFile.cs
+++ b/Src/CSharpier.Cli/IgnoreFile.cs
@@ -108,7 +108,8 @@ internal class IgnoreFile
 
     // this will return the ignore paths in order of priority
     // the first csharpierignore it finds at or above the path
-    // and then all .gitignores (at or above stopping once it encounters a .git directory) it finds in order from closest to further away
+    // and then all .gitignores (at or above stopping once it encounters a .git directory or
+    // a .git file, which marks a worktree boundary) it finds in order from closest to further away
     private static List<string> FindIgnorePaths(string baseDirectoryPath, IFileSystem fileSystem)
     {
         var result = new List<string>();
@@ -141,7 +142,8 @@ internal class IgnoreFile
                 }
             }
 
-            if (fileSystem.Directory.Exists(Path.Combine(directoryInfo.FullName, ".git")))
+            var gitPath = Path.Combine(directoryInfo.FullName, ".git");
+            if (fileSystem.Directory.Exists(gitPath) || fileSystem.File.Exists(gitPath))
             {
                 includeGitIgnores = false;
             }

--- a/Src/CSharpier.Tests/CommandLineFormatterTests.cs
+++ b/Src/CSharpier.Tests/CommandLineFormatterTests.cs
@@ -719,6 +719,23 @@ public class CommandLineFormatterTests
     }
 
     [Test]
+    public async Task Gitignore_Above_Worktree_Is_Not_Used()
+    {
+        // In a git worktree, `.git` is a file containing a `gitdir:` pointer rather than
+        // a directory. The walk that collects .gitignore files must still stop at this
+        // boundary, otherwise the parent repo's .gitignore (which typically excludes the
+        // worktree path) will mark every file in the worktree as ignored.
+        var context = new TestContext();
+        context.WhenAFileExists("Sub/File.cs", UnformattedClassContent);
+        context.WhenAFileExists(".gitignore", "*.cs");
+        context.WhenAFileExists("Sub/.git", "gitdir: ../.git/worktrees/foo");
+
+        var result = await Format(context, directoryOrFilePaths: "Sub");
+
+        result.OutputLines.FirstOrDefault().Should().StartWith("Formatted 1 files in ");
+    }
+
+    [Test]
     public async Task Gitignore_Can_Unignore_All_Directories()
     {
         var context = new TestContext();


### PR DESCRIPTION
# Issue
csharpier was not formatting any files, in a worktree under a .gitignored folder path

## Description

`IgnoreFile.FindIgnorePaths` walks up from the target directory collecting `.gitignore` files and stops when it encounters a `.git` directory. In a git worktree, `.git` is a *file* containing a `gitdir:` pointer rather than a directory, so the walk continued past the worktree root.

When the worktree lives at a path the parent repo's `.gitignore` excludes (e.g. tools that create worktrees inside an ignored folder), every file in the worktree is matched by the parent ignore rule and `dotnet csharpier format .` reports `Formatted 0 files`.

This change also stops the walk when `.git` exists as a file, matching git's own treatment of the worktree as a separate working tree. Added a regression test that mirrors the existing `Gitignore_Outside_Git_Is_Not_Used` but with `.git` as a file.

## Related Issue

Follow-up to #1627 / #1649, which introduced the `.git` directory boundary but did not cover worktrees.

### Checklist

- [x] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [x] I will not force push after a code review of my PR has started
- [x] I have added tests that cover my changes