### PR TITLE
Support closed and union syntax via preview Roslyn

### DIFF
--- a/RoslynPreviewSdkReferences.props
+++ b/RoslynPreviewSdkReferences.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <RoslynPreviewSdkPath>/usr/share/dotnet/sdk/11.0.100-preview.5.26302.115/Roslyn/bincore</RoslynPreviewSdkPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <!--
+      DRAFT PR HACK: use the Roslyn bits from .NET 11 Preview 5 so CSharpier can
+      parse C# 15 closed/union syntax before matching NuGet packages are published.
+      Replace this import with Microsoft.CodeAnalysis.CSharp from NuGet once available.
+    -->
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>$(RoslynPreviewSdkPath)/Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp">
+      <HintPath>$(RoslynPreviewSdkPath)/Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/Src/CSharpier.Cli/CSharpier.Cli.csproj
+++ b/Src/CSharpier.Cli/CSharpier.Cli.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Nuget/Build.props" />
+  <Import Project="../../RoslynPreviewSdkReferences.props" />
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1510</NoWarn>
     <OutputType>Exe</OutputType>

--- a/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
+++ b/Src/CSharpier.Core/CSharp/SyntaxPrinter/Modifiers.cs
@@ -21,6 +21,7 @@ internal static class Modifiers
             "new",
             "virtual",
             "abstract",
+            "closed",
             "sealed",
             "override",
             "readonly",

--- a/Src/CSharpier.Core/CSharpier.Core.csproj
+++ b/Src/CSharpier.Core/CSharpier.Core.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Nuget/Build.props" />
+  <Import Project="../../RoslynPreviewSdkReferences.props" />
   <PropertyGroup>
     <PackageId>CSharpier.Core</PackageId>
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0</TargetFrameworks>
@@ -13,7 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LovettSoftware.XmlDiff" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,6 +23,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
     <PackageReference Include="System.Text.Json" />

--- a/Src/CSharpier.Generators/NodePrinterGenerator.cs
+++ b/Src/CSharpier.Generators/NodePrinterGenerator.cs
@@ -74,6 +74,7 @@ public class NodePrinterGenerator : IIncrementalGenerator
                 nameof(SyntaxKind.RecordStructDeclaration),
                 nameof(SyntaxKind.EnumDeclaration),
                 nameof(SyntaxKind.ExtensionBlockDeclaration),
+                "(SyntaxKind)9082", // SyntaxKind.UnionDeclaration in .NET 11 Preview 5
             }
         },
         {
@@ -275,7 +276,12 @@ public class NodePrinterGenerator : IIncrementalGenerator
                 PrinterName = fileName,
                 SyntaxNodeName = $"{fileName}Syntax",
                 SyntaxKinds = SpecialCase.TryGetValue($"{fileName}Syntax", out var kinds)
-                    ? string.Join(" or ", kinds.Select(x => $"SyntaxKind.{x}"))
+                    ? string.Join(
+                        " or ",
+                        kinds.Select(x =>
+                            x.StartsWith("(", StringComparison.Ordinal) ? x : $"SyntaxKind.{x}"
+                        )
+                    )
                     : $"SyntaxKind.{fileName}",
             })
             .OrderBy(o => o.SyntaxNodeName)

--- a/Src/CSharpier.Tests/CSharpier.Tests.csproj
+++ b/Src/CSharpier.Tests/CSharpier.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../RoslynPreviewSdkReferences.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>CSharpier.Tests</RootNamespace>

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ClosedAndUnionModifiers.expected.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ClosedAndUnionModifiers.expected.test
@@ -1,0 +1,20 @@
+public closed record class JobStatus;
+
+public record class Queued : JobStatus;
+
+public record class Running(int PercentComplete) : JobStatus;
+
+public union Pet(Cat, Dog, Bird);
+
+public union Length(Meters, Feet)
+{
+    public double TotalMeters =>
+        this switch
+        {
+            Meters m => m.Value,
+            Feet f => f.Value * 0.3048,
+            _ => throw new InvalidOperationException("The Length has no value."),
+        };
+
+    public Length Add(Length other) => new Meters(TotalMeters + other.TotalMeters);
+}

--- a/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ClosedAndUnionModifiers.test
+++ b/Src/CSharpier.Tests/FormattingTests/TestFiles/cs/ClosedAndUnionModifiers.test
@@ -1,0 +1,19 @@
+public closed record class JobStatus;
+
+public record class Queued : JobStatus;
+
+public record class Running(int PercentComplete) : JobStatus;
+
+public union Pet(Cat, Dog, Bird);
+
+public union Length(Meters, Feet)
+{
+    public double TotalMeters => this switch
+    {
+        Meters m => m.Value,
+        Feet f => f.Value * 0.3048,
+        _ => throw new InvalidOperationException("The Length has no value."),
+    };
+
+    public Length Add(Length other) => new Meters(TotalMeters + other.TotalMeters);
+}


### PR DESCRIPTION
## Description

Add closed to modifier ordering and route Roslyn's preview UnionDeclaration syntax kind through the existing base type declaration printer. Add formatting coverage for closed record classes and union declarations.

For modifier ordering, the current IDE0036 default-order documentation does not yet list the new closed modifier, so this PR makes a local ordering choice rather than copying an official one. I placed closed with the inheritance/type-shape modifiers, directly after abstract and before sealed, because the C# preview docs describe closed as a class modifier for closed hierarchies, and it is related to inheritance constraints. That keeps it near the modifiers it semantically overlaps with while leaving the existing documented order otherwise unchanged.

## Microsoft.CodeAnalysis.CSharp

Unfortunately, the published nuget for Microsoft.CodeAnalysis.CSharp does not yet support either closed or union.  To implement it temporarily, I reference the packages from the .NET 11 preview 5 SDK.  Thus, we should not merge this PR as-is.  The idea is to just have something ready. 

When Microsoft.CodeAnalysis.CSharp is updated on nuget, we can take out the `RoslynPreviewSdkReferences.props` file and all the overrides and just use the nuget package, and then the PR will be ready to merge.

This draft intentionally references the .NET 11 Preview 5 SDK Roslyn assemblies for net10.0 builds because matching Microsoft.CodeAnalysis.CSharp NuGet packages are not yet published. Replace RoslynPreviewSdkReferences.props with a normal NuGet package update before merging.

## Related Issue

Fixes #1880 

## Checklist

- [X] My code follows the project's code style
  - always `var`
  - follow existing naming conventions
  - always `this.`
  - no pointless comments
- [X] I will not force push after a code review of my PR has started
- [X] I have added tests that cover my changes
