### PR TITLE
perf: refactor ignore logic to prevent duplicate work and allocations

### DIFF
--- a/Src/CSharpier.Cli/DotIgnore/IgnoreList.cs
+++ b/Src/CSharpier.Cli/DotIgnore/IgnoreList.cs
@@ -8,14 +8,14 @@ namespace CSharpier.Cli.DotIgnore;
 
 internal class IgnoreList(string basePath)
 {
-    private static readonly string[] alwaysIgnoredText =
+    private static readonly IgnoreRule[] alwaysIgnoredRules =
     [
-        "**/bin",
-        "**/node_modules",
-        "**/obj",
-        "**/.git",
+        new("**/bin"),
+        new("**/node_modules"),
+        new("**/obj"),
+        new("**/.git"),
     ];
-    private readonly List<IgnoreRule> rules = [];
+    private IgnoreRule[] rules = [];
 
     public static async Task<IgnoreList> CreateAsync(
         IFileSystem fileSystem,
@@ -26,11 +26,9 @@ internal class IgnoreList(string basePath)
     {
         var ignoreList = new IgnoreList(basePath);
         ignoreList.AddRules(
-            alwaysIgnoredText.Concat(
-                ignoreFilePath is null
-                    ? Enumerable.Empty<string>()
-                    : await fileSystem.File.ReadAllLinesAsync(ignoreFilePath, cancellationToken)
-            )
+            ignoreFilePath is null
+                ? Enumerable.Empty<string>()
+                : await fileSystem.File.ReadAllLinesAsync(ignoreFilePath, cancellationToken)
         );
         return ignoreList;
     }
@@ -38,12 +36,11 @@ internal class IgnoreList(string basePath)
     private void AddRules(IEnumerable<string> newRules)
     {
         // TODO it seems like we have two rules that are both "*", they most likely have different pattern flags to account for the ! and the /
-        this.rules.AddRange(
-            newRules
-                .Select(o => o.Trim())
-                .Where(o => o.Length > 0 && !o.StartsWith('#'))
-                .Select(o => new IgnoreRule(o))
-        );
+        this.rules = newRules
+            .Select(o => o.Trim())
+            .Where(o => o.Length > 0 && !o.StartsWith('#'))
+            .Select(o => new IgnoreRule(o))
+            .ToArray();
     }
 
     public (bool hasMatchingRule, bool isIgnored) IsIgnored(string path, bool isDirectory)
@@ -112,7 +109,27 @@ internal class IgnoreList(string basePath)
         var isIgnored = false;
         var hasMatchingRule = false;
 
-        foreach (var rule in this.rules)
+        EvaluateRules(
+            alwaysIgnoredRules,
+            path,
+            pathIsDirectory,
+            ref isIgnored,
+            ref hasMatchingRule
+        );
+        EvaluateRules(this.rules, path, pathIsDirectory, ref isIgnored, ref hasMatchingRule);
+
+        return (hasMatchingRule, isIgnored);
+    }
+
+    private static void EvaluateRules(
+        IgnoreRule[] rules,
+        string path,
+        bool pathIsDirectory,
+        ref bool isIgnored,
+        ref bool hasMatchingRule
+    )
+    {
+        foreach (var rule in rules)
         {
             var isNegativeRule = (rule.PatternFlags & PatternFlags.NEGATION) != 0;
 
@@ -125,7 +142,5 @@ internal class IgnoreList(string basePath)
                 isIgnored = !isNegativeRule;
             }
         }
-
-        return (hasMatchingRule, isIgnored);
     }
 }

--- a/Src/CSharpier.Cli/DotIgnore/IgnoreList.cs
+++ b/Src/CSharpier.Cli/DotIgnore/IgnoreList.cs
@@ -51,9 +51,7 @@ internal class IgnoreList(string basePath)
         }
 
         var pathRelativeToIgnoreFile =
