### PR TITLE
perf: remove string allocation using `Replace(char` overload

### DIFF
--- a/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
+++ b/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
@@ -4,8 +4,6 @@ internal static class StringExtensions
 {
     internal static string NormalisePath(this string path)
     {
-        return path.Replace(":", string.Empty)
-            .Replace(char.ToString(Path.DirectorySeparatorChar), "/")
-            .Trim();
+        return path.Replace(":", string.Empty).Replace(Path.DirectorySeparatorChar, '/').Trim();
     }
 }


### PR DESCRIPTION
Each call to `StringExtensions.NormalisePath` would allocate a new `string` of `Path.DirectorySeparatorChar`
From profiling `csharpier format` on the csharpier repo #1896
<img width="1004" height="184" alt="image" src="https://github.com/user-attachments/assets/8b15a876-90b3-4f40-a370-e77a62a93b6b" />
