### PR TITLE
perf: prevent boxing `SyntaxTokenList` by calling `ToArray` earlier

### DIFF
--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
@@ -99,18 +99,23 @@ internal static class Modifiers
             return Doc.Null;
         }
 
+        var modifierArray = modifiers.ToArray();
+
         // reordering modifiers inside of #ifs can lead to code that doesn't compile
         var willReorderModifiers =
-            modifiers.Count > 1
-            && !modifiers.Skip(1).Any(o => o.LeadingTrivia.Any(p => p.IsDirective || p.IsComment()))
-            && !modifiers[0].LeadingTrivia.Any(p => p.IsDirective);
+            modifierArray.Length > 1
+            && !modifierArray
+                .Skip(1)
+                .Any(o => o.LeadingTrivia.Any(p => p.IsDirective || p.IsComment()))
+            && !modifierArray[0].LeadingTrivia.Any(p => p.IsDirective);
 
-        var sortedModifiers = modifiers.ToArray();
-        var leadingToken = sortedModifiers.FirstOrDefault();
+        var leadingToken = modifierArray.FirstOrDefault();
         if (willReorderModifiers)
         {
-            Array.Sort(sortedModifiers, Comparer);
+            Array.Sort(modifierArray, Comparer);
         }
+
+        var sortedModifiers = modifierArray;
 
         if (willReorderModifiers && !sortedModifiers.SequenceEqual(modifiers))
         {


### PR DESCRIPTION
Prevent boxing `SyntaxTokenList` by moving the `ToArray` call to be earlier.
Renamed to `modifierArray` to reflect the fact its not sorted yet, and later create a local variable called `sortedModifiers`


### Benchmarks - small memory saving timing is inaccurate
#### Before
Method | Mean | Error | StdDev | Median | Gen0 | Gen1 | Gen2 | Allocated
-- | -- | -- | -- | -- | -- | -- | -- | --
Default_CodeFormatter_Tests | 198.9 ms | 9.40 ms | 26.98 ms | 202.2 ms | 2000.0000 | 1000.0000 | - | 28.8 MB
Default_CodeFormatter_Complex | 336.0 ms | 7.01 ms | 20.23 ms | 325.7 ms | 5000.0000 | 2500.0000 | 500.0000 | 47.64 MB

#### After
Method | Mean | Error | StdDev | Gen0 | Gen1 | Gen2 | Allocated
-- | -- | -- | -- | -- | -- | -- | --
Default_CodeFormatter_Tests | 218.6 ms | 20.83 ms | 61.08 ms | 2000.0000 | 1000.0000 | - | 28.77 MB
Default_CodeFormatter_Complex | 300.4 ms | 5.94 ms | 10.25 ms | 5000.0000 | 3000.0000 | 1000.0000 | 47.42 MB