-            path.Length > basePath.Length
-                ? path[basePath.Length..].Replace('\\', '/')
-                : string.Empty;
+            path.Length > basePath.Length ? PathRelativeToIgnoreFile(path) : string.Empty;
 
         var ancestorIgnored = this.IsAnyParentDirectoryIgnored(pathRelativeToIgnoreFile);
 
@@ -65,7 +63,14 @@ internal class IgnoreList(string basePath)
         return this.IsPathIgnored(pathRelativeToIgnoreFile, isDirectory);
     }
 
-    private bool IsAnyParentDirectoryIgnored(string path)
+    private ReadOnlySpan<char> PathRelativeToIgnoreFile(string path)
+    {
+        var relativeSpan = path.AsSpan()[basePath.Length..];
+        var index = relativeSpan.IndexOf('\\');
+        return index < 0 ? relativeSpan : path[basePath.Length..].Replace('\\', '/');
+    }
+
+    private bool IsAnyParentDirectoryIgnored(ReadOnlySpan<char> path)
     {
         var nextPathIndex = path.LastIndexOf('/');
         if (nextPathIndex > 0)
@@ -78,9 +83,10 @@ internal class IgnoreList(string basePath)
 
     private readonly ConcurrentDictionary<string, bool> directoryIgnoredByPath = new();
 
-    private bool IsDirectoryIgnored(string path)
+    private bool IsDirectoryIgnored(ReadOnlySpan<char> path)
     {
-        if (this.directoryIgnoredByPath.TryGetValue(path, out var isIgnored))
+        var lookup = this.directoryIgnoredByPath.GetAlternateLookup<ReadOnlySpan<char>>();
+        if (lookup.TryGetValue(path, out var isIgnored))
         {
             return isIgnored;
         }
@@ -99,11 +105,14 @@ internal class IgnoreList(string basePath)
             }
         }
 
-        this.directoryIgnoredByPath.TryAdd(path, isIgnored);
+        lookup.TryAdd(path, isIgnored);
         return isIgnored;
     }
 
-    private (bool hasMatchingRule, bool isIgnored) IsPathIgnored(string path, bool pathIsDirectory)
+    private (bool hasMatchingRule, bool isIgnored) IsPathIgnored(
+        ReadOnlySpan<char> path,
+        bool pathIsDirectory
+    )
     {
         // This pattern modified from https://github.com/henon/GitSharp/blob/master/GitSharp/IgnoreRules.cs
         var isIgnored = false;
@@ -123,7 +132,7 @@ internal class IgnoreList(string basePath)
 
     private static void EvaluateRules(
         IgnoreRule[] rules,
-        string path,
+        ReadOnlySpan<char> path,
         bool pathIsDirectory,
         ref bool isIgnored,
         ref bool hasMatchingRule

--- a/Src/CSharpier.Cli/DotIgnore/IgnoreRule.cs
+++ b/Src/CSharpier.Cli/DotIgnore/IgnoreRule.cs
@@ -1,10 +1,11 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Buffers;
+using System.Text.RegularExpressions;
 
 namespace CSharpier.Cli.DotIgnore;
 
 internal class IgnoreRule
 {
-    private static readonly char[] _wildcardChars = ['*', '[', '?'];
+    private static readonly SearchValues<char> _wildcardChars = SearchValues.Create('*', '[', '?');
 
     private readonly int wildcardIndex;
     private readonly Regex? regex;
@@ -69,20 +70,17 @@ internal class IgnoreRule
         }
     }
 
-    public bool IsMatch(string path, bool pathIsDirectory)
+    public bool IsMatch(ReadOnlySpan<char> path, bool pathIsDirectory)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        if (path.IsEmpty || path.IsWhiteSpace())
         {
             throw new ArgumentException("Path cannot be null or empty", nameof(path));
         }
 
         // .gitignore files use Unix paths (with a forward slash separator),
         // so make sure our input also uses forward slashes
-#if NET8_0
         var normalisedPath = path.NormalisePath().TrimStart('/');
-#else
-        var normalisedPath = path.NormalisePath().AsSpan().TrimStart('/');
-#endif
+
         // Shortcut return if the pattern is directory-only and the path isn't a directory
         // This has to be determined by the OS (at least that's the only reliable way),
         // so we pass that information in as a boolean so the consuming code can provide it
@@ -116,15 +114,6 @@ internal class IgnoreRule
             && path.Contains('/')
         )
         {
-#if NET8_0
-            foreach (var segment in normalisedPath.Split('/'))
-            {
-                if (Matcher.TryMatch(this.regex, segment))
-                {
-                    return true;
-                }
-            }
-#else
             foreach (var range in normalisedPath.Split('/'))
             {
                 if (Matcher.TryMatch(this.regex, normalisedPath[range]))
@@ -132,7 +121,6 @@ internal class IgnoreRule
                     return true;
                 }
             }
