### PR TITLE
perf: change `List` to array

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/SyntaxNodePrinters/InvocationExpression.cs
@@ -100,7 +100,7 @@ internal static class InvocationExpression
                     Doc.Concat(groups[1].Select(o => o.Doc).ToArray())
                 )
                 : Doc.Null,
-            PrintIndentedGroup(groups.Skip(shouldMergeFirstTwoGroups ? 2 : 1).ToList())
+            PrintIndentedGroup(groups.Skip(shouldMergeFirstTwoGroups ? 2 : 1).ToArray())
         );
 
         return
@@ -378,20 +378,20 @@ internal static class InvocationExpression
         return outputArray;
     }
 
-    private static Doc PrintIndentedGroup(List<List<PrintedNode>> groups)
+    private static Doc PrintIndentedGroup(List<PrintedNode>[] groups)
     {
-        if (groups.Count == 0)
+        if (groups.Length == 0)
         {
             return Doc.Null;
         }
 
-        var result = new DocListBuilder(groups.Count * 2);
+        var result = new DocListBuilder(groups.Length * 2);
 
-        for (int index = 0; index < groups.Count; index++)
+        for (int index = 0; index < groups.Length; index++)
         {
             Doc GetPossibleContents()
             {
-                if (index >= groups.Count)
+                if (index >= groups.Length)
                 {
                     return Doc.Null;
                 }


### PR DESCRIPTION
Small change:
Convert `ToList` call to `ToArray` call, this is useful for cases where the result collection doesn't contain items letting us use an empty array instead of allocating a new empty `List<PrintedNode>[]`


#### Benchmarks timing is inaccurate, memory usage is not
### Before

Method | Mean | Error | StdDev | Median | Gen0 | Gen1 | Gen2 | Allocated
-- | -- | -- | -- | -- | -- | -- | -- | --
Default_CodeFormatter_Tests | 198.9 ms | 9.40 ms | 26.98 ms | 202.2 ms | 2000.0000 | 1000.0000 | - | 28.8 MB
Default_CodeFormatter_Complex | 336.0 ms | 7.01 ms | 20.23 ms | 325.7 ms | 5000.0000 | 2500.0000 | 500.0000 | 47.64 MB


### After

Method | Mean | Error | StdDev | Median | Gen0 | Gen1 | Allocated
-- | -- | -- | -- | -- | -- | -- | --
Default_CodeFormatter_Tests | 148.0 ms | 2.95 ms | 6.84 ms | 147.0 ms | 2000.0000 | 1000.0000 | 28.76 MB
Default_CodeFormatter_Complex | 308.4 ms | 11.78 ms | 34.00 ms | 294.5 ms | 4000.0000 | 2000.0000 | 47.44 MB