### PR TITLE
perf: use string interpolation for string creation

### DIFF
--- a/Src/CSharpier.Core/BasePrintingContext.cs
+++ b/Src/CSharpier.Core/BasePrintingContext.cs
@@ -13,6 +13,6 @@ internal abstract class BasePrintingContext
         var number = this.groupNumberByValue.GetValueOrDefault(value, 0) + 1;
         this.groupNumberByValue[value] = number;
 
-        return value + " #" + number;
+        return $"{value} #{number}";
     }
 }


### PR DESCRIPTION
Use string interpolation to create a string in `PrintingContext.GroupFor`. Very small improvement 