-#endif
 
             return false;
         }

--- a/Src/CSharpier.Cli/DotIgnore/IgnoreRule.cs
+++ b/Src/CSharpier.Cli/DotIgnore/IgnoreRule.cs
@@ -78,8 +78,11 @@ internal class IgnoreRule
 
         // .gitignore files use Unix paths (with a forward slash separator),
         // so make sure our input also uses forward slashes
-        path = path.NormalisePath().TrimStart('/');
-
+#if NET8_0
+        var normalisedPath = path.NormalisePath().TrimStart('/');
+#else
+        var normalisedPath = path.NormalisePath().AsSpan().TrimStart('/');
+#endif
         // Shortcut return if the pattern is directory-only and the path isn't a directory
         // This has to be determined by the OS (at least that's the only reliable way),
         // so we pass that information in as a boolean so the consuming code can provide it
@@ -91,11 +94,11 @@ internal class IgnoreRule
         // If the pattern is an absolute path pattern, the path must start with the part of the pattern
         // before any wildcards occur. If it doesn't, we can just return a negative match
         var patternBeforeFirstWildcard =
-            this.wildcardIndex != -1 ? this.Pattern[..this.wildcardIndex] : this.Pattern;
+            this.wildcardIndex != -1 ? this.Pattern.AsSpan()[..this.wildcardIndex] : this.Pattern;
 
         if (
             (this.PatternFlags & PatternFlags.ABSOLUTE_PATH) != 0
-            && !path.StartsWith(patternBeforeFirstWildcard, this.stringComparison)
+            && !normalisedPath.StartsWith(patternBeforeFirstWildcard, this.stringComparison)
         )
         {
             return false;
@@ -113,15 +116,33 @@ internal class IgnoreRule
             && path.Contains('/')
         )
         {
-            return path.Split('/').Any(segment => Matcher.TryMatch(this.regex, segment));
+#if NET8_0
+            foreach (var segment in normalisedPath.Split('/'))
+            {
+                if (Matcher.TryMatch(this.regex, segment))
+                {
+                    return true;
+                }
+            }
+#else
+            foreach (var range in normalisedPath.Split('/'))
+            {
+                if (Matcher.TryMatch(this.regex, normalisedPath[range]))
+                {
+                    return true;
+                }
+            }
+#endif
+
+            return false;
         }
 
         // If the *path* doesn't contain any slashes, we should skip over the conditional above
-        return Matcher.TryMatch(this.regex, path);
+        return Matcher.TryMatch(this.regex, normalisedPath);
     }
 
     public override string ToString()
     {
-        return this.Pattern + " " + this.PatternFlags;
+        return $"{this.Pattern} {this.PatternFlags}";
     }
 }

--- a/Src/CSharpier.Cli/DotIgnore/Matcher.cs
+++ b/Src/CSharpier.Cli/DotIgnore/Matcher.cs
@@ -39,7 +39,7 @@ internal static partial class Matcher
         { "[:xdigit:]", "A-Fa-f0-9" },
     };
 
