### PR TITLE
Docs: Updated API documentation to reflect changes in 1.3.0

### DIFF
--- a/Src/Website/docs/API.md
+++ b/Src/Website/docs/API.md
@@ -21,12 +21,12 @@ var options = new CodeFormatterOptions { Width = 60 };
 var narrowerCode = CSharpFormatter.Format(unformattedCode, options);
 var asyncNarrowerCode = await CSharpFormatter.FormatAsync(unformattedCode, options);
 
-var codeWithCompilationErrors = "public class ClassName   {";
-var result = CSharpFormatter.Format(codeFormCompilationErrors);
-if (result.CompilationErrors.Any())
+var codeWithErrorDiagnostics = "public class ClassName   {";
+var result = CSharpFormatter.Format(codeWithErrorDiagnostics);
+if (result.ErrorDiagnostics.Any())
 {
     // result.Code will still be the unformatted code, it is not possible to format code that can't compile
-    // result.CompilationErrors will contain all the errors from attempting to compile the code
+    // result.ErrorDiagnostics will contain all the errors from attempting to format the code
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,12 +21,12 @@ var options = new CodeFormatterOptions { Width = 60 };
 var narrowerCode = CSharpFormatter.Format(unformattedCode, options);
 var asyncNarrowerCode = await CSharpFormatter.FormatAsync(unformattedCode, options);
 
-var codeWithCompilationErrors = "public class ClassName   {";
-var result = CSharpFormatter.Format(codeFormCompilationErrors);
-if (result.CompilationErrors.Any())
+var codeWithErrorDiagnostics = "public class ClassName   {";
+var result = CSharpFormatter.Format(codeWithErrorDiagnostics);
+if (result.ErrorDiagnostics.Any())
 {
     // result.Code will still be the unformatted code, it is not possible to format code that can't compile
-    // result.CompilationErrors will contain all the errors from attempting to compile the code
+    // result.ErrorDiagnostics will contain all the errors from attempting to format the code
 }
 ```
 


### PR DESCRIPTION
Replaced all references to CompilationErrors with ErrorDiagnostics in API documentation. Updated variable names and comments to match the new terminology.

## Description

Doc only change. The example code provided in the documentation is not inline with the breaking change from 1.3.0 where CompilationErrors was renamed to ErrorDiagnostics. This pull request brings the docs inline. 

## Related Issue

n/a

### Checklist

- [ n/a ] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [ x ] I will not force push after a code review of my PR has started
- [ n/a ] I have added tests that cover my changes