-    public static bool TryMatch(Regex? regex, string path)
+    public static bool TryMatch(Regex? regex, ReadOnlySpan<char> path)
     {
         if (regex == null)
         {

--- a/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
+++ b/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
@@ -4,8 +4,6 @@ internal static class StringExtensions
 {
     internal static string NormalisePath(this string path)
     {
-        return path.Replace(":", string.Empty)
-            .Replace(char.ToString(Path.DirectorySeparatorChar), "/")
-            .Trim();
+        return path.Replace(":", string.Empty).Replace(Path.DirectorySeparatorChar, '/').Trim();
     }
 }

--- a/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
+++ b/Src/CSharpier.Cli/DotIgnore/StringExtensions.cs
@@ -1,9 +1,20 @@
-﻿namespace CSharpier.Cli.DotIgnore;
+﻿using System.Buffers;
+
+namespace CSharpier.Cli.DotIgnore;
 
 internal static class StringExtensions
 {
-    internal static string NormalisePath(this string path)
+    private static readonly SearchValues<char> invalidCharacters = SearchValues.Create(',', '/');
+
+    internal static ReadOnlySpan<char> NormalisePath(this ReadOnlySpan<char> path)
     {
-        return path.Replace(":", string.Empty).Replace(Path.DirectorySeparatorChar, '/').Trim();
+        var index = path.IndexOfAny(invalidCharacters);
+        return index < 0
+            ? path.Trim()
+            : path.ToString()
+                .Replace(":", string.Empty)
+                .Replace(Path.DirectorySeparatorChar, '/')
+                .AsSpan()
+                .Trim();
     }
 }

--- a/Src/CSharpier.Cli/EditorConfig/GlobMatcher.cs
+++ b/Src/CSharpier.Cli/EditorConfig/GlobMatcher.cs
@@ -5,12 +5,10 @@
  * From https://github.com/SLaks/Minimatch
  */
 
-using System;
-using System.Collections.Generic;
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -90,8 +88,11 @@ internal partial class GlobMatcher
         this.myEmpty = empty;
     }
 
-    private static readonly char[] ourUnixPathSeparators = ['/'];
-    private static readonly char[] ourWinPathSeparators = ['/', '\\'];
+    private static readonly SearchValues<char> ourUnixPathSeparators = SearchValues.Create('/');
+    private static readonly SearchValues<char> ourWinPathSeparators = SearchValues.Create(
+        '/',
+        '\\'
+    );
 
     ///<summary>Checks whether a given string matches this pattern.</summary>
     public bool IsMatch(string input)
@@ -144,7 +145,7 @@ internal partial class GlobMatcher
             this.myOptions.IgnoreCase
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
-        private readonly char[] PathSeparatorChars =>
+        private readonly SearchValues<char> PathSeparatorChars =>
             this.myOptions.AllowWindowsPaths ? ourWinPathSeparators : ourUnixPathSeparators;
 
         public MatchContext(GlobMatcherOptions options, string str, PatternCase patternCase)
@@ -168,14 +169,13 @@ internal partial class GlobMatcher
                 {
                     this.SkipLastPathSeparators();
 
-                    var lastSeparator = this.myStr.LastIndexOfAny(
-                        this.PathSeparatorChars,
-                        this.myEndOffset - 1,
-                        this.myEndOffset - this.myStartOffset
-                    );
+                    var lastSeparator = this
+                        .myStr.AsSpan()
+                        .Slice(this.myEndOffset - 1, this.myEndOffset - this.myStartOffset)
+                        .LastIndexOfAny(this.PathSeparatorChars);
                     if (lastSeparator != -1)
                     {
-                        this.myStartOffset = lastSeparator + 1;
+                        this.myStartOffset = lastSeparator + this.myEndOffset;
                     }
                 }
             }
@@ -523,15 +523,17 @@ internal partial class GlobMatcher
                         return true;
                     }
 
-                    var pos = this.myStr.IndexOfAny(
-                        this.PathSeparatorChars,
-                        this.myStartOffset + numberOfOneCharItemsBefore,
-                        this.myEndOffset - this.myStartOffset - numberOfOneCharItemsBefore
-                    );
+                    var pos = this
+                        .myStr.AsSpan()
+                        .Slice(
+                            this.myStartOffset + numberOfOneCharItemsBefore,
+                            this.myEndOffset - this.myStartOffset - numberOfOneCharItemsBefore
+                        )
+                        .IndexOfAny(this.PathSeparatorChars);
                     if (pos == -1)
                         return false;
 
-                    this.myStartOffset = pos - numberOfOneCharItemsBefore;
+                    this.myStartOffset = pos + this.myStartOffset;
                     if (this.myEndOffset - this.myStartOffset < fixedItemsLengthAfterAsterisk)
                         return false;
                 }
@@ -572,11 +574,8 @@ internal partial class GlobMatcher
                 if (newStartPos > oldStartPos)
                 {
                     if (
-                        this.myStr.IndexOfAny(
-                            this.PathSeparatorChars,
-                            oldStartPos,
-                            newStartPos - oldStartPos
-                        ) != -1
+                        this.myStr.AsSpan()[oldStartPos..newStartPos]
+                            .IndexOfAny(this.PathSeparatorChars) != -1
                     )
                         return false;
 

--- a/Src/CSharpier.Cli/Options/CSharpierConfigParser.cs
+++ b/Src/CSharpier.Cli/Options/CSharpierConfigParser.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.IO.Abstractions;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -8,7 +9,10 @@ namespace CSharpier.Cli.Options;
 
 internal static class CSharpierConfigParser
 {
-    private static readonly string[] validExtensions = [".csharpierrc", ".json", ".yml", ".yaml"];
+    private static readonly SearchValues<string> validExtensions = SearchValues.Create(
+        [".csharpierrc", ".json", ".yml", ".yaml"],
+        StringComparison.OrdinalIgnoreCase
+    );
     private static readonly JsonSerializerOptions CaseInsensitiveJson = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -28,9 +32,7 @@ internal static class CSharpierConfigParser
             {
                 var file = directoryInfo
                     .EnumerateFiles(".csharpierrc*", SearchOption.TopDirectoryOnly)
-                    .Where(o =>
-                        validExtensions.Contains(o.Extension, StringComparer.OrdinalIgnoreCase)
-                    )
+                    .Where(o => o.Extension.ContainsAny(validExtensions))
                     .MinBy(o => o.Extension);
 
                 if (file != null)


### PR DESCRIPTION
Builds on #1897, supports #1893
#### IgnoreList
- Convert `alwaysIgnoredRules` to use `IgnoreRule[]`, avoiding the cost of compiling the regex for each construction of `IgnoreList`
- Instead of concatenating `alwaysIgnoredRules` and the parsed rules we simply evaluate one after the other to avoid allocating a `List` or larger array

#### IgnoreRule
- Use `TrimStart(ReadOnlySpan<char>` overload to avoid reallocating a `string` for every call
- Use preprocessor to use the more modern `Split` api that returns a `Range` instead of creating substrings.
Related #1896

#### StringExtensions
- Keeps the change from #1897, avoids allocating a new string each call

### Benchmarks - from #1896
Note that timing isn't very accurate due to low iteration count
#### Before

Method | Mean | Error | StdDev | Gen0 | Gen1 | Gen2 | Allocated
-- | -- | -- | -- | -- | -- | -- | --
FormatCli | 737.4 ms | 116.9 ms | 30.36 ms | 6000.0000 | - | - | 57.53 MB
CheckFiles | 43,895.1 ms | 639.7 ms | 98.99 ms | 53000.0000 | 52000.0000 | 2000.0000 | 459.28 MB


#### After


Method | Mean | Error | StdDev | Gen0 | Gen1 | Gen2 | Allocated
-- | -- | -- | -- | -- | -- | -- | --
FormatCli | 643.6 ms | 63.36 ms | 16.46 ms | 2000.0000 | - | - | 24.9 MB
CheckFiles | 33,135.1 ms | 842.61 ms | 130.39 ms | 45000.0000 | 44000.0000 | 2000.0000 | 393.78 MB

Pretty large performance gains for `FormatCli`, curious to see how large the real world impact will be